### PR TITLE
Add prototype for converting Pest's Pairs to AST

### DIFF
--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -37,6 +37,7 @@ rust_decimal = "~1.22.0"
 lalrpop-util = "~0.19.7"
 logos = "~0.12.0"
 
+itertools = "~0.10.3"
 
 [dev-dependencies]
 rstest = "~0.9.0"

--- a/partiql-parser/benches/bench_parse.rs
+++ b/partiql-parser/benches/bench_parse.rs
@@ -2,6 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use partiql_parser::lalr_parse;
 use partiql_parser::logos_lex;
 use partiql_parser::peg_parse;
+use partiql_parser::peg_parse_to_ast;
 use partiql_parser::result::ParserResult;
 use pest::iterators::Pairs;
 
@@ -30,6 +31,15 @@ fn pest_benchmark(c: &mut Criterion) {
     c.bench_function("peg-complex", |b| b.iter(|| parse(black_box(Q_COMPLEX))));
 }
 
+fn pest_to_ast_benchmark(c: &mut Criterion) {
+    let parse = peg_parse_to_ast;
+    c.bench_function("peg-ast-simple", |b| b.iter(|| parse(black_box(Q_STAR))));
+    c.bench_function("peg-ast-group", |b| b.iter(|| parse(black_box(Q_GROUP))));
+    c.bench_function("peg-ast-complex", |b| {
+        b.iter(|| parse(black_box(Q_COMPLEX)))
+    });
+}
+
 fn logos_benchmark(c: &mut Criterion) {
     let parse = |s| logos_lex(s).count(); // Just use `.count` to consume the lexer iterator
     c.bench_function("logos-simple", |b| b.iter(|| parse(black_box(Q_STAR))));
@@ -44,5 +54,11 @@ fn lalr_benchmark(c: &mut Criterion) {
     c.bench_function("lalr-complex", |b| b.iter(|| parse(black_box(Q_COMPLEX))));
 }
 
-criterion_group!(parse, pest_benchmark, logos_benchmark, lalr_benchmark);
+criterion_group!(
+    parse,
+    pest_benchmark,
+    pest_to_ast_benchmark,
+    logos_benchmark,
+    lalr_benchmark
+);
 criterion_main!(parse);

--- a/partiql-parser/benches/bench_parse.rs
+++ b/partiql-parser/benches/bench_parse.rs
@@ -3,13 +3,11 @@ use partiql_parser::lalr_parse;
 use partiql_parser::logos_lex;
 use partiql_parser::peg_parse;
 use partiql_parser::peg_parse_to_ast;
-
-
+use std::time::Duration;
 
 const Q_STAR: &str = "SELECT *";
 
-const Q_GROUP: &str =
-    "SELECT g FROM data GROUP BY a AS x, b + c AS y, foo(d) AS z GROUP AS g";
+const Q_GROUP: &str = "SELECT g FROM data GROUP BY a AS x, b + c AS y, foo(d) AS z GROUP AS g";
 
 const Q_COMPLEX: &str = r#"
             SELECT (
@@ -54,11 +52,13 @@ fn lalr_benchmark(c: &mut Criterion) {
     c.bench_function("lalr-complex", |b| b.iter(|| parse(black_box(Q_COMPLEX))));
 }
 
-criterion_group!(
-    parse,
-    pest_benchmark,
+criterion_group! {
+    name = parse;
+    config = Criterion::default().measurement_time(Duration::new(10, 0));
+    targets = pest_benchmark,
     pest_to_ast_benchmark,
     logos_benchmark,
     lalr_benchmark
-);
+}
+
 criterion_main!(parse);

--- a/partiql-parser/benches/bench_parse.rs
+++ b/partiql-parser/benches/bench_parse.rs
@@ -3,15 +3,15 @@ use partiql_parser::lalr_parse;
 use partiql_parser::logos_lex;
 use partiql_parser::peg_parse;
 use partiql_parser::peg_parse_to_ast;
-use partiql_parser::result::ParserResult;
-use pest::iterators::Pairs;
 
-const Q_STAR: &'static str = "SELECT *";
 
-const Q_GROUP: &'static str =
+
+const Q_STAR: &str = "SELECT *";
+
+const Q_GROUP: &str =
     "SELECT g FROM data GROUP BY a AS x, b + c AS y, foo(d) AS z GROUP AS g";
 
-const Q_COMPLEX: &'static str = r#"
+const Q_COMPLEX: &str = r#"
             SELECT (
                 SELECT numRec, data
                 FROM delta_full_transactions.deltas delta,

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -18,3 +18,4 @@ pub use lalr::lex_partiql as logos_lex;
 pub use lalr::parse_partiql as lalr_parse;
 pub use lalr::ParseResult as LalrParseResult;
 pub use peg::parse_partiql as peg_parse;
+pub use peg::parse_partiql_to_ast as peg_parse_to_ast;

--- a/partiql-parser/src/peg/ast_builder.rs
+++ b/partiql-parser/src/peg/ast_builder.rs
@@ -1,0 +1,774 @@
+use crate::peg::grammar::Rule;
+use crate::prelude::ParserError;
+use crate::result::ParserResult;
+use itertools::Itertools;
+use partiql_ast::experimental::ast;
+use partiql_ast::experimental::ast::{
+    FromClause, FromClauseKind, JoinKind, JoinSpec, ProjectItemKind, SymbolPrimitive,
+};
+use pest::iterators::{Pair, Pairs};
+use std::str::FromStr;
+
+pub(crate) fn build_query(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    let pair = pairs.next().unwrap();
+
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::query_full => build_query(pair.into_inner()),
+        Rule::query => build_query(pair.into_inner()),
+        Rule::sfw_query => build_sfw_query(pair.into_inner()),
+        Rule::expr_query => build_expr_query(pair.into_inner()),
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+pub(crate) fn build_sfw_query(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    let mut setq = None;
+    let mut project = None;
+    let mut from = None;
+    let mut from_let = None;
+    let mut where_clause = None;
+    let mut group_by = None;
+    let mut having = None;
+    let mut order_by = None;
+    let mut limit = None;
+    let mut offset = None;
+
+    for pair in pairs {
+        let rule = pair.as_rule();
+
+        match rule {
+            Rule::select_clause => project = Some(build_select_clause(pair.into_inner())?),
+            Rule::from_clause => from = Some(build_from_clause(pair.into_inner())?),
+            Rule::limit_clause => limit = Some(build_limit_clause(pair.into_inner())?),
+            Rule::offset_clause => offset = Some(build_offset_clause(pair.into_inner())?),
+            Rule::order_by_clause => order_by = Some(build_order_by_clause(pair.into_inner())?),
+            Rule::where_clause => where_clause = Some(build_where_clause(pair.into_inner())?),
+            Rule::having_clause => having = Some(build_having_clause(pair.into_inner())?),
+            Rule::group_by_clause => group_by = Some(build_group_by_clause(pair.into_inner())?),
+            _ => todo!("Unhandled rule [{:?}]", rule),
+        }
+    }
+
+    let project = project.expect("Select required");
+    Ok(Box::new(ast::Expr {
+        kind: ast::ExprKind::Select(ast::Select {
+            setq,
+            project,
+            from,
+            from_let,
+            where_clause,
+            group_by,
+            having,
+            order_by,
+            limit,
+            offset,
+        }),
+    }))
+}
+
+pub(crate) fn build_group_by_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::GroupByExpr>> {
+    let mut parts: Vec<_> = pairs.rev().collect();
+
+    let mut next = parts.pop().unwrap();
+    let strategy = if let Rule::group_all = next.as_rule() {
+        next = parts.pop().unwrap();
+        ast::GroupingStrategy {
+            kind: ast::GroupingStrategyKind::GroupFull,
+        }
+    } else {
+        ast::GroupingStrategy {
+            kind: ast::GroupingStrategyKind::GroupPartial,
+        }
+    };
+
+    let keys = next
+        .into_inner()
+        .map(|out_binding| {
+            let mut parts = out_binding.into_inner();
+            let expr = build_expr_query(parts.next().unwrap().into_inner());
+            let as_alias = parts.next().map(|pair| ast::SymbolPrimitive {
+                value: pair.as_str().trim_matches('"').to_string(),
+            });
+            expr.map(|expr| ast::GroupKey {
+                expr: *expr,
+                as_alias,
+            })
+        })
+        .collect::<ParserResult<Vec<_>>>()?;
+    let key_list = ast::GroupKeyList { keys };
+
+    let group_as_alias = if let Some(pair) = parts.pop() {
+        Some(ast::SymbolPrimitive {
+            value: pair.as_str().trim_matches('"').to_string(),
+        })
+    } else {
+        None
+    };
+
+    Ok(Box::new(ast::GroupByExpr {
+        strategy: strategy,
+        key_list: key_list,
+        group_as_alias: group_as_alias,
+    }))
+}
+
+pub(crate) fn build_order_by_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::OrderByExpr>> {
+    let pair = pairs.next().unwrap();
+
+    let rule = pair.as_rule();
+
+    let order_expr = match rule {
+        Rule::order_sort_preserve => ast::OrderByExpr { sort_specs: vec![] },
+        Rule::order_sort_spec_list => ast::OrderByExpr {
+            sort_specs: build_order_sort_specs(pair.into_inner())?,
+        },
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    };
+    Ok(Box::new(order_expr))
+}
+
+pub(crate) fn build_order_sort_specs(mut pairs: Pairs<Rule>) -> ParserResult<Vec<ast::SortSpec>> {
+    pairs
+        .map(|pair| build_order_sort_spec(pair.into_inner()))
+        .collect::<ParserResult<Vec<_>>>()
+}
+
+pub(crate) fn build_order_sort_spec(mut pairs: Pairs<Rule>) -> ParserResult<ast::SortSpec> {
+    let expr = build_expr_query(pairs.next().unwrap().into_inner())?;
+    let mut ordering_spec = None;
+    let mut null_ordering_spec = None;
+
+    for pair in pairs {
+        match pair.as_rule() {
+            Rule::order_by_spec => {
+                let kind = if pair.as_str().to_lowercase() == "asc" {
+                    ast::OrderingSpecKind::Asc
+                } else {
+                    ast::OrderingSpecKind::Desc
+                };
+                ordering_spec = Some(ast::OrderingSpec { kind })
+            }
+            Rule::order_by_null_spec => {
+                let kind = if pair.as_str().to_lowercase().contains("first") {
+                    ast::NullOrderingSpecKind::First
+                } else {
+                    ast::NullOrderingSpecKind::Last
+                };
+                null_ordering_spec = Some(ast::NullOrderingSpec { kind })
+            }
+            _ => todo!("Unhandled rule [{:?}]", pair.as_rule()),
+        }
+    }
+
+    Ok(ast::SortSpec {
+        expr,
+        ordering_spec,
+        null_ordering_spec,
+    })
+}
+
+pub(crate) fn build_limit_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    build_expr_query(pairs.next().unwrap().into_inner())
+}
+
+pub(crate) fn build_offset_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    build_expr_query(pairs.next().unwrap().into_inner())
+}
+
+pub(crate) fn build_where_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    build_expr_query(pairs)
+}
+
+pub(crate) fn build_having_clause(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    build_expr_query(pairs)
+}
+
+pub(crate) fn build_select_clause(mut pairs: Pairs<Rule>) -> ParserResult<ast::Projection> {
+    let pair = pairs.next().unwrap();
+
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::select_sql_clause => {
+            let project_items = pair
+                .into_inner()
+                .map(|out_binding| match out_binding.as_rule() {
+                    Rule::out_binding => {
+                        let mut parts = out_binding.into_inner();
+                        let expr = build_expr_query(parts.next().unwrap().into_inner());
+                        let as_alias = parts.next().map(|pair| ast::SymbolPrimitive {
+                            value: pair.as_str().trim_matches('"').to_string(),
+                        });
+                        expr.map(|expr| ast::ProjectItem {
+                            kind: ast::ProjectItemKind::ProjectExpr(ast::ProjectExpr {
+                                expr: *expr,
+                                as_alias,
+                            }),
+                        })
+                    }
+                    _ => todo!("Unhandled rule [{:?}]", rule),
+                })
+                .collect::<ParserResult<Vec<_>>>()?;
+            Ok(ast::Projection {
+                kind: ast::ProjectionKind::ProjectList(ast::ProjectList { project_items }),
+            })
+        }
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+pub(crate) fn build_from_clause(mut pairs: Pairs<Rule>) -> ParserResult<ast::FromClause> {
+    let froms: Vec<ast::FromClause> = pairs
+        .map(|pair| build_table_reference(pair))
+        .collect::<ParserResult<Vec<_>>>()?;
+
+    let from = froms
+        .into_iter()
+        .reduce(|lfrom, rfrom| {
+            let join = ast::Join {
+                kind: ast::JoinKind::Cross,
+                left: Box::new(lfrom),
+                right: Box::new(rfrom),
+                predicate: None,
+            };
+            ast::FromClause {
+                kind: ast::FromClauseKind::Join(join),
+            }
+        })
+        .unwrap(); // safe, because we know there's at least 1 input
+    Ok(from)
+}
+
+fn build_table_reference(pair: Pair<Rule>) -> Result<FromClause, ParserError> {
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::table_joined => build_table_joined(pair.into_inner()),
+        Rule::table_unpivot => build_table_unpivot(pair.into_inner()),
+        Rule::table_base_reference => build_table_base_reference(pair.into_inner()),
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+fn build_table_unpivot(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let expr = build_expr_query(pairs.next().unwrap().into_inner());
+    let as_alias = pairs.next().map(|pair| ast::SymbolPrimitive {
+        value: pair.as_str().trim_matches('"').to_string(),
+    });
+    let at_alias = pairs.next().map(|pair| ast::SymbolPrimitive {
+        value: pair.as_str().trim_matches('"').to_string(),
+    });
+    expr.map(|expr| ast::FromClause {
+        kind: FromClauseKind::FromLet(ast::FromLet {
+            kind: ast::FromLetKind::Unpivot,
+            expr,
+            as_alias,
+            at_alias,
+            by_alias: None,
+        }),
+    })
+}
+
+fn build_table_base_reference(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let expr = build_expr_query(pairs.next().unwrap().into_inner());
+    let as_alias = pairs.next().map(|pair| ast::SymbolPrimitive {
+        value: pair.as_str().trim_matches('"').to_string(),
+    });
+    expr.map(|expr| ast::FromClause {
+        kind: FromClauseKind::FromLet(ast::FromLet {
+            kind: ast::FromLetKind::Scan,
+            expr,
+            as_alias,
+            at_alias: None,
+            by_alias: None,
+        }),
+    })
+}
+
+fn build_table_joined(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let pair = pairs.next().unwrap();
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::table_joined => build_table_joined(pair.into_inner()),
+        Rule::table_cross_join => build_table_cross_join(pair.into_inner()),
+        Rule::table_natural_join => build_table_natural_join(pair.into_inner()),
+        Rule::table_join_spec => build_table_join_spec(pair.into_inner()),
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+fn build_join_spec(mut pairs: Pairs<Rule>) -> Result<JoinSpec, ParserError> {
+    let pair = pairs.next().unwrap();
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::search_condition => {
+            todo!()
+        }
+        Rule::path_expr_list => {
+            todo!()
+        }
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+fn build_table_join_spec(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let mut parts: Vec<_> = pairs.collect();
+    let spec = build_join_spec(parts.pop().unwrap().into_inner())?;
+    let right = build_table_reference(parts.pop().unwrap())?;
+    let kind = if parts.len() > 1 {
+        let pair = parts.pop().unwrap();
+        let rule = pair.as_rule();
+
+        match rule {
+            Rule::join_type => {
+                let mut inner = pair.into_inner();
+                if let Some(outer_type) = inner.next() {
+                    let outer_str = outer_type.as_str().to_lowercase();
+                    if outer_str == "left" {
+                        JoinKind::Left
+                    } else if outer_str == "right" {
+                        JoinKind::Right
+                    } else if outer_str == "full" {
+                        JoinKind::Full
+                    } else {
+                        panic!("Unknown Join type [{:?}]", outer_type)
+                    }
+                } else {
+                    JoinKind::Inner
+                }
+            }
+            _ => todo!("Unhandled rule [{:?}]", rule),
+        }
+    } else {
+        JoinKind::Inner
+    };
+    let left = build_table_base_reference(parts.pop().unwrap().into_inner())?;
+
+    Ok(ast::FromClause {
+        kind: FromClauseKind::Join(ast::Join {
+            kind,
+            left: Box::new(left),
+            right: Box::new(right),
+            predicate: Some(spec),
+        }),
+    })
+}
+
+fn build_table_natural_join(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let mut parts: Vec<_> = pairs.collect();
+    let right = build_table_reference(parts.pop().unwrap())?;
+    let kind = if parts.len() > 1 {
+        let pair = parts.pop().unwrap();
+        let rule = pair.as_rule();
+
+        match rule {
+            Rule::join_type => {
+                let mut inner = pair.into_inner();
+                if let Some(outer_type) = inner.next() {
+                    let outer_str = outer_type.as_str().to_lowercase();
+                    if outer_str == "left" {
+                        JoinKind::Left
+                    } else if outer_str == "right" {
+                        JoinKind::Right
+                    } else if outer_str == "full" {
+                        JoinKind::Full
+                    } else {
+                        panic!("Unknown Join type [{:?}]", outer_type)
+                    }
+                } else {
+                    JoinKind::Inner
+                }
+            }
+            _ => todo!("Unhandled rule [{:?}]", rule),
+        }
+    } else {
+        JoinKind::Inner
+    };
+    let left = build_table_base_reference(parts.pop().unwrap().into_inner())?;
+
+    Ok(ast::FromClause {
+        kind: FromClauseKind::Join(ast::Join {
+            kind,
+            left: Box::new(left),
+            right: Box::new(right),
+            predicate: None,
+        }),
+    })
+}
+
+fn build_table_cross_join(mut pairs: Pairs<Rule>) -> Result<FromClause, ParserError> {
+    let left = build_table_base_reference(pairs.next().unwrap().into_inner())?;
+    let right = build_table_reference(pairs.next().unwrap())?;
+
+    Ok(ast::FromClause {
+        kind: FromClauseKind::Join(ast::Join {
+            kind: ast::JoinKind::Cross,
+            left: Box::new(left),
+            right: Box::new(right),
+            predicate: None,
+        }),
+    })
+}
+
+pub(crate) fn build_expr_query(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    let mut parts: Vec<_> = pairs
+        .map(|pair| {
+            let rule = pair.as_rule();
+
+            match rule {
+                Rule::expr_query => build_expr_query(pair.into_inner()),
+                Rule::expr_term => build_expr_term(pair.into_inner()),
+                Rule::op_bool => {
+                    if pair.as_str().to_lowercase() == "or" {
+                        Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Or(ast::Or { operands: vec![] }),
+                        }))
+                    } else if pair.as_str().to_lowercase() == "and" {
+                        Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::And(ast::And { operands: vec![] }),
+                        }))
+                    } else {
+                        panic!("Unexpected bool operator [{:?}]", pair.as_str());
+                    }
+                }
+                Rule::op_infix => {
+                    // TODO this doesn't handle precedence correctly
+                    // TODO use Pest's precedence climber
+                    let op_pair = pair.into_inner().next().unwrap();
+                    match op_pair.as_rule() {
+                        Rule::op_caret => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Exponentiate(ast::Exponentiate {
+                                operands: vec![],
+                            }),
+                        })),
+                        Rule::op_multiply => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Times(ast::Times { operands: vec![] }),
+                        })),
+                        Rule::op_divide => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Divide(ast::Divide { operands: vec![] }),
+                        })),
+                        Rule::op_modulus => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Modulo(ast::Modulo { operands: vec![] }),
+                        })),
+                        Rule::op_add => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Plus(ast::Plus { operands: vec![] }),
+                        })),
+                        Rule::op_subtract => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Minus(ast::Minus { operands: vec![] }),
+                        })),
+
+                        Rule::op_eq => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Eq(ast::Eq { operands: vec![] }),
+                        })),
+                        Rule::op_neq => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Ne(ast::Ne { operands: vec![] }),
+                        })),
+                        Rule::op_lt => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Lt(ast::Lt { operands: vec![] }),
+                        })),
+                        Rule::op_gt => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Gt(ast::Gt { operands: vec![] }),
+                        })),
+                        Rule::op_lteq => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Lte(ast::Lte { operands: vec![] }),
+                        })),
+                        Rule::op_gteq => Ok(Box::new(ast::Expr {
+                            kind: ast::ExprKind::Gte(ast::Gte { operands: vec![] }),
+                        })),
+
+                        _ => panic!("Unexpected infix operator [{:?}]", op_pair.as_str()),
+                    }
+                }
+                _ => todo!("Unhandled rule [{:?}]", rule),
+            }
+        })
+        .collect::<ParserResult<Vec<_>>>()?;
+
+    let len = parts.len();
+    let res = if len == 1 {
+        parts.pop().unwrap()
+    } else if len == 2 {
+        let (unary, expr) = (parts.pop().unwrap(), parts.pop().unwrap());
+        todo!()
+    } else if len == 3 {
+        let (lhs, operator, rhs) = (
+            parts.pop().unwrap(),
+            parts.pop().unwrap(),
+            parts.pop().unwrap(),
+        );
+        let new_operands = vec![lhs, rhs];
+        let mut op = *operator;
+        let new_op = if let ast::Expr { mut kind } = op {
+            match kind {
+                ast::ExprKind::And(ast::And { .. }) => ast::Expr {
+                    kind: ast::ExprKind::And(ast::And {
+                        operands: new_operands,
+                    }),
+                },
+                ast::ExprKind::Or(ast::Or { .. }) => ast::Expr {
+                    kind: ast::ExprKind::Or(ast::Or {
+                        operands: new_operands,
+                    }),
+                },
+                ast::ExprKind::Plus(ast::Plus { .. }) => ast::Expr {
+                    kind: ast::ExprKind::Plus(ast::Plus {
+                        operands: new_operands,
+                    }),
+                },
+                // TODO all other infix operators
+                ast::ExprKind::Eq(ast::Eq { .. }) => ast::Expr {
+                    kind: ast::ExprKind::Eq(ast::Eq {
+                        operands: new_operands,
+                    }),
+                },
+                _ => todo!("Unhandled operator kind [{:?}]", kind),
+            }
+        } else {
+            todo!("Unhandled operator [{:?}]", op)
+        };
+        Box::new(new_op)
+    } else {
+        todo!("Unexpected part of expr_query")
+    };
+
+    Ok(res)
+}
+
+pub(crate) fn build_expr_term(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    let pair = pairs.next().unwrap();
+
+    let rule = pair.as_rule();
+
+    match rule {
+        Rule::query => build_query(pair.into_inner()),
+        Rule::expr_function_call => build_expr_function_call(pair.into_inner()),
+        Rule::literal => build_literal(pair.into_inner()),
+        Rule::path_expr => build_path_expr(pair.into_inner()),
+        Rule::expr_tuple => {
+            let fields: Vec<ast::ExprPair> = pair
+                .into_inner()
+                .map(|pair| build_expr_query(pair.into_inner()))
+                .tuples::<(_, _)>()
+                .map(|(k, v)| {
+                    if let Ok(first) = k {
+                        if let Ok(second) = v {
+                            Ok(ast::ExprPair { first, second })
+                        } else {
+                            Err(v.unwrap_err())
+                        }
+                    } else {
+                        Err(k.unwrap_err())
+                    }
+                })
+                .collect::<ParserResult<Vec<_>>>()?;
+
+            Ok(Box::new(ast::Expr {
+                kind: ast::ExprKind::Struct(ast::Struct { fields }),
+            }))
+        }
+        Rule::expr_array => {
+            let values = pair
+                .into_inner()
+                .map(|pair| build_expr_query(pair.into_inner()))
+                .collect::<ParserResult<Vec<_>>>()?;
+            Ok(Box::new(ast::Expr {
+                kind: ast::ExprKind::List(ast::List { values }),
+            }))
+        }
+        Rule::expr_bag => {
+            let values = pair
+                .into_inner()
+                .map(|pair| build_expr_query(pair.into_inner()))
+                .collect::<ParserResult<Vec<_>>>()?;
+            Ok(Box::new(ast::Expr {
+                kind: ast::ExprKind::Bag(ast::Bag { values }),
+            }))
+        }
+        _ => todo!("Unhandled rule [{:?}]", rule),
+    }
+}
+
+pub(crate) fn build_expr_function_call(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    let pair = pairs.next().unwrap();
+
+    let func_name = ast::SymbolPrimitive {
+        value: pair.as_str().trim_matches('"').to_string(),
+    };
+
+    let args = pairs
+        .map(|pair| build_expr_query(pair.into_inner()))
+        .collect::<ParserResult<Vec<_>>>()?;
+
+    Ok(Box::new(ast::Expr {
+        kind: ast::ExprKind::Call(ast::Call { func_name, args }),
+    }))
+}
+
+pub(crate) fn build_path_expr(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    if let Some(pair) = pairs.next() {
+        let rule = pair.as_rule();
+
+        match rule {
+            Rule::identifier => {
+                let ident = ast::Expr {
+                    kind: ast::ExprKind::VarRef(ast::VarRef {
+                        name: ast::SymbolPrimitive {
+                            value: pair.as_str().trim_matches('"').to_string(),
+                        },
+                        case: ast::CaseSensitivity {
+                            kind: ast::CaseSensitivityKind::CaseInsensitive,
+                        },
+                        qualifier: ast::ScopeQualifier {
+                            kind: ast::ScopeQualifierKind::Unqualified,
+                        },
+                    }),
+                };
+                Ok(Box::new(ast::Expr {
+                    kind: ast::ExprKind::Path(ast::Path {
+                        root: Box::new(ident),
+                        steps: vec![],
+                    }),
+                }))
+            }
+            _ => todo!("Unhandled rule [{:?}]", rule),
+        }
+    } else {
+        let ident = ast::Expr {
+            kind: ast::ExprKind::VarRef(ast::VarRef {
+                name: ast::SymbolPrimitive {
+                    value: "*".to_string(),
+                },
+                case: ast::CaseSensitivity {
+                    kind: ast::CaseSensitivityKind::CaseInsensitive,
+                },
+                qualifier: ast::ScopeQualifier {
+                    kind: ast::ScopeQualifierKind::Unqualified,
+                },
+            }),
+        };
+        Ok(Box::new(ast::Expr {
+            kind: ast::ExprKind::Path(ast::Path {
+                root: Box::new(ident),
+                steps: vec![],
+            }),
+        }))
+    }
+}
+
+pub(crate) fn build_literal(mut pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr>> {
+    fn build_string(lit: Pair<Rule>) -> ast::Expr {
+        let litstr = lit.as_str();
+        ast::Expr {
+            kind: ast::ExprKind::Lit(ast::Lit {
+                kind: ast::LitKind::CharStringLit(ast::CharStringLit {
+                    value: litstr[1..litstr.len() - 1].to_string(),
+                }),
+            }),
+        }
+    }
+
+    let lit = pairs.next().unwrap();
+    let res = match lit.as_rule() {
+        Rule::literal_absent => {
+            if lit.as_str().to_lowercase() == "null" {
+                ast::Expr {
+                    kind: ast::ExprKind::Lit(ast::Lit {
+                        kind: ast::LitKind::Null,
+                    }),
+                }
+            } else {
+                ast::Expr {
+                    kind: ast::ExprKind::Lit(ast::Lit {
+                        kind: ast::LitKind::Missing,
+                    }),
+                }
+            }
+        }
+        Rule::literal_ion => todo!(),
+        Rule::literal_string => build_string(lit),
+        Rule::literal_bool => {
+            let value = lit.as_str().to_lowercase() == "true";
+            ast::Expr {
+                kind: ast::ExprKind::Lit(ast::Lit {
+                    kind: ast::LitKind::BoolLit(ast::BoolLit { value }),
+                }),
+            }
+        }
+        Rule::literal_real => {
+            let value = if let Ok(dec) = rust_decimal::Decimal::from_str(lit.as_str()) {
+                dec
+            } else if let Ok(dec) = rust_decimal::Decimal::from_scientific(lit.as_str()) {
+                dec
+            } else {
+                todo!()
+            };
+            ast::Expr {
+                kind: ast::ExprKind::Lit(ast::Lit {
+                    kind: ast::LitKind::NumericLit(ast::NumericLit {
+                        kind: ast::NumericLitKind::DecimalLit(ast::DecimalLit { value }),
+                    }),
+                }),
+            }
+        }
+        Rule::literal_int => {
+            let value: i64 = lit.as_str().parse().unwrap();
+            ast::Expr {
+                kind: ast::ExprKind::Lit(ast::Lit {
+                    kind: ast::LitKind::NumericLit(ast::NumericLit {
+                        kind: ast::NumericLitKind::Int64Lit(ast::Int64Lit { value }),
+                    }),
+                }),
+            }
+        }
+        Rule::literal_tuple => {
+            let fields: Vec<ast::ExprPair> = lit
+                .into_inner()
+                .map(|e| match e.as_rule() {
+                    Rule::literal_string => Ok(Box::new(build_string(e))),
+                    _ => build_literal(e.into_inner()),
+                })
+                .tuples::<(_, _)>()
+                .map(|(k, v)| {
+                    if let Ok(first) = k {
+                        if let Ok(second) = v {
+                            Ok(ast::ExprPair { first, second })
+                        } else {
+                            Err(v.unwrap_err())
+                        }
+                    } else {
+                        Err(k.unwrap_err())
+                    }
+                })
+                .collect::<ParserResult<Vec<_>>>()?;
+
+            ast::Expr {
+                kind: ast::ExprKind::Struct(ast::Struct { fields }),
+            }
+        }
+        Rule::literal_array => {
+            let values = lit
+                .into_inner()
+                .map(|pair| build_literal(pair.into_inner()))
+                .collect::<ParserResult<Vec<_>>>()?;
+            ast::Expr {
+                kind: ast::ExprKind::List(ast::List { values }),
+            }
+        }
+        Rule::literal_bag => {
+            let values = lit
+                .into_inner()
+                .map(|pair| build_literal(pair.into_inner()))
+                .collect::<ParserResult<Vec<_>>>()?;
+            ast::Expr {
+                kind: ast::ExprKind::Bag(ast::Bag { values }),
+            }
+        }
+        _ => panic!("Unexpected rule [{:?}]", lit.as_rule()),
+    };
+
+    Ok(Box::new(res))
+}

--- a/partiql-parser/src/peg/ast_builder.rs
+++ b/partiql-parser/src/peg/ast_builder.rs
@@ -3,9 +3,7 @@ use crate::prelude::ParserError;
 use crate::result::ParserResult;
 use itertools::Itertools;
 use partiql_ast::experimental::ast;
-use partiql_ast::experimental::ast::{
-    FromClause, FromClauseKind, JoinKind, JoinSpec,
-};
+use partiql_ast::experimental::ast::{FromClause, FromClauseKind, JoinKind, JoinSpec};
 use pest::iterators::{Pair, Pairs};
 use std::str::FromStr;
 
@@ -100,8 +98,8 @@ pub(crate) fn build_group_by_clause(pairs: Pairs<Rule>) -> ParserResult<Box<ast:
     let key_list = ast::GroupKeyList { keys };
 
     let group_as_alias = parts.pop().map(|pair| ast::SymbolPrimitive {
-            value: pair.as_str().trim_matches('"').to_string(),
-        });
+        value: pair.as_str().trim_matches('"').to_string(),
+    });
 
     Ok(Box::new(ast::GroupByExpr {
         strategy,

--- a/partiql-parser/src/peg/grammar.rs
+++ b/partiql-parser/src/peg/grammar.rs
@@ -1,4 +1,3 @@
-
 use pest_derive::Parser;
 
 #[derive(Parser)]

--- a/partiql-parser/src/peg/grammar.rs
+++ b/partiql-parser/src/peg/grammar.rs
@@ -1,0 +1,6 @@
+use pest::Parser;
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar = "peg/partiql.pest"]
+pub(crate) struct PartiQLParser;

--- a/partiql-parser/src/peg/grammar.rs
+++ b/partiql-parser/src/peg/grammar.rs
@@ -1,4 +1,4 @@
-use pest::Parser;
+
 use pest_derive::Parser;
 
 #[derive(Parser)]

--- a/partiql-parser/src/peg/mod.rs
+++ b/partiql-parser/src/peg/mod.rs
@@ -12,17 +12,18 @@
 //! ```
 //!
 //! [partiql]: https://partiql.org
-
+//!
 use pest::iterators::Pairs;
+use pest::Parser;
 
 use crate::result::ParserResult;
 
-use pest::Parser;
-use pest_derive::Parser;
+mod ast_builder;
+mod grammar;
 
-#[derive(Parser)]
-#[grammar = "peg/partiql.pest"]
-pub(crate) struct PartiQLParser;
+pub(crate) use crate::peg::ast_builder::{build_literal, build_query};
+pub(crate) use crate::peg::grammar::{PartiQLParser, Rule};
+use partiql_ast::experimental::ast;
 
 /// Parser for PartiQL queries.
 ///
@@ -32,6 +33,10 @@ pub fn parse_partiql(input: &str) -> ParserResult<Pairs<Rule>> {
     Ok(PartiQLParser::parse(Rule::query_full, input)?)
 }
 
+pub fn parse_partiql_to_ast(input: &str) -> ParserResult<Box<ast::Expr>> {
+    build_query(parse_partiql(input)?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -39,6 +44,16 @@ mod tests {
     macro_rules! parse {
         ($q:expr) => {{
             let res = parse_partiql($q);
+            println!("{:#?}", res);
+            match res {
+                Ok(_) => (),
+                _ => assert!(false, "{:?}", res),
+            }
+        }};
+    }
+    macro_rules! parse_to_ast {
+        ($q:expr) => {{
+            let res = build_query(parse_partiql($q).expect("parse"));
             println!("{:#?}", res);
             match res {
                 Ok(_) => (),
@@ -64,6 +79,7 @@ mod tests {
             ($q:expr) => {{
                 literal!($q);
                 parse!($q);
+                parse_to_ast!($q);
             }};
         }
 
@@ -134,6 +150,7 @@ mod tests {
             ($q:expr) => {{
                 value!($q);
                 parse!($q);
+                parse_to_ast!($q);
             }};
         }
         #[test]
@@ -163,95 +180,111 @@ mod tests {
     mod expr {
         use super::*;
 
+        macro_rules! parse_and_ast {
+            ($q:expr) => {{
+                parse!($q);
+                parse_to_ast!($q);
+            }};
+        }
+
         #[test]
         fn or_simple() {
-            parse!(r#"TRUE OR FALSE"#)
+            parse_and_ast!(r#"TRUE OR FALSE"#)
         }
 
         #[test]
         fn or() {
-            parse!(r#"t1.super OR test(t2.name, t1.name)"#)
+            parse_and_ast!(r#"t1.super OR test(t2.name, t1.name)"#)
         }
 
         #[test]
         fn and_simple() {
-            parse!(r#"TRUE and FALSE"#)
+            parse_and_ast!(r#"TRUE and FALSE"#)
         }
 
         #[test]
         fn and() {
-            parse!(r#"test(t2.name, t1.name) AND t1.id = t2.id"#)
+            parse_and_ast!(r#"test(t2.name, t1.name) AND t1.id = t2.id"#)
         }
 
         #[test]
         fn or_and() {
-            parse!(r#"t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#)
+            parse_and_ast!(r#"t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#)
         }
     }
 
     mod sfw {
         use super::*;
 
+        macro_rules! parse_and_ast {
+            ($q:expr) => {{
+                parse!($q);
+                parse_to_ast!($q);
+            }};
+        }
+
         #[test]
         fn select1() {
-            parse!("SELECT g")
+            parse_and_ast!("SELECT g")
         }
 
         #[test]
         fn select_list() {
-            parse!("SELECT g, k as ck, h")
+            parse_and_ast!("SELECT g, k as ck, h")
         }
 
         #[test]
         fn fun_call() {
-            parse!(r#"fun_call('bar', 1,2,3,4,5,'foo')"#)
+            parse_and_ast!(r#"fun_call('bar', 1,2,3,4,5,'foo')"#)
         }
 
         #[test]
         fn select3() {
-            parse!("SELECT g, k, function('2') as fn_result")
+            parse_and_ast!("SELECT g, k, function('2') as fn_result")
         }
 
         #[test]
         fn group() {
-            parse!("SELECTg FROM data GROUP BY a")
+            parse_and_ast!("SELECTg FROM data GROUP BY a")
         }
 
         #[test]
         fn group_complex() {
-            parse!("SELECT g FROM data GROUP BY a AS x, b + c AS y, foo(d) AS z GROUP AS g")
+            parse_and_ast!("SELECT g FROM data GROUP BY a AS x, b + c AS y, foo(d) AS z GROUP AS g")
         }
 
         #[test]
         fn order_by() {
-            parse!(r#"SELECT a FROM tb ORDER BY PRESERVE"#);
-            parse!(r#"SELECT a FROM tb ORDER BY rk1"#);
-            parse!(r#"SELECT a FROM tb ORDER BY rk1 ASC, rk2 DESC"#);
+            parse_and_ast!(r#"SELECT a FROM tb ORDER BY PRESERVE"#);
+            parse_and_ast!(r#"SELECT a FROM tb ORDER BY rk1"#);
+            parse_and_ast!(r#"SELECT a FROM tb ORDER BY rk1 ASC, rk2 DESC"#);
         }
 
         #[test]
         fn where_simple() {
-            parse!(r#"SELECT a FROM tb WHERE hk = 1"#)
+            parse_and_ast!(r#"SELECT a FROM tb WHERE hk = 1"#)
         }
 
         #[test]
         fn where_boolean() {
-            parse!(r#"SELECT a FROM tb WHERE t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#)
+            parse_and_ast!(
+                r#"SELECT a FROM tb WHERE t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#
+            )
         }
 
         #[test]
         fn limit() {
-            parse!(r#"SELECT * FROM a LIMIT 10"#)
+            parse_and_ast!(r#"SELECT * FROM a LIMIT 10"#)
         }
 
         #[test]
         fn offset() {
-            parse!(r#"SELECT * FROM a OFFSET 10"#)
+            parse_and_ast!(r#"SELECT * FROM a OFFSET 10"#)
         }
 
         #[test]
         fn limit_offset() {
-            parse!(r#"SELECT * FROM a LIMIT 10 OFFSET 2"#)
+            parse_and_ast!(r#"SELECT * FROM a LIMIT 10 OFFSET 2"#)
         }
 
         #[test]
@@ -268,58 +301,7 @@ mod tests {
             )
             AS deltas FROM SOURCE_VIEW_DELTA_FULL_TRANSACTIONS delta_full_transactions
             "#;
-            parse!(q)
+            parse_and_ast!(q)
         }
     }
-    /*
-    #[rstest]
-
-    #[case::select_value(
-    r#"SELECT VALUE 5"#,
-    Ok(())
-    )]
-    #[case::select_value_from(
-    r#"SELECT VALUE 5 FROM some_table"#,
-    Ok(())
-    )]
-    #[case::select_value_from_where(
-    r#"SELECT VALUE 5 FROM some_table WHERE TRUE"#,
-    Ok(())
-    )]
-    #[case::select_value_from_where_containers(
-    r#"select Value {'age': 6, 'ice_cream': "🍦"} fRoM <<'🚽'>> WHERE is_amazing"#,
-    Ok(())
-    )]
-    #[case::bad_identifier(
-    r#"SELECT value aWeSoMe FROM 💩"#,
-    syntax_error("IGNORED MESSAGE", Position::at(1, 27))
-    )]
-    #[case::missing_from_with_where(
-    r#"SELECT value aWeSoMe WHERE FALSE"#,
-    syntax_error("IGNORED MESSAGE", Position::at(1, 22))
-    )]
-    fn recognize(#[case] input: &str, #[case] expected: ParserResult<()>) -> ParserResult<()> {
-        let actual = recognize_partiql(input);
-        match (expected, actual) {
-            (
-                Err(ParserError::SyntaxError {
-                        position: expected_position,
-                        ..
-                    }),
-                Err(ParserError::SyntaxError {
-                        position: actual_position,
-                        ..
-                    }),
-            ) => {
-                // just compare the positions for syntax errors...
-                assert_eq!(expected_position, actual_position)
-            }
-            (expected, actual) => {
-                assert_eq!(expected, actual);
-            }
-        }
-        Ok(())
-    }
-
-     */
 }

--- a/partiql-parser/src/peg/mod.rs
+++ b/partiql-parser/src/peg/mod.rs
@@ -21,7 +21,7 @@ use crate::result::ParserResult;
 mod ast_builder;
 mod grammar;
 
-pub(crate) use crate::peg::ast_builder::{build_query};
+pub(crate) use crate::peg::ast_builder::build_query;
 pub(crate) use crate::peg::grammar::{PartiQLParser, Rule};
 use partiql_ast::experimental::ast;
 

--- a/partiql-parser/src/peg/mod.rs
+++ b/partiql-parser/src/peg/mod.rs
@@ -21,7 +21,7 @@ use crate::result::ParserResult;
 mod ast_builder;
 mod grammar;
 
-pub(crate) use crate::peg::ast_builder::{build_literal, build_query};
+pub(crate) use crate::peg::ast_builder::{build_query};
 pub(crate) use crate::peg::grammar::{PartiQLParser, Rule};
 use partiql_ast::experimental::ast;
 

--- a/partiql-parser/src/peg/partiql.pest
+++ b/partiql-parser/src/peg/partiql.pest
@@ -71,18 +71,21 @@ out_binding = { expr_query ~ (K_as ~ attr_name)? }
 // ------------------------------------------------------------------------------ //
 from_clause = { K_from ~ table_references }
 table_references = _{ table_reference ~ ("," ~ K_lateral? ~ table_reference )* }
-table_reference = { table_joined | table_unpivot | table_base_reference }
-table_unpivot = { K_unpivot ~ table_base_reference }
+table_reference = _{ table_joined | table_unpivot | table_base_reference }
+table_unpivot = { K_unpivot ~ expr_query ~ K_as? ~ correlation_name ~ K_at ~ correlation_name }
 table_base_reference = { expr_query ~ ( correlation_spec )? }
 
-correlation_spec = { K_as? ~ correlation_name ~ ( K_at ~ correlation_name )? }
-correlation_name = { !(reserved_join) ~ !(reserved_clause) ~ identifier }
+correlation_spec = _{ K_as? ~ correlation_name }
+correlation_name = _{ !(reserved_join) ~ !(reserved_clause) ~ identifier }
 
 table_joined = { table_cross_join | table_qualified_join | "(" ~ table_joined ~ ")" }
 table_cross_join = { table_base_reference ~ K_cross ~ K_join ~ K_lateral? ~ table_reference }
-table_qualified_join = {
+table_qualified_join = _{ table_natural_join | table_join_spec }
+table_natural_join = {
+      table_base_reference ~ K_natural ~ join_type? ~ K_join ~ K_lateral? ~ table_reference
+}
+table_join_spec = {
       table_base_reference ~ join_type? ~ K_join ~ K_lateral? ~ table_reference ~ join_spec
-    | table_base_reference ~ K_natural ~ join_type? ~ K_join ~ K_lateral? ~ table_reference
 }
 join_type = { K_inner | (join_outer_type ~ K_outer?) }
 join_outer_type = { K_left | K_right | K_full }
@@ -100,13 +103,16 @@ where_clause = { K_where ~ search_condition }
 // ------------------------------------------------------------------------------ //
 //                                   GROUP BY                                     //
 // ------------------------------------------------------------------------------ //
-group_by_clause = { K_group ~ (K_all)? ~ K_by ~ out_bindings ~ (K_group ~ K_as ~ attr_name)? }
+group_by_clause = { K_group ~ group_all? ~ K_by ~ group_out_bindings ~ group_as? }
+group_out_bindings = { out_bindings }
+group_all = {K_all}
+group_as = {K_group ~ K_as ~ attr_name}
 
 // ------------------------------------------------------------------------------ //
 //                                    HAVING                                      //
 // ------------------------------------------------------------------------------ //
 having_clause = { K_having ~ search_condition }
-search_condition = { expr_query }
+search_condition = _{ expr_query }
 
 // ------------------------------------------------------------------------------ //
 //                            UNION/INTERSECT/EXCEPT                              //
@@ -119,7 +125,7 @@ set_op_clause = { "TODO" }
 order_by_clause = { K_order ~ K_by ~ ( order_sort_preserve | order_sort_spec_list ) }
 order_sort_preserve = { K_preserve }
 order_sort_spec_list = { order_sort_spec ~ ("," ~ order_sort_spec )* }
-order_sort_spec = { identifier ~ order_by_spec? ~ order_by_null_spec? }
+order_sort_spec = { expr_query ~ order_by_spec? ~ order_by_null_spec? }
 order_by_spec = { K_asc | K_desc }
 order_by_null_spec = { K_nulls ~ (K_first | K_last) }
 
@@ -175,7 +181,7 @@ path_expr_list = { path_expr ~ ("," ~ path_expr )*}
 
 expr_function_call = { function_name ~ "(" ~ expr_function_args ~ ")" }
 expr_function_args = _{ expr_function_arg ~ ("," ~ expr_function_arg )*  }
-expr_function_arg  = { expr_query }
+expr_function_arg  = _{ expr_query }
 
 // Operators
 op_infix = { op_caret | op_math | op_comp }
@@ -214,8 +220,8 @@ op_gteq     = { ">=" }
 //
 // TODO
 //
-attr_name = { identifier }
-function_name = { identifier }
+attr_name = _{ identifier }
+function_name = _{ identifier }
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //


### PR DESCRIPTION
#58 

### Add prototype for converting Pest's `Pairs` to AST

This prototypes AST creation from the PEG grammar. 

The code is not particularly well documented, nor is it comprehensive of the grammar/AST. Rather this is basically the minimal amount of AST building necessary to pass the existing set of parser tests. 

The intent is to be able to assess the general readability/complexity of parsing from text to AST in order to compare the LALRPOP vs PEG approaches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
