### PR TITLE
Adds reference to cargo workspaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This is a collection of crates to provide Rust support for the [PartiQL][partiql
 ***The crates in this repository are considered experimental, under active/early development,
 and APIs are subject to change.***
 
+This project uses [workspaces][workspaces] to manage the crates in this repository.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
@@ -14,3 +16,4 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 This project is licensed under the Apache-2.0 License.
 
 [partiql]: https://partiql.org/
+[workspaces]: https://doc.rust-lang.org/stable/cargo/reference/workspaces.html


### PR DESCRIPTION
Updates the README to indicate the use of a Cargo workspace.

Really this is a PR that I used to test the branch protection hooks on `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
