### PR TITLE
Load file implementation of `TryPestToIon`

### DIFF
--- a/pest-ion/Cargo.toml
+++ b/pest-ion/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = "~1.0.25"
 pest = "~2.1.3"
 pest_meta = "~2.1.3"
 ion-rs = "~0.6.0"
-smallvec = "~1.6.1"
 
 [dev-dependencies]
 rstest = "~0.10.0"

--- a/pest-ion/src/lib.rs
+++ b/pest-ion/src/lib.rs
@@ -98,7 +98,9 @@ impl TryPestToElement for str {
             Ok(ast) => ast,
             Err(errors) => {
                 return if errors.is_empty() {
-                    invalid("Error converting Pest grammar to AST with no context")
+                    invalid(
+                        "Parser indicated an error happened but didn't return any error messages",
+                    )
                 } else {
                     // TODO deal with more than one error..
                     let err = errors.into_iter().next().unwrap();

--- a/pest-ion/src/result.rs
+++ b/pest-ion/src/result.rs
@@ -18,6 +18,10 @@ pub enum PestToIonError {
     #[error("Ion Error: {0}")]
     Ion(#[from] ion_rs::result::IonError),
 
+    /// An I/O error.
+    #[error("I/O Error: {0}")]
+    Io(#[from] std::io::Error),
+
     /// General error from this library.
     #[error("Pest to Ion Error: {0}")]
     Invalid(String),


### PR DESCRIPTION
Removes `smallvec` and changes expression serialization to use heap
allocated `Vec`.  For very heavily nested grammars (e.g. PartiQL's
keyword rules), this can blow out the stack.

Adds support for `TryPestToElement` from `Read` via a wrapper.
Interior mutability via `RefCell<T>` is required because `TryPestToElement`
is designed around `&self` which makes sense for things like `&str`/`String`/`Path`.

Also:
* Adds blanket `TryPestToElement` implementation for all references.
* Adds `TryPestToElement` implementations for `Path` and `String`.
* Adds test to load PartiQL Pest.
* Adds `PestToIonError::Io`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
