### PR TITLE
Add COMMENT to Scanner grammar rule

### DIFF
--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -1,8 +1,9 @@
 WHITESPACE = _{ " " | "\t" | "\x0B" | "\x0C" | "\r" | "\n" }
 
+COMMENT = _{ LineComment | BlockComment }
+
 BlockComment = { "/*" ~ ( BlockComment | (!"*/" ~ ANY) )* ~ "*/" }
-UntilEolComment = { "--" ~ ( !"\n" ~ ANY )* ~ "\n" }
-COMMENT = _{ UntilEolComment | BlockComment }
+LineComment = { "--" ~ ( !"\n" ~ ANY )* ~ "\n" }
 
 // TODO implement a full grammar, this is a very primitive version to start
 //      working with Pest and its APIs.

--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -1,4 +1,5 @@
 WHITESPACE = _{ " " | "\t" | "\x0B" | "\x0C" | "\r" | "\n" }
+COMMENT = _{ "--" ~ ANY* }
 
 // TODO implement a full grammar, this is a very primitive version to start
 //      working with Pest and its APIs.
@@ -9,7 +10,7 @@ Query = _{ SOI ~ Token+ ~ EOI}
 // Entry point for query "scanning"
 // Note that this is factored this way to support an iteration style API
 // where we can call back into this rule on subsequent input.
-Scanner = _{ SOI ~ Token }
+Scanner = _{ SOI ~ !COMMENT ~ Token }
 
 Token = _{
       Keyword

--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -1,5 +1,8 @@
 WHITESPACE = _{ " " | "\t" | "\x0B" | "\x0C" | "\r" | "\n" }
-COMMENT = _{ "--" ~ ANY* }
+
+BlockComment = { "/*" ~ ( BlockComment | (!"*/" ~ ANY) )* ~ "*/" }
+UntilEolComment = { "--" ~ ( !"\n" ~ ANY )* ~ "\n" }
+COMMENT = _{ UntilEolComment | BlockComment }
 
 // TODO implement a full grammar, this is a very primitive version to start
 //      working with Pest and its APIs.
@@ -10,7 +13,7 @@ Query = _{ SOI ~ Token+ ~ EOI}
 // Entry point for query "scanning"
 // Note that this is factored this way to support an iteration style API
 // where we can call back into this rule on subsequent input.
-Scanner = _{ SOI ~ !COMMENT ~ Token }
+Scanner = _{ SOI ~ Token }
 
 Token = _{
       Keyword

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -24,6 +24,8 @@ impl LineAndColumn {
     /// Constructs at [`LineAndColumn`] without verifying 1-position invariant.
     #[inline]
     pub(crate) fn at(line: usize, column: usize) -> Self {
+        assert_ne!(0, line);
+        assert_ne!(0, column);
         Self(line, column)
     }
 

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -446,13 +446,13 @@ mod test {
     #[case::comment_block_nested(
         scanner_test_case![
             "employee" => identifier("employee"),
-            " /* ",
+            " /*\n ",
             "CASE",
             " /* ",
             "WHERE",
-            " */ ",
+            " \n */ ",
             "employee",
-            " */ ",
+            " \n\n*/ ",
             "IN" => keyword("IN"),
         ]
     )]
@@ -589,6 +589,11 @@ mod test {
 
     #[rstest]
     #[case::bad_identifier("💩")]
+    #[case::unterminated_line_comment("-- DROP")]
+    #[case::unbalanced_block_comment("/*\n\n SELECT /* WHERE */")]
+    #[case::unbalanced_block_comment("/* CASE do WHEN re THEN mi ELSE fa END /*")]
+    #[case::unbalanced_block_comment("/*SELECT /* FROM /* FULL OUTER JOIN */ */ ")]
+    #[case::unbalanced_block_comment("/*/*/*/*/*/*/*/*[ascii art here]*/*/*/*/*/*/*/ ")]
     fn bad_tokens(#[case] input: &str) -> ParserResult<()> {
         let expecteds = vec![syntax_error("IGNORED MESSAGE", Position::at(1, 1))];
         assert_input(input, expecteds)

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -400,6 +400,40 @@ mod test {
     }
 
     #[rstest]
+    #[case::commented_single_keyword(
+        "  -- SELECT  ",
+        vec![
+            syntax_error("IGNORED MESSAGE", Position::at(1, 14)),
+        ]
+    )]
+    #[rstest]
+    #[case::comment_mid_line(
+        "  SELECT FROM -- WHERE  ",
+        vec![
+            Ok(Token {
+                content: Content::Keyword("SELECT".into()),
+                start: LineAndColumn::at(1, 3),
+                end: LineAndColumn::at(1, 9),
+                text: "SELECT",
+                remainder: Remainder {
+                    input: " FROM -- WHERE  ",
+                    offset: LineAndColumn::at(1, 9)
+                }
+            }),
+            Ok(Token {
+                content: Content::Keyword("FROM".into()),
+                start: LineAndColumn::at(1, 10),
+                end: LineAndColumn::at(1, 14),
+                text: "FROM",
+                remainder: Remainder {
+                    input: " -- WHERE  ",
+                    offset: LineAndColumn::at(1, 14)
+                }
+            }),
+            syntax_error("IGNORED MESSAGE", Position::at(1, 25)),
+        ]
+    )]
+    #[rstest]
     #[case::single_keyword(
         scanner_test_case![
             "  ",

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -400,37 +400,60 @@ mod test {
     }
 
     #[rstest]
-    #[case::commented_single_keyword(
-        "  -- SELECT  ",
-        vec![
-            syntax_error("IGNORED MESSAGE", Position::at(1, 14)),
+    #[case::comment_single_keyword(
+        scanner_test_case![
+            "--",
+            "SELECT",
+            " \n ",
         ]
     )]
     #[rstest]
     #[case::comment_mid_line(
