### PR TITLE
Adds CLI tests for `pest2ion`

### DIFF
--- a/pest-ion/Cargo.toml
+++ b/pest-ion/Cargo.toml
@@ -31,8 +31,8 @@ anyhow = "~1.0.40"
 
 [dev-dependencies]
 rstest = "~0.10.0"
+assert_cmd = "~1.0.5"
+tempfile = "~3.2.0"
 
 [[bin]]
 name = "pest2ion"
-test = false
-bench = false

--- a/pest-ion/tests/cli.rs
+++ b/pest-ion/tests/cli.rs
@@ -30,7 +30,7 @@ enum FileMode {
         }
     "#
 )]
-fn simple(
+fn run_it(
     #[case] pest_src: &str,
     #[case] ion_text: &str,
     #[values("", "-t", "-p", "-b")] format_flag: &str,

--- a/pest-ion/tests/cli.rs
+++ b/pest-ion/tests/cli.rs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates.
+
+use anyhow::Result;
+use assert_cmd::Command;
+use ion_rs::value::reader::*;
+use rstest::*;
+use std::fs::File;
+use std::io::{Read, Write};
+use tempfile::TempDir;
+
+/// The input or output mode of the CLI.
+enum FileMode {
+    /// Use `STDIN` or `STDOUT`
+    Default,
+    /// Use a named file.
+    Named,
+}
+
+#[rstest]
+#[case::simple(
+    r#"
+        a = { "a" ~ "b" }
+    "#,
+    r#"
+        {
+            a: {
+                type: normal,
+                expression: (sequence (string exact "a") (string exact "b")),
+            }
+        }
+    "#
+)]
+fn simple(
+    #[case] pest_src: &str,
+    #[case] ion_text: &str,
+    #[values("", "-t", "-p", "-b")] format_flag: &str,
+    #[values(FileMode::Default, FileMode::Named)] input_mode: FileMode,
+    #[values(FileMode::Default, FileMode::Named)] output_mode: FileMode,
+) -> Result<()> {
+    // working space for our tests when they need files
+    let temp_dir = TempDir::new()?;
+    let input_path = temp_dir.path().join("INPUT.pest");
+    let output_path = temp_dir.path().join("OUTPUT.ion");
+
+    let mut cmd = Command::cargo_bin("pest2ion")?;
+    if format_flag != "" {
+        cmd.arg(format_flag);
+    }
+    match output_mode {
+        FileMode::Default => {
+            // do nothing
+        }
+        FileMode::Named => {
+            // tell our driver to output to a file
+            cmd.arg("-o");
+            cmd.arg(&output_path);
+        }
+    }
+    match input_mode {
+        FileMode::Default => {
+            // do nothing
+        }
+        FileMode::Named => {
+            // dump our test data to input file
+            let mut input_file = File::create(&input_path)?;
+            input_file.write(pest_src.as_bytes())?;
+            input_file.flush()?;
+
+            // make this the input for our driver
+            cmd.arg(input_path.to_str().unwrap());
+        }
+    };
+    println!("{:?}", cmd);
+    let assert = cmd.write_stdin(pest_src).assert();
+
+    let actual = match output_mode {
+        FileMode::Default => {
+            let output = assert.get_output();
+            element_reader().read_one(&output.stdout)?
+        }
+        FileMode::Named => {
+            let mut output_file = File::open(output_path)?;
+            let mut output_buffer = vec![];
+            output_file.read_to_end(&mut output_buffer)?;
+            element_reader().read_one(&output_buffer)?
+        }
+    };
+    let expected = element_reader().read_one(ion_text.as_bytes())?;
+    assert_eq!(expected, actual);
+
+    assert.success();
+
+    Ok(())
+}


### PR DESCRIPTION
Uses `assert_cmd` and `rstest` to test the different permutations of the
`pest2ion` command with real arguments.  This includes testing
STDIN/STDOUT defaults as well as file arguments using a temporary
directory per test case.  Each format mode is also permuted.

Note that this does not test the "long" argument names, if we care to,
we can always add that for completeness.

The goal here is to make sure the driver works, not to test the completeness
of the `pest-ion` library crate.

Resolves #42.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
