### PR TITLE
Adds Badges to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PartiQL Rust
 
+[![Crate](https://img.shields.io/crates/v/partiql.svg)](https://crates.io/crates/partiql)
+[![Docs](https://docs.rs/partiql/badge.svg)](https://docs.rs/partiql)
+[![License](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/partiql/partiql-lang-rust/blob/main/LICENSE)
+[![CI Build](https://github.com/partiql/partiql-lang-rust/workflows/CI%20Build/badge.svg)](https://github.com/partiql/partiql-lang-rust/actions?query=workflow%3A%22CI+Build%22)
+[![codecov](https://codecov.io/gh/partiql/partiql-lang-rust/branch/main/graph/badge.svg?token=PDCNQZPVBD)](https://codecov.io/gh/partiql/partiql-lang-rust)
+
 This is a collection of crates to provide Rust support for the [PartiQL][partiql] query language.
 
 ***The crates in this repository are considered experimental, under active/early development,


### PR DESCRIPTION
Note that I only put the crate/docs badge for the `partiql` crate
as we'll likely re-export dependencies there anyhow for a one stop
shop for PartiQL APIs.  We can always put them all here if we like.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
