### PR TITLE
Adds ignore for peg.rs and updates nightly for coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,3 +8,8 @@ coverage:
       default:
         target: 85%
         threshold: 5%
+
+ignore:
+  # Ignore the Pest generated code until we have a better way to test
+  # and target coverage for it
+  - "partiql-parser/src/peg.rs"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-04-24
+          toolchain: nightly-2021-05-09
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
The Pest generated parser yields code paths that are hard to target for
coverage.  This is not an excuse to not target good coverage, but we
should do this systematically through broader PartiQL tests and/or fuzz
testing.

This also updates the coverage CI to `nightly-2021-05-09`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
