### PR TITLE
Upgrade toolchain for GitHub coverage.yaml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2021-05-09
+          toolchain: nightly-2022-01-10
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
We're getting some odd errors in GitHub action when building
our dependencies, upgrading the toolchain to resolve such errors.

```
error: failed to parse manifest at `/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/ion-c-sys-macros-0.1.1/Cargo.toml`
Error: failed to parse manifest at `/home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/ion-c-sys-macros-0.1.1/Cargo.toml`
Caused by:
  feature `edition2021` is required

  consider adding `cargo-features = ["edition2021"]` to the manifest
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 101
```

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