-        "  SELECT FROM -- WHERE  ",
-        vec![
-            Ok(Token {
-                content: Content::Keyword("SELECT".into()),
-                start: LineAndColumn::at(1, 3),
-                end: LineAndColumn::at(1, 9),
-                text: "SELECT",
-                remainder: Remainder {
-                    input: " FROM -- WHERE  ",
-                    offset: LineAndColumn::at(1, 9)
-                }
-            }),
-            Ok(Token {
-                content: Content::Keyword("FROM".into()),
-                start: LineAndColumn::at(1, 10),
-                end: LineAndColumn::at(1, 14),
-                text: "FROM",
-                remainder: Remainder {
-                    input: " -- WHERE  ",
-                    offset: LineAndColumn::at(1, 14)
-                }
-            }),
-            syntax_error("IGNORED MESSAGE", Position::at(1, 25)),
+        scanner_test_case![
+            "SELECT" => keyword("SELECT"),
+            "  ",
+            "FROM" => keyword("FROM"),
+            " -- ",
+            "WHERE",
+            " \n ",
+        ]
+    )]
+    #[rstest]
+    #[case::comment_until_eol(
+        scanner_test_case![
+            " -- ",
+            "CASE",
+            "  ",
+            "IN",
+            "  ",
+            "WHERE",
+            " \n ",
+            "SELECT" => keyword("SELECT"),
+        ]
+    )]
+    #[rstest]
+    #[case::comment_block(
+        scanner_test_case![
+            " /* ",
+            "CASE",
+            "  ",
+            "IN",
+            " */ ",
+            "SELECT" => keyword("SELECT"),
+        ]
+    )]
+    #[rstest]
+    #[case::comment_block_nested(
+        scanner_test_case![
+            "employee" => identifier("employee"),
+            " /* ",
+            "CASE",
+            " /* ",
+            "WHERE",
+            " */ ",
+            "employee",
+            " */ ",
+            "IN" => keyword("IN"),
         ]
     )]
     #[rstest]


### PR DESCRIPTION
*Issue:* 
#17 

*Description of changes:* 
I added COMMENT rule to the pest grammar. I was hesitant to edit the Rule::Query as well. Should I?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
