### PR TITLE
Initial API for `Scanner`.

### DIFF
--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -32,8 +32,8 @@
 //!         Keyword(kw) => assert_eq!("FROM", kw),
 //!     }
 //!     // the other thing we can do is get line/column information from a token
-//!     assert_eq!(LineAndColumn::at(1, 8), second.start_loc());
-//!     assert_eq!(LineAndColumn::at(1, 12), second.end_loc());
+//!     assert_eq!(LineAndColumn::at(1, 8), second.start());
+//!     assert_eq!(LineAndColumn::at(1, 12), second.end());
 //!
 //!     // this API is built on immutable slices, so we can restart scanning from any token
 //!     scanner = first.into();

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -32,8 +32,8 @@
 //!         Keyword(kw) => assert_eq!("FROM", kw),
 //!     }
 //!     // the other thing we can do is get line/column information from a token
-//!     assert_eq!(LineAndColumn::at(1, 8), second.start());
-//!     assert_eq!(LineAndColumn::at(1, 12), second.end());
+//!     assert_eq!(LineAndColumn::try_at(1, 8)?, second.start());
+//!     assert_eq!(LineAndColumn::try_at(1, 12)?, second.end());
 //!
 //!     // this API is built on immutable slices, so we can restart scanning from any token
 //!     scanner = first.into();

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -2,10 +2,54 @@
 
 //! Provides a parser for the [PartiQL][partiql] query language.
 //!
+//! # Usage
+//!
+//! An API to interact with PartiQL tokens is the [`mod@scanner`] module.
+//! The [`scanner()`] function creates a [`Scanner`](scanner::Scanner) instance
+//! that one can use to parse tokens incrementally from some input slice.
+//!
+//! ```
+//! use partiql_parser::prelude::*;
+//! use partiql_parser::scanner;
+//!
+//! fn main() -> ParserResult<()> {
+//!     use partiql_parser::scanner::Content::*;
+//!
+//!     let mut scanner = scanner("SELECT FROM");
+//!     let first = scanner.next_token()?;
+//!
+//!     // get the parsed variant of the token
+//!     match first.content() {
+//!         Keyword(kw) => assert_eq!("SELECT", kw),
+//!     }
+//!     // the entire text of a token can be fetched--which looks the roughly the
+//!     // same for a keyword.
+//!     assert_eq!("SELECT", first.text());
+//!     
+//!     let second = scanner.next_token()?;
+//!     // get the parsed variant of the token
+//!     match second.content() {
+//!         Keyword(kw) => assert_eq!("FROM", kw),
+//!     }
+//!     // the other thing we can do is get line/column information from a token
+//!     assert_eq!(LineAndColumn::at(1, 8), second.start_loc());
+//!     assert_eq!(LineAndColumn::at(1, 12), second.end_loc());
+//!
+//!     // this API is built on immutable slices, so we can restart scanning from any token
+//!     scanner = first.into();
+//!     let second_again = scanner.next_token()?;
+//!     assert_eq!(second, second_again);
+//!     
+//!     Ok(())
+//! }
+//! ```
+//!
 //! [partiql]: https://partiql.org
 
 mod peg;
 pub mod prelude;
 pub mod result;
+pub mod scanner;
 
 pub use peg::recognize_partiql;
+pub use scanner::scanner;

--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -1,9 +1,15 @@
 WHITESPACE = _{ " " | "\t" | "\x0B" | "\x0C" | "\r" | "\n" }
 
-// really basic rules to just detect a sequence of keywords
-// two dip our toes in Pest
+// TODO implement a full grammar, this is a very primitive version to start
+//      working with Pest and its APIs.
 
-Keywords = _{ SOI ~ Keyword+ ~ EOI}
+// Entry point for full query parsing
+Query = _{ SOI ~ Keyword+ ~ EOI}
+
+// Entry point for query "scanning"
+// Note that this is factored this way to support an iteration style API
+// where we can call back into this rule on subsequent input.
+Scanner = _{ SOI ~ Keyword }
 
 Keyword = { AllKeywords }
 

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -28,7 +28,7 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
                 if let Some(other_pair) = self.next() {
                     syntax_error(
                         format!("Expected one token pair, got: {:?}, {:?}", pair, other_pair),
-                        pair.start_loc().into(),
+                        pair.start().into(),
                     )?;
                 }
                 Ok(pair)
