### PR TITLE
Adds numeric literals to grammar.

### DIFF
--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -23,6 +23,9 @@ version = "0.0.0"
 pest = "~2.1.3"
 pest_derive = "~2.1.0"
 thiserror = "~1.0.24"
+num-traits = "~0.2.14"
+num-bigint = "~0.4.0"
+bigdecimal = "~0.2.0"
 
 [dev-dependencies]
 rstest = "~0.9.0"

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -21,7 +21,7 @@
 //!     // get the parsed variant of the token
 //!     match first.content() {
 //!         Keyword(kw) => assert_eq!("SELECT", kw),
-//!         Identifier(_) | StringLiteral(_) => panic!("Didn't get a keyword!"),
+//!         _ => panic!("Didn't get a keyword!"),
 //!     }
 //!     // the entire text of a token can be fetched--which looks the roughly the
 //!     // same for a keyword.
@@ -31,7 +31,7 @@
 //!     // get the parsed variant of the token
 //!     match second.content() {
 //!         StringLiteral(text) => assert_eq!("🦄💩", text),
-//!         Keyword(_) | Identifier(_) => panic!("Didn't get a string literal!"),
+//!         _ => panic!("Didn't get a string literal!"),
 //!     }
 //!     // the other thing we can do is get line/column information from a token
 //!     assert_eq!(LineAndColumn::try_at(1, 8)?, second.start());

--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -14,8 +14,38 @@ Scanner = _{ SOI ~ Token }
 Token = _{
       Keyword
     | String
+    | Number
     | Identifier
 }
+
+//
+// Numeric Literals
+//
+
+Number = ${
+      DecimalExp
+    | Decimal
+    | Integer
+}
+
+DecimalExp = {
+    Decimal ~ ("e" | "E") ~ Integer
+}
+
+Decimal = {
+    Integer? ~ "." ~ Fraction
+}
+
+Fraction = {
+    Digit*
+}
+
+Integer = {
+   Sign? ~ Digit+
+}
+
+Sign = _{ "+" | "-" }
+Digit = _{ '0'..'9' }
 
 //
 // String Literals
@@ -40,7 +70,7 @@ NonQuotedIdentifier = @{
 
 NonQuotedIdentifierStart = _{ "_" | "$" | 'a'..'z' | 'A'..'Z' }
 
-NonQuotedIdentifierCont = _{ NonQuotedIdentifierStart | '0'..'9' }
+NonQuotedIdentifierCont = _{ NonQuotedIdentifierStart | Digit }
 
 QuotedIdentifier = @{ "\"" ~ QuotedIdentifierContent* ~ "\"" }
 

--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -40,6 +40,9 @@ Fraction = {
     Digit*
 }
 
+// XXX this explicitly supports arbitrary zero prefixing in various places
+//     which is part of the SQL grammar and also supported in implementations
+//     like Postgres/SQLite/MySQL/etc.
 Integer = {
    Sign? ~ Digit+
 }

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -69,7 +69,10 @@ impl<'val, R: RuleType> PairExt<'val, R> for Pair<'val, R> {
     }
 
     fn syntax_error<T, S: Into<String>>(&self, message: S) -> ParserResult<T> {
-        syntax_error(message, self.start()?.into())
+        let position = self
+            .start()
+            .map_or(Position::Unknown, |location| location.into());
+        syntax_error(message, position)
     }
 }
 


### PR DESCRIPTION
Specifically adds the `Number` rule for parsing decimals and integers.
Also adds the `IntegerLiteral` and `DecimalLiteral` to capture the
respective literal tokens.

Notes:
* Adds `num-traits`, `num-bigint`, and `bigdecimal` to provide support
  for integer/decimal parsing.
* Adds `PairExt::unexpected()` for dealing with unexpected rules.
* Adds `PairExt::syntax_error()` for easily creating syntax errors from a pair.
* Updates scanner doc test to `panic!` for unexpected tokens.
* Fixes the bad recognizer test because it only has scanner support and we
  cannot detect that `99_RANCH` is syntactically incorrect but lexes to
  `99` and `_RANCH`.  Real PartiQL parsing will fix this in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
