### PR TITLE
Minor fix to doc comment in `pest_ion::result`

### DIFF
--- a/pest-ion/src/result.rs
+++ b/pest-ion/src/result.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! [`Error`] and [`Result`] types for working with Pest to Ion.
+//! [`Error`](std::error::Error) and [`Result`] types for working with Pest to Ion.
 
 use thiserror::Error;
 


### PR DESCRIPTION
Fixes broken link to `std::error::Error`, qualifies it because of the
ambiguity to the derive macro.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