@@ -44,20 +44,20 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
 /// Extension methods for working with [`Pair`].
 pub(crate) trait PairExt<'val, R: RuleType> {
     /// Translates the start position of the [`Pair`] into a [`LineAndColumn`].
-    fn start_loc(&self) -> LineAndColumn;
+    fn start(&self) -> LineAndColumn;
 
     /// Translates the end position of the [`Pair`] into a [`LineAndColumn`].
-    fn end_loc(&self) -> LineAndColumn;
+    fn end(&self) -> LineAndColumn;
 }
 
 impl<'val, R: RuleType> PairExt<'val, R> for Pair<'val, R> {
     #[inline]
-    fn start_loc(&self) -> LineAndColumn {
+    fn start(&self) -> LineAndColumn {
         self.as_span().start_pos().line_col().into()
     }
 
     #[inline]
-    fn end_loc(&self) -> LineAndColumn {
+    fn end(&self) -> LineAndColumn {
         self.as_span().end_pos().line_col().into()
     }
 }

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -28,7 +28,7 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
                 if let Some(other_pair) = self.next() {
                     syntax_error(
                         format!("Expected one token pair, got: {:?}, {:?}", pair, other_pair),
-                        pair.start().into(),
+                        pair.start()?.into(),
                     )?;
                 }
                 Ok(pair)
@@ -44,21 +44,21 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
 /// Extension methods for working with [`Pair`].
 pub(crate) trait PairExt<'val, R: RuleType> {
     /// Translates the start position of the [`Pair`] into a [`LineAndColumn`].
-    fn start(&self) -> LineAndColumn;
+    fn start(&self) -> ParserResult<LineAndColumn>;
 
     /// Translates the end position of the [`Pair`] into a [`LineAndColumn`].
-    fn end(&self) -> LineAndColumn;
+    fn end(&self) -> ParserResult<LineAndColumn>;
 }
 
 impl<'val, R: RuleType> PairExt<'val, R> for Pair<'val, R> {
     #[inline]
-    fn start(&self) -> LineAndColumn {
-        self.as_span().start_pos().line_col().into()
+    fn start(&self) -> ParserResult<LineAndColumn> {
+        self.as_span().start_pos().line_col().try_into()
     }
 
     #[inline]
-    fn end(&self) -> LineAndColumn {
-        self.as_span().end_pos().line_col().into()
+    fn end(&self) -> ParserResult<LineAndColumn> {
+        self.as_span().end_pos().line_col().try_into()
     }
 }
 

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -4,12 +4,63 @@
 //! can be exported for users to consume.
 
 use crate::prelude::*;
-use pest::Parser;
+use crate::result::syntax_error;
+use pest::iterators::{Pair, Pairs};
+use pest::{Parser, RuleType};
 use pest_derive::Parser;
 
 #[derive(Parser)]
 #[grammar = "partiql.pest"]
-struct PartiQLParser;
+pub(crate) struct PartiQLParser;
+
+/// Extension methods for working with [`Pairs`].
+pub(crate) trait PairsExt<'val, R: RuleType> {
+    /// Consumes a [`Pairs`] as a singleton, returning an error if there are less or more than
+    /// one [`Pair`].
+    fn exactly_one(self) -> ParserResult<Pair<'val, R>>;
+}
+
+impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
+    fn exactly_one(mut self) -> ParserResult<Pair<'val, R>> {
+        match self.next() {
+            Some(pair) => {
+                // make sure there isn't something more...
+                if let Some(other_pair) = self.next() {
+                    syntax_error(
+                        format!("Expected one token pair, got: {:?}, {:?}", pair, other_pair),
+                        pair.start_loc().into(),
+                    )?;
+                }
+                Ok(pair)
+            }
+            None => syntax_error(
+                "Expected at one token pair, got nothing!",
+                Position::Unknown,
+            ),
+        }
+    }
+}
+
+/// Extension methods for working with [`Pair`].
+pub(crate) trait PairExt<'val, R: RuleType> {
+    /// Translates the start position of the [`Pair`] into a [`LineAndColumn`].
+    fn start_loc(&self) -> LineAndColumn;
+
+    /// Translates the end position of the [`Pair`] into a [`LineAndColumn`].
+    fn end_loc(&self) -> LineAndColumn;
+}
+
+impl<'val, R: RuleType> PairExt<'val, R> for Pair<'val, R> {
+    #[inline]
+    fn start_loc(&self) -> LineAndColumn {
+        self.as_span().start_pos().line_col().into()
+    }
+
+    #[inline]
+    fn end_loc(&self) -> LineAndColumn {
+        self.as_span().end_pos().line_col().into()
+    }
+}
 
 /// Recognizer for PartiQL queries.
 ///
