### PR TITLE
Add Experimental AST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "partiql",
+  "partiql-ast",
   "partiql-eval",
   "partiql-irgen",
   "partiql-parser",

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -1,0 +1,26 @@
+name = "partiql-ast"
+authors = ["PartiQL Team <partiql-team@amazon.com>"]
+description = "PartiQL AST"
+homepage = "https://github.com/partiql/partiql-lang-rust"
+repository = "https://github.com/partiql/partiql-lang-rust"
+license = "Apache-2.0"
+readme = "../README.md"
+keywords = ["sql", "ast", "query", "compilers", "interpreters"]
+categories = ["database", "compilers", "ast-implementations"]
+exclude = [
+  "**/.git/**",
+  "**/.github/**",
+]
+edition = "2021"
+version = "0.0.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+ion-rs = "~0.8.0"
+
+[dev-dependencies]
+rstest = "~0.12.0"

--- a/partiql-ast/LICENSE
+++ b/partiql-ast/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -1,0 +1,877 @@
+//! An experimental PartiQL abstract syntax tree (AST) module, see the following for motivation:
+//! https://github.com/partiql/partiql-lang-rust/issues/52
+//!
+//! This module contains the structures for the language AST.
+//! Two main entities in the module are [`Item`] and [`ItemKind`]. `Item` represents an AST element
+//! and `ItemKind` represents a concrete type with the data specific to the type of the item.
+
+// Types defined in this module are mostly from the current partiql-ir-generator spec. and comments
+// are excerpts from the spec definition.
+// https://github.com/partiql/partiql-lang-kotlin/blob/4bcfc7f73d3e6e54286bcc03a54d5f6425eec4cc/lang/resources/org/partiql/type-domains/partiql.ion
+
+// TODO Follow-up 'the trait `Hash` is not implemented for `OwnedValue`' with ion-team.
+// TODO Add documentation.
+
+use ion_rs::value::owned::OwnedValue;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Item {
+    pub kind: ItemKind,
+    // We can/require to extend the fields as we get more clarity on the path forward.
+    // Candidate additional fields are `name: Ident`, `span: Span`, `attr: Vec<Attribute>`.
+    // Also targeting on spinning up a parallel discussion with regards to AST versioning
+    // and how it contributes to backward compatibility.
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ItemKind {
+    Query(Query),
+    Dml(Dml),
+    Ddl(Ddl),
+    Exec(Exec),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Query {
+    pub expr: Expr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Dml {
+    pub operations: DmlOpList,
+    pub from_clause: FromClause,
+    pub where_clause: Expr,
+    pub returning: Option<ReturningExpr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ddl {
+    pub operations: DdlOp,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Exec {
+    pub procedure_name: SymbolPrimitive,
+    pub args: Vec<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Expr {
+    pub kind: ExprKind,
+}
+
+/// The expressions that can result in values.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExprKind {
+    Missing,
+    Lit(Lit),
+    /// A variable reference
+    Id(Id),
+    /// A parameter, i.e. `?`
+    Param(Param),
+    /// Unary operators
+    Not(Not),
+    Pos(Pos),
+    Neg(Neg),
+    /// Arithmetic operators
+    Plus(Plus),
+    Minus(Minus),
+    Times(Times),
+    Divide(Divide),
+    Modulo(Modulo),
+    Concat(Concat),
+    /// Logical operators
+    And(And),
+    Or(Or),
+    /// Comparison operators
+    Eq(Eq),
+    Ne(Ne),
+    Gt(Gt),
+    Gte(Gte),
+    Lt(Lt),
+    Lte(Lte),
+    Like(Like),
+    Between(Between),
+    In(In),
+    Is(Is),
+    /// CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
+    SimpleCase(SimpleCase),
+    /// CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
+    SearchedCase(SearchCase),
+    /// Conpub structors
+    Struct(Struct),
+    Bag(Bag),
+    List(List),
+    Sexp(Sexp),
+    /// Conpub structors for DateTime types
+    Date(Date),
+    LitTime(LitTime),
+    /// Set operators
+    Union(Union),
+    Except(Except),
+    Intersect(Intersect),
+    /// Other expression types
+    Path(Path),
+    Call(Call),
+    CallAgg(CallAgg),
+    Cast(Cast),
+    CanCast(CanCast),
+    CanLossLessCast(CanLossLessCast),
+    NullIf(NullIf),
+    Coalesce(Coalesce),
+
+    /// `SELECT` and its parts.
+    Select(Select),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Lit {
+    pub value: OwnedValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Id {
+    pub name: SymbolPrimitive,
+    pub case: CaseSensitivity,
+    pub qualifier: ScopeQualifier,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Param {
+    pub index: i32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Not {
+    pub expr: Box<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Pos {
+    pub expr: Box<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Neg {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Plus {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Minus {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Times {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Divide {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Modulo {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Concat {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct And {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Or {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Eq {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ne {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gt {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gte {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Lt {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Lte {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Like {
+    pub value: Box<Expr>,
+    pub pattern: Box<Expr>,
+    pub escape: Option<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Between {
+    pub value: Box<Expr>,
+    pub from: Box<Expr>,
+    pub to: Box<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct In {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Is {
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SimpleCase {
+    pub expr: Box<Expr>,
+    pub cases: ExprPairList,
+    pub default: Option<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SearchCase {
+    pub cases: ExprPairList,
+    pub default: Option<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Struct {
+    pub fields: Vec<ExprPair>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Bag {
+    pub values: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct List {
+    pub values: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Sexp {
+    pub values: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Date {
+    pub year: i32,
+    pub month: i32,
+    pub day: i32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LitTime {
+    pub value: TimeValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Union {
+    pub setq: SetQuantifier,
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Except {
+    pub setq: SetQuantifier,
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Intersect {
+    pub setq: SetQuantifier,
+    pub operands: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Path {
+    pub root: Box<Expr>,
+    pub steps: Vec<PathStep>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Call {
+    pub func_name: SymbolPrimitive,
+    pub args: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CallAgg {
+    pub func_name: SymbolPrimitive,
+    args: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Cast {
+    pub value: Box<Expr>,
+    pub as_type: Type,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CanCast {
+    pub value: Box<Expr>,
+    pub as_type: Type,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CanLossLessCast {
+    pub value: Box<Expr>,
+    pub as_type: Type,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NullIf {
+    pub expr1: Box<Expr>,
+    pub expr2: Box<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Coalesce {
+    pub args: Vec<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Select {
+    pub setq: Option<SetQuantifier>,
+    pub project: Projection,
+    pub from: FromClause,
+    pub from_let: Option<Let>,
+    pub where_clause: Option<Box<Expr>>,
+    pub group_by: Option<GroupByExpr>,
+    pub having: Option<Box<Expr>>,
+    pub order_by: Option<OrderByExpr>,
+    pub limit: Option<Box<Expr>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TimeValue {
+    pub hour: i32,
+    pub minute: i32,
+    pub second: i32,
+    pub nano: i32,
+    pub precision: i32,
+    pub with_time_zone: bool,
+    pub tz_minutes: Option<i32>,
+}
+
+/// A "step" within a path expression; that is the components of the expression following the root.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PathStep {
+    pub kind: PathStepKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum PathStepKind {
+    PathExpr(PathExpr),
+    PathWildCard,
+    PathUnpivot,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PathExpr {
+    pub index: Expr,
+    pub case: CaseSensitivity,
+}
+
+/// Is used to determine if variable lookup should be case-sensitive or not.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CaseSensitivity {
+    pub kind: CaseSensitivityKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CaseSensitivityKind {
+    CaseSensitive,
+    CaseInsensitive,
+}
+
+/// Indicates the type of projection in a SFW query.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Projection {
+    pub kind: ProjectionKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProjectionKind {
+    ProjectStar,
+    ProjectList(ProjectList),
+    ProjectPivot(ProjectPivot),
+    ProjectValue(ProjectValue),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectList {
+    pub project_items: Vec<ProjectItem>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectPivot {
+    pub value: Box<Expr>,
+    pub key: Box<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectValue {
+    pub value: Box<Expr>,
+}
+
+/// An item to be projected in a `SELECT`-list.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectItem {
+    pub kind: ProjectItemKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProjectItemKind {
+    /// For `.*` in SELECT list
+    ProjectAll(ProjectAll),
+    /// For `<expr> [AS <id>]`
+    ProjectExpr(ProjectExpr),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectAll {
+    pub expr: Expr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProjectExpr {
+    pub expr: Expr,
+    pub as_alias: Option<SymbolPrimitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Let {
+    /// A list of LET bindings
+    pub let_bindings: Vec<LetBinding>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LetBinding {
+    pub expr: Expr,
+    pub name: SymbolPrimitive,
+}
+
+/// FROM clause of an SFW query
+#[derive(Clone, Debug, PartialEq)]
+pub struct FromClause {
+    pub kind: FromClauseKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum FromClauseKind {
+    FromLet(FromLet),
+    /// <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
+    Join(Join),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FromLet {
+    pub expr: Box<Expr>,
+    pub kind: FromLetKind,
+    pub as_alias: Option<SymbolPrimitive>,
+    pub at_alias: Option<SymbolPrimitive>,
+    pub by_alias: Option<SymbolPrimitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Join {
+    pub kind: JoinKind,
+    pub left: Box<FromClause>,
+    pub right: Box<FromClause>,
+    pub predicate: Option<Box<Expr>>,
+}
+
+/// Indicates the type of FromLet, see the following for more details:
+/// https:///github.com/partiql/partiql-lang-kotlin/issues/242
+#[derive(Clone, Debug, PartialEq)]
+pub enum FromLetKind {
+    Scan,
+    Unpivot,
+}
+
+/// Indicates the logical type of join.
+#[derive(Clone, Debug, PartialEq)]
+pub enum JoinKind {
+    Inner,
+    Left,
+    Right,
+    Full,
+}
+
+/// A generic pair of expressions. Used in the `pub struct`, `searched_case`
+/// and `simple_case` expr variants above.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprPair {
+    pub first: Expr,
+    pub second: Expr,
+}
+
+/// A list of expr_pair. Used in the `pub struct`, `searched_case` and `simple_case`
+/// expr variants above.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ExprPairList {
+    pub pairs: Vec<ExprPair>,
+}
+
+/// GROUP BY <grouping_strategy> <group_key_list>... [AS <symbol>]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupByExpr {
+    pub strategy: GroupingStrategy,
+    pub key_list: GroupKeyList,
+    pub group_as_alias: Option<SymbolPrimitive>,
+}
+
+/// Desired grouping qualifier:  ALL or PARTIAL.  Note: the `group_` prefix is
+/// needed to avoid naming clashes.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupingStrategy {
+    pub kind: GroupingStrategyKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GroupingStrategyKind {
+    GroupFull,
+    GroupPartial,
+}
+
+/// <group_key>[, <group_key>]...
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupKeyList {
+    pub keys: Vec<GroupKey>,
+}
+
+/// <expr> [AS <symbol>]
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupKey {
+    pub expr: Expr,
+    pub as_alias: Option<SymbolPrimitive>,
+}
+
+/// ORDER BY <sort_spec>...
+#[derive(Clone, Debug, PartialEq)]
+pub struct OrderByExpr {
+    pub sort_specs: Vec<SortSpec>,
+}
+
+/// <expr> [ASC | DESC] ?
+#[derive(Clone, Debug, PartialEq)]
+pub struct SortSpec {
+    pub expr: Expr,
+    pub ordering_spec: Option<OrderingSpec>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OrderingSpec {
+    pub kind: OrderingSpecKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum OrderingSpecKind {
+    Asc,
+    Desc,
+}
+
+/// Indicates scope search order when resolving variables.
+/// Has no effect except within `FROM` sources.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScopeQualifier {
+    kind: ScopeQualifierKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ScopeQualifierKind {
+    /// Use the default search order.
+    Unqualified,
+    /// Skip the globals, first check within FROM sources and resolve starting with the local scope.
+    Qualified,
+}
+
+/// Indicates if a set should be reduced to its distinct elements or not.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SetQuantifier {
+    pub kind: SetQuantifierKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SetQuantifierKind {
+    All,
+    Distinct,
+}
+
+/// Data Manipulation Operations.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DmlOpList {
+    pub ops: Vec<DmlOp>,
+}
+
+/// A Data Manipulation Operation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DmlOp {
+    pub kind: DmlOpKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DmlOpKind {
+    /// `INSERT INTO <expr> <expr>`
+    Insert(Insert),
+    /// `INSERT INTO <expr> VALUE <expr> [AT <expr>]` [ON CONFLICT WHERE <expr> DO NOTHING]`
+    InsertValue(InsertValue),
+    /// `SET <assignment>...`
+    Set(Set),
+    /// `REMOVE <expr>`
+    Remove(Remove),
+    /// DELETE
+    Delete,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Insert {
+    pub target: Expr,
+    pub values: Expr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct InsertValue {
+    pub target: Expr,
+    pub value: Expr,
+    pub index: Option<Expr>,
+    pub on_conflict: Option<OnConflict>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Set {
+    pub assignment: Assignment,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Remove {
+    pub target: Expr,
+}
+
+/// `ON CONFLICT <expr> <conflict_action>`
+#[derive(Clone, Debug, PartialEq)]
+pub struct OnConflict {
+    pub expr: Expr,
+    pub conflict_action: ConflictAction,
+}
+
+/// `CONFLICT_ACTION <action>`
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConflictAction {
+    pub kind: ConflictActionKind,
+}
+
+/// `CONFLICT_ACTION <action>`
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConflictActionKind {
+    DonNothing,
+}
+
+/// A data definition operation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DdlOp {
+    pub kind: DdlOpKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum DdlOpKind {
+    /// `CREATE TABLE <symbol>`
+    CreateTable(CreateTable),
+    /// `DROP TABLE <Ident>`
+    DropTable(DropTable),
+    /// `CREATE INDEX ON <Ident> (<expr> [, <expr>]...)`
+    CreateIndex(CreateIndex),
+    /// DROP INDEX <Ident> ON <Ident>
+    /// In Statement, first <Ident> represents keys, second represents table
+    DropIndex(DropIndex),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreateTable {
+    pub table_name: SymbolPrimitive,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DropTable {
+    pub table_name: SymbolPrimitive,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreateIndex {
+    pub index_name: Ident,
+    pub fields: Vec<Expr>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DropIndex {
+    pub table: Ident,
+    pub keys: Ident,
+}
+
+/// `RETURNING (<returning_elem> [, <returning_elem>]...)`
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReturningExpr {
+    pub elems: Vec<ReturningElem>,
+}
+
+/// `<returning mapping> (<expr> [, <expr>]...)`
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReturningElem {
+    pub mapping: ReturningMapping,
+    pub column: ColumnComponent,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ColumnComponent {
+    pub kind: ColumnComponentKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ColumnComponentKind {
+    ReturningWildcard,
+    ReturningColumn(ReturningColumn),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReturningColumn {
+    pub expr: Expr,
+}
+
+/// ( MODIFIED | ALL ) ( NEW | OLD )
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReturningMapping {
+    pub kind: ReturningMappingKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ReturningMappingKind {
+    ModifiedNew,
+    ModifiedOld,
+    AllNew,
+    AllOld,
+}
+
+/// `Ident` can be used for names that need to be looked up with a notion of case-sensitivity.
+
+/// For both `create_index` and `create_table`, there is no notion of case-sensitivity
+/// for table Idents since they are *defining* new Idents.  However, for `drop_index` and
+/// `drop_table` *do* have the notion of case sensitivity since they are referring to existing names.
+/// Idents with case-sensitivity is already modeled with the `id` variant of `expr`,
+/// but there is no way to specify to PIG that we want to only allow a single variant of a sum as
+/// an element of a type.  (Even though in the Kotlin code each varaint is its own type.)  Hence, we
+/// define an `Ident` type above which can be used without opening up an element's domain to
+/// all of `expr`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ident {
+    pub name: SymbolPrimitive,
+    pub case: CaseSensitivity,
+}
+
+/// Represents `<expr> = <expr>` in a DML SET operation.  Note that in this case, `=` is representing
+/// an assignment operation and *not* the equality operator.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Assignment {
+    pub target: Expr,
+    pub value: Expr,
+}
+
+/// Represents all possible PartiQL data types.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Type {
+    pub kind: TypeKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum TypeKind {
+    NullType,
+    BooleanType,
+    SmallIntType,
+    Integer4Type,
+    Integer8Type,
+    IntegerType,
+    FloatType,
+    RealType,
+    DoublePrecisionType,
+    DecimalType,
+    NumericType,
+    TimestampType,
+    CharacterType,
+    CharacterVaryingType,
+    MissingType,
+    StringType,
+    SymbolType,
+    BlobType,
+    ClobType,
+    DateType,
+    TimeType,
+    TimeWithTimeZoneType,
+    StructType,
+    TupleType,
+    ListType,
+    SexpType,
+    BagType,
+    AnyType,
+
+    CustomType(CustomType),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FloatType {
+    precision: Option<LongPrimitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CharacterType {
+    pub length: Option<LongPrimitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CharacterVaryingType {
+    pub length: Option<LongPrimitive>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CustomType {
+    pub name: SymbolPrimitive,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SymbolPrimitive {
+    pub value: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct LongPrimitive {
+    pub value: i32,
+}

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod experimental {
+    pub mod ast;
+}

--- a/partiql-ast/tests/common.rs
+++ b/partiql-ast/tests/common.rs
@@ -1,0 +1,3 @@
+pub fn setup() {
+    // setup test code goes here
+}

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -1,0 +1,22 @@
+mod common;
+
+use ion_rs::value::owned::OwnedValue;
+use ion_rs::value::AnyInt;
+use partiql_ast::experimental::ast::*;
+
+#[test]
+fn test_ast_init() {
+    common::setup();
+
+    let _i = Item {
+        kind: ItemKind::Query(Query {
+            expr: Expr {
+                kind: ExprKind::Lit(Lit {
+                    value: OwnedValue::Integer(AnyInt::I64(1)),
+                }),
+            },
+        }),
+    };
+
+    // TODO Add assertion once we have tree traversals
+}


### PR DESCRIPTION
This commit includes an experimental implementation of PartiQL AST
 based on the current kotlin implementation which has been
auto-generated by `partiql-ir-generator`:
- https://github.com/partiql/partiql-ir-generator

We want to create an experimental PartiQL AST so that:

- solidify our expected core model (at least for the first iteration)
  prior to developing AST code generation i.e. using
  partiql-ir-generator spec or a substitute.
- we can get an early review with having integration with parser
  in the picture.

This implementation does _not_ include:
- The addition of MetaContainer and with_meta method.
  For code region data, We try to see if a substitute approach like
  using Span works as a substitute approach.

- The implementation of std::fmt::Display Trait for ast entities.
  Will be tracked in a separate issue.
- The tree traversal and transform utilities.
  Will be tracked in a separate issue.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
