### PR TITLE
First issue

### DIFF
--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -4,7 +4,8 @@
 //! can be exported for users to consume.
 
 use crate::prelude::*;
-use crate::result::syntax_error;
+// use crate::result::syntax_error;
+use crate::result::{illegal_state, syntax_error};
 use pest::iterators::{Pair, Pairs};
 use pest::{Parser, RuleType};
 use pest_derive::Parser;
@@ -33,10 +34,7 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
                 }
                 Ok(pair)
             }
-            None => syntax_error(
-                "Expected at one token pair, got nothing!",
-                Position::Unknown,
-            ),
+            None => illegal_state(),
         }
     }
 }

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -4,7 +4,6 @@
 //! can be exported for users to consume.
 
 use crate::prelude::*;
-// use crate::result::syntax_error;
 use crate::result::{illegal_state, syntax_error};
 use pest::iterators::{Pair, Pairs};
 use pest::{Parser, RuleType};

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -33,7 +33,7 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
                 }
                 Ok(pair)
             }
-            None => illegal_state("Expected at one token pair, got nothing!"),
+            None => illegal_state("Expected at least one token pair, got nothing!"),
         }
     }
 }

--- a/partiql-parser/src/peg.rs
+++ b/partiql-parser/src/peg.rs
@@ -33,7 +33,7 @@ impl<'val, R: RuleType> PairsExt<'val, R> for Pairs<'val, R> {
                 }
                 Ok(pair)
             }
-            None => illegal_state(),
+            None => illegal_state("Expected at one token pair, got nothing!"),
         }
     }
 }

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -191,9 +191,9 @@ pub enum ParserError {
     #[error("Invalid Argument: {message}")]
     InvalidArgument { message: String },
 
-    /// Indicates that there is an internal error that isn't SyntaxError nor InvalidArgument.
-    #[error("Illegal State")]
-    IllegalState,
+    /// Indicates that there is an internal error that was not due to user input or API violation.
+    #[error("Illegal State: {message}")]
+    IllegalState { message: String },
 }
 
 impl ParserError {
@@ -213,6 +213,14 @@ impl ParserError {
             message: message.into(),
         }
     }
+
+    /// Convenience function to create a [`IllegalState`](ParserError::IllegalState).
+    #[inline]
+    pub fn illegal_state<S: Into<String>>(message: S) -> Self {
+        Self::IllegalState {
+            message: message.into(),
+        }
+    }
 }
 
 /// Convenience function to create an `Err([SyntaxError](ParserError::SyntaxError))`.
@@ -229,8 +237,8 @@ pub fn invalid_argument<T, S: Into<String>>(message: S) -> ParserResult<T> {
 
 /// Convenience function to create an `Err([IllegalState](ParserError::IllegalState))`.
 #[inline]
-pub fn illegal_state<T>() -> ParserResult<T> {
-    Err(ParserError::IllegalState)
+pub fn illegal_state<T, S: Into<String>>(message: S) -> ParserResult<T> {
+    Err(ParserError::illegal_state(message))
 }
 
 impl<R> From<pest::error::Error<R>> for ParserError

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -190,6 +190,10 @@ pub enum ParserError {
     /// Indicates that there is a problem with run-time violation of some API.
     #[error("Invalid Argument: {message}")]
     InvalidArgument { message: String },
+
+    /// Indicates that there is an internal error that isn't SyntaxError nor InvalidArgument.
+    #[error("Illegal State")]
+    IllegalState,
 }
 
 impl ParserError {
@@ -221,6 +225,12 @@ pub fn syntax_error<T, S: Into<String>>(message: S, position: Position) -> Parse
 #[inline]
 pub fn invalid_argument<T, S: Into<String>>(message: S) -> ParserResult<T> {
     Err(ParserError::invalid_argument(message))
+}
+
+/// Convenience function to create an `Err([IllegalState](ParserError::IllegalState))`.
+#[inline]
+pub fn illegal_state<T>() -> ParserResult<T> {
+    Err(ParserError::IllegalState)
 }
 
 impl<R> From<pest::error::Error<R>> for ParserError


### PR DESCRIPTION
*Issue #, if available:* #23

*Description of changes:* Adds a unit variant `IllegalState` to ParserError enum. [Users](https://github.com/partiql/partiql-lang-rust/pull/12#discussion_r635494493) of the enum would call `illegal_state()` convenience function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