@@ -18,7 +69,7 @@ struct PartiQLParser;
 ///
 /// This API will be replaced with one that produces an AST in the future.
 pub fn recognize_partiql(input: &str) -> ParserResult<()> {
-    PartiQLParser::parse(Rule::Keywords, input)?;
+    PartiQLParser::parse(Rule::Query, input)?;
     Ok(())
 }
 
@@ -34,13 +85,9 @@ mod tests {
     #[test]
     fn error() -> ParserResult<()> {
         match recognize_partiql("SELECT FROM MOO") {
-            Err(ParserError::SyntaxError { position, .. }) => assert_eq!(
-                Position::At {
-                    line: 1,
-                    column: 13
-                },
-                position
-            ),
+            Err(ParserError::SyntaxError { position, .. }) => {
+                assert_eq!(Position::at(1, 13), position)
+            }
             _ => panic!("Expected Syntax Error"),
         };
         Ok(())

--- a/partiql-parser/src/prelude.rs
+++ b/partiql-parser/src/prelude.rs
@@ -8,3 +8,5 @@ pub use crate::result::ParserError;
 pub use crate::result::ParserResult;
 pub use crate::result::Position;
 pub use crate::scanner::Scanner;
+pub use std::convert::TryFrom;
+pub use std::convert::TryInto;

--- a/partiql-parser/src/prelude.rs
+++ b/partiql-parser/src/prelude.rs
@@ -3,6 +3,8 @@
 //! Convenience export of common traits and basic types that are almost always
 //! needed when using the parser APIs.
 
+pub use crate::result::LineAndColumn;
 pub use crate::result::ParserError;
 pub use crate::result::ParserResult;
 pub use crate::result::Position;
+pub use crate::scanner::Scanner;

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -34,6 +34,7 @@ impl LineAndColumn {
     /// ## Examples
     /// ```
     /// # use partiql_parser::prelude::*;
+    /// // we're not repositioning anything!
     /// assert_eq!(
     ///     LineAndColumn::at(1, 1),
     ///     LineAndColumn::at(1, 1).position_from(LineAndColumn::at(1, 1))
@@ -42,6 +43,7 @@ impl LineAndColumn {
     ///
     /// ```
     /// # use partiql_parser::prelude::*;
+    /// // same here, we're really at the origin
     /// assert_eq!(
     ///     LineAndColumn::at(1, 2),
     ///     LineAndColumn::at(1, 2).position_from(LineAndColumn::at(1, 1))
@@ -50,6 +52,7 @@ impl LineAndColumn {
     ///
     /// ```
     /// # use partiql_parser::prelude::*;
+    /// // same line from origin, adjust only the column
     /// assert_eq!(
     ///     LineAndColumn::at(5, 10),
     ///     LineAndColumn::at(1, 4).position_from(LineAndColumn::at(5, 7))
@@ -58,6 +61,7 @@ impl LineAndColumn {
     ///
     /// ```
     /// # use partiql_parser::prelude::*;
+    /// // we're moving lines, adjust the line and take the target column as-is
     /// assert_eq!(
     ///     LineAndColumn::at(21, 2),
     ///     LineAndColumn::at(20, 2).position_from(LineAndColumn::at(2, 15))

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -21,8 +21,12 @@ pub struct LineAndColumn(pub usize, pub usize);
 
 impl LineAndColumn {
     /// Constructs a [`LineAndColumn`].
+    ///
+    /// Note that this function will panic if `line` or `column` is zero.
     #[inline]
     pub fn at(line: usize, column: usize) -> Self {
+        assert_ne!(0, line);
+        assert_ne!(0, column);
         Self(line, column)
     }
 
@@ -85,6 +89,9 @@ impl LineAndColumn {
 }
 
 impl From<(usize, usize)> for LineAndColumn {
+    /// Constructs a [`LineAndColumn`] from a pair.
+    ///
+    /// This function will panic if the `line` or `column` is zero.
     fn from(line_and_column: (usize, usize)) -> Self {
         let (line, column) = line_and_column;
         Self::at(line, column)
@@ -108,6 +115,8 @@ pub enum Position {
 
 impl Position {
     /// Shorthand for creating a [`Position::At`] variant.
+    ///
+    /// Note that this will panic if `line` or `column` is zero.
     #[inline]
     pub fn at(line: usize, column: usize) -> Self {
         Self::At(LineAndColumn::at(line, column))
@@ -195,5 +204,23 @@ mod tests {
     fn display(#[case] error: ParserError, #[case] expected: &str) {
         let message = format!("{}", error);
         assert_eq!(expected, message);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_position() {
+        Position::at(0, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_line_and_column() {
+        LineAndColumn::at(0, 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_line_and_column_from_pair() {
+        LineAndColumn::from((0, 0));
     }
 }

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -1,0 +1,270 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+//! Provides a simple API to scan PartiQL syntax.
+//!
+//! The [`Scanner`] trait provides tools the capability to recognize PartiQL lexemes such as
+//! keywords, identifiers, etc.  This API is not a full parser, but a lexer in
+//! traditional parser terminology.  This API can be useful for tooling or IDEs that wish to
+//! do things like syntax highlighting, where full parsing is not required.
+
+use crate::peg::{PairExt, PairsExt, PartiQLParser, Rule};
+use crate::prelude::*;
+use crate::result::syntax_error;
+use pest::iterators::Pair;
+use pest::Parser;
+
+/// The parsed content associated with a [`Token`] that has been scanned.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Content<'val> {
+    /// A PartiQL keyword.  Contains the slice for
+    Keyword(&'val str),
+    // TODO things like literals, punctuation, etc.
+}
+
+/// Internal type to keep track of remaining input and relative line/column information.
+///
+/// This is used to leverage the PEG to do continuation parsing and calculating the line/offset
+/// information correctly.  Line/offset information does not correspond to UTF-8 code unit (octet)
+/// positions so this has to be tracked separately.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct Remainder<'val> {
+    /// The remainder of text to scan.
+    input: &'val str,
+    /// The offset in the input translate locations from
+    offset: LineAndColumn,
+}
+
+impl<'val> Remainder<'val> {
+    /// Produces a new [`Remainder`] by slicing the input by the given amount and providing
+    /// a new line/column baseline.
+    ///
+    /// The offset given is the logical one as if the input was the start of the sequence.
+    /// This method will calculate the new [`Remainder`] offset based on that.
+    fn consume(&self, amount: usize, offset: LineAndColumn) -> Self {
+        Self {
+            input: &self.input[amount..],
+            offset: offset.position_from(self.offset),
+        }
+    }
+}
+
+/// A lexeme of PartiQL derived from a slice of input text.
+///
+/// A token can be thought of as a sort of continuation, it knows where it is in the input list
+/// and allows scanning to resume from it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Token<'val> {
+    /// The underlying value of the token.
+    content: Content<'val>,
+    /// Start location for this token.
+    start_location: LineAndColumn,
+    /// End location for this token.
+    end_location: LineAndColumn,
+    /// Slice from the input containing the whole token.
+    text: &'val str,
+    /// The remaining unscanned value after this token.
+    remainder: Remainder<'val>,
+}
+
+impl<'val> Token<'val> {
+    /// Returns the parsed content of this token.
+    pub fn content(&self) -> Content<'val> {
+        self.content
+    }
+
+    /// Returns the location of where this token starts in the input.
+    pub fn start_loc(&self) -> LineAndColumn {
+        self.start_location
+    }
+
+    /// Returns the location of where this token ends in the input.
+    pub fn end_loc(&self) -> LineAndColumn {
+        self.end_location
+    }
+
+    /// Returns the slice of the input encompassing the entire token.
+    pub fn text(&self) -> &str {
+        self.text
+    }
+
+    /// Returns the remainder of the input after this token.
+    pub fn rem(&self) -> &str {
+        self.remainder.input
+    }
+}
+
+/// Returns tokens from a given slice of input text.
+pub trait Scanner<'val> {
+    /// Returns the next token from the input.
+    fn next_token(&mut self) -> ParserResult<Token<'val>>;
+}
+
+/// Root scanner, leverages the underlying PEG to provide the scanner.
+pub struct PartiQLScanner<'val> {
+    /// The remaining input to scan.
+    remainder: Remainder<'val>,
+}
+
+impl<'val> PartiQLScanner<'val> {
+    fn do_next_token(&mut self) -> ParserResult<Token<'val>> {
+        // the scanner rule is expected to return a single node
+        let pair: Pair<'val, Rule> =
+            PartiQLParser::parse(Rule::Scanner, self.remainder.input)?.exactly_one()?;
+        let start_location = pair.start_loc().position_from(self.remainder.offset);
+        let end_location = pair.end_loc().position_from(self.remainder.offset);
+        let text = pair.as_str();
+        let start_off = pair.as_span().start();
+        self.remainder = self
+            .remainder
+            .consume(start_off + text.len(), pair.end_loc());
+
+        let content = match pair.as_rule() {
+            Rule::Keyword => Content::Keyword(text),
+            _ => {
+                return syntax_error(
+                    format!("Unexpected rule: {:?}", pair),
+                    pair.start_loc().into(),
+                )
+            }
+        };
+
+        Ok(Token {
+            content,
+            start_location,
+            end_location,
+            text,
+            remainder: self.remainder,
+        })
+    }
+}
+
+impl<'val> Scanner<'val> for PartiQLScanner<'val> {
+    fn next_token(&mut self) -> ParserResult<Token<'val>> {
+        let start_loc = self.remainder.offset;
+        self.do_next_token().map_err(|e| match e {
+            ParserError::SyntaxError { message, position } => {
+                let position = match position {
+                    Position::Unknown => Position::Unknown,
+                    // make sure to translate line/column position from where we started
+                    Position::At(location) => Position::At(location.position_from(start_loc)),
+                };
+                ParserError::syntax_error(message, position)
+            }
+        })
+    }
+}
+
+impl<'val> From<Token<'val>> for PartiQLScanner<'val> {
+    fn from(token: Token<'val>) -> Self {
+        PartiQLScanner {
+            remainder: token.remainder,
+        }
+    }
+}
+
+/// Returns a [`Scanner`] over an slice containing PartiQL.
+pub fn scanner(input: &str) -> PartiQLScanner {
+    let remainder = Remainder {
+        input,
+        offset: LineAndColumn::at(1, 1),
+    };
+    PartiQLScanner { remainder }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::*;
+
+    #[rstest]
+    #[case::single_keyword(
+        "  SELECT  ",
+        vec![
+            Ok(Token {
+                content: Content::Keyword("SELECT"),
+                start_location: LineAndColumn::at(1, 3),
+                end_location: LineAndColumn::at(1, 9),
+                text: "SELECT",
+                remainder: Remainder {
+                    input: "  ",
+                    offset: LineAndColumn::at(1, 9)
+                }
+            }),
+            syntax_error("Expected [Keyword]", Position::at(1, 11)),
+        ]
+    )]
+    #[case::some_keywords(
+        "  CASE\tFROM\n \x0B\x0CWHERE",
+        vec![
+            Ok(Token {
+                content: Content::Keyword("CASE"),
+                start_location: LineAndColumn::at(1, 3),
+                end_location: LineAndColumn::at(1, 7),
+                text: "CASE",
+                remainder: Remainder {
+                    input: "\tFROM\n \x0B\x0CWHERE",
+                    offset: LineAndColumn::at(1, 7)
+                }
+            }),
+            Ok(Token {
+                content: Content::Keyword("FROM"),
+                start_location: LineAndColumn::at(1, 8),
+                end_location: LineAndColumn::at(1, 12),
+                text: "FROM",
+                remainder: Remainder {
+                    input: "\n \x0B\x0CWHERE",
+                    offset: LineAndColumn::at(1, 12)
+                }
+            }),
+            Ok(Token {
+                content: Content::Keyword("WHERE"),
+                start_location: LineAndColumn::at(2, 4),
+                end_location: LineAndColumn::at(2, 9),
+                text: "WHERE",
+                remainder: Remainder {
+                    input: "",
+                    offset: LineAndColumn::at(2, 9)
+                }
+            }),
+            syntax_error("Expected [Keyword]", Position::at(2, 9)),
+        ]
+    )]
+    fn tokenize(
+        #[case] input: &str,
+        #[case] expecteds: Vec<ParserResult<Token>>,
+    ) -> ParserResult<()> {
+        let mut scanner = scanner(input);
+        for expected in expecteds {
+            let actual = scanner.next_token();
+            match (&expected, &actual) {
+                (Ok(expected_tok), Ok(actual_tok)) => {
+                    assert_eq!(expected_tok, actual_tok);
+                    // make sure accessors do what we expect
+                    assert_eq!(expected_tok.content, actual_tok.content(), "Content NE");
+                    assert_eq!(
+                        expected_tok.start_location,
+                        actual_tok.start_loc(),
+                        "Start Location NE"
+                    );
+                    assert_eq!(
+                        expected_tok.end_location,
+                        actual_tok.end_loc(),
+                        "End Location NE"
+                    );
+                    assert_eq!(expected_tok.text, actual_tok.text(), "Text NE");
+                    assert_eq!(
+                        expected_tok.remainder.input,
+                        actual_tok.rem(),
+                        "Remainder NE"
+                    );
+                }
+                (Err(expected_err), Err(actual_err)) => {
+                    // TODO make this less strict with respect to error message
+                    assert_eq!(expected_err, actual_err);
+                }
+                _ => panic!("Did not expect: {:?} and {:?}", expected, actual),
+            }
+        }
+        Ok(())
+    }
+}

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -16,7 +16,7 @@ use pest::Parser;
 /// The parsed content associated with a [`Token`] that has been scanned.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Content<'val> {
-    /// A PartiQL keyword.  Contains the slice for
+    /// A PartiQL keyword. Contains a `str` reference to the UTF8 input bytes that comprise the keyword.
     Keyword(&'val str),
     // TODO things like literals, punctuation, etc.
 }
@@ -30,7 +30,7 @@ pub enum Content<'val> {
 struct Remainder<'val> {
     /// The remainder of text to scan.
     input: &'val str,
-    /// The offset in the input translate locations from
+    /// The offset in the input to translate locations from
     offset: LineAndColumn,
 }
 

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -110,15 +110,15 @@ impl<'val> PartiQLScanner<'val> {
         // the scanner rule is expected to return a single node
         let pair: Pair<'val, Rule> =
             PartiQLParser::parse(Rule::Scanner, self.remainder.input)?.exactly_one()?;
-        let start = pair.start().position_from(self.remainder.offset);
-        let end = pair.end().position_from(self.remainder.offset);
+        let start = pair.start()?.position_from(self.remainder.offset);
+        let end = pair.end()?.position_from(self.remainder.offset);
         let text = pair.as_str();
         let start_off = pair.as_span().start();
-        self.remainder = self.remainder.consume(start_off + text.len(), pair.end());
+        self.remainder = self.remainder.consume(start_off + text.len(), pair.end()?);
 
         let content = match pair.as_rule() {
             Rule::Keyword => Content::Keyword(text),
-            _ => return syntax_error(format!("Unexpected rule: {:?}", pair), pair.start().into()),
+            _ => return syntax_error(format!("Unexpected rule: {:?}", pair), pair.start()?.into()),
         };
 
         Ok(Token {
@@ -143,6 +143,9 @@ impl<'val> Scanner<'val> for PartiQLScanner<'val> {
                 };
                 ParserError::syntax_error(message, position)
             }
+            // other errors that don't have position information just pass up as position is not
+            // relevant...
+            error => error,
         })
     }
 }


### PR DESCRIPTION
Provides an interface for _lexing_ PartiQL.  Traditionally we would
factor this as the low-level interface for the parser, but with the PEG
based implementation, we just surface the relevant parts of the parser
as a rule to parse with.

This commit helps explore how to effectively integrate with the somewhat
low-level APIs for parsing that Pest provides.

Notes:
* Adds `scanner` module.
* Adds `Scanner` trait to the prelude.
* Makes `PartiQLParser` public to crate.
* Refactors `LineAndColumn` as a tuple for `Position::At`.
  - Adds this to the `prelude`.
* Changes entry point for PEG to `Query` and added `Scanner` as the
  entry point rules for implementing the `Scanner` API.
* Adds `PairsExt`/`PairExt` trait/impl to add utility methods for working
  with Pest `Pairs`/`Pair`.
* Adds `LineAndColumn::move_relative` and cleans up some doc/doc tests.

Pest links for reference:
* https://pest.rs/book/parser_api.html - API description
* https://docs.rs/pest/2.1.3/pest/index.html - API Reference

This PR is dependent on #8 and as such is targeting a staging branch but I did not want to prevent review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
