### PR TITLE
Adds `pest2ion` CLI test for PartiQL Grammar

### DIFF
--- a/pest-ion/tests/cli.rs
+++ b/pest-ion/tests/cli.rs
@@ -26,7 +26,7 @@ struct TestCase<S: AsRef<str>> {
 }
 
 impl From<(&'static str, &'static str)> for TestCase<&'static str> {
-    /// Simple conversion for static `str` slices into a test acse
+    /// Simple conversion for static `str` slices into a test case
     fn from((pest_text, ion_text): (&'static str, &'static str)) -> Self {
         let expected_ion = element_reader().read_one(ion_text.as_bytes()).unwrap();
         Self {

--- a/pest-ion/tests/cli.rs
+++ b/pest-ion/tests/cli.rs
@@ -25,8 +25,6 @@ struct TestCase<S: AsRef<str>> {
     expected_ion: OwnedElement,
 }
 
-impl<S: AsRef<str>> TestCase<S> {}
-
 impl From<(&'static str, &'static str)> for TestCase<&'static str> {
     /// Simple conversion for static `str` slices into a test acse
     fn from((pest_text, ion_text): (&'static str, &'static str)) -> Self {


### PR DESCRIPTION
Adds a `TestCase` struct to encapsulate the test case parameters for
testing the CLI.  Makes a simple conversion from `&'static str` pair
which is for when you have simple in/out type of tests.  Adds function
to generate a test case out of the PartiQL grammar file which doesn't
really validate anything about the grammar serialization other than we
get something the library would produce.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
