### PR TITLE
Applies minor style fixes.

### DIFF
--- a/partiql-parser/src/partiql.pest
+++ b/partiql-parser/src/partiql.pest
@@ -2,8 +2,8 @@ WHITESPACE = _{ " " | "\t" | "\x0B" | "\x0C" | "\r" | "\n" }
 
 COMMENT = _{ LineComment | BlockComment }
 
-BlockComment = { "/*" ~ ( BlockComment | (!"*/" ~ ANY) )* ~ "*/" }
-LineComment = { "--" ~ ( !"\n" ~ ANY )* ~ "\n" }
+BlockComment = { "/*" ~ (BlockComment | (!"*/" ~ ANY))* ~ "*/" }
+LineComment = { "--" ~ (!"\n" ~ ANY )* ~ "\n" }
 
 // TODO implement a full grammar, this is a very primitive version to start
 //      working with Pest and its APIs.

--- a/partiql-parser/src/scanner.rs
+++ b/partiql-parser/src/scanner.rs
@@ -407,7 +407,6 @@ mod test {
             " \n ",
         ]
     )]
-    #[rstest]
     #[case::comment_mid_line(
         scanner_test_case![
             "SELECT" => keyword("SELECT"),
@@ -418,7 +417,6 @@ mod test {
             " \n ",
         ]
     )]
-    #[rstest]
     #[case::comment_until_eol(
         scanner_test_case![
             " -- ",
@@ -431,7 +429,6 @@ mod test {
             "SELECT" => keyword("SELECT"),
         ]
     )]
-    #[rstest]
     #[case::comment_block(
         scanner_test_case![
             " /* ",
@@ -442,7 +439,6 @@ mod test {
             "SELECT" => keyword("SELECT"),
         ]
     )]
-    #[rstest]
     #[case::comment_block_nested(
         scanner_test_case![
             "employee" => identifier("employee"),
@@ -456,7 +452,6 @@ mod test {
             "IN" => keyword("IN"),
         ]
     )]
-    #[rstest]
     #[case::single_keyword(
         scanner_test_case![
             "  ",
@@ -590,10 +585,10 @@ mod test {
     #[rstest]
     #[case::bad_identifier("💩")]
     #[case::unterminated_line_comment("-- DROP")]
-    #[case::unbalanced_block_comment("/*\n\n SELECT /* WHERE */")]
-    #[case::unbalanced_block_comment("/* CASE do WHEN re THEN mi ELSE fa END /*")]
-    #[case::unbalanced_block_comment("/*SELECT /* FROM /* FULL OUTER JOIN */ */ ")]
-    #[case::unbalanced_block_comment("/*/*/*/*/*/*/*/*[ascii art here]*/*/*/*/*/*/*/ ")]
+    #[case::unbalanced_block_nested("/*\n\n SELECT /* WHERE */")]
+    #[case::unbalanced_block_end_dangling("/* CASE do WHEN re THEN mi ELSE fa END /*")]
+    #[case::unbalanced_block_nested_open_two_deep("/*SELECT /* FROM /* FULL OUTER JOIN */ */ ")]
+    #[case::unbalanced_block_deeply_nested("/*/*/*/*/*/*/*/*[ascii art here]*/*/*/*/*/*/*/ ")]
     fn bad_tokens(#[case] input: &str) -> ParserResult<()> {
         let expecteds = vec![syntax_error("IGNORED MESSAGE", Position::at(1, 1))];
         assert_input(input, expecteds)


### PR DESCRIPTION
This applies some very minor changes that I meant to apply as part
of #25, but forgot to before merging.

Also removes some redundant `#[rstest]` attributes in the tests
and makes the spacing in the PEG more consistent around parenthesis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
