### PR TITLE
Remove ast clippy warnings

### DIFF
--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -588,7 +588,7 @@ pub struct Call {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CallAgg {
     pub func_name: SymbolPrimitive,
-    args: Vec<Expr>,
+    pub args: Vec<Box<Expr>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -70,7 +70,7 @@ pub struct DropTable {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CreateIndex {
     pub index_name: Ident,
-    pub fields: Vec<Expr>,
+    pub fields: Vec<Box<Expr>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -89,7 +89,7 @@ pub struct Dml {
 pub struct DmlOp {
     pub kind: DmlOpKind,
     pub from_clause: Option<FromClause>,
-    pub where_clause: Option<Expr>,
+    pub where_clause: Option<Box<Expr>>,
     pub returning: Option<ReturningExpr>,
 }
 
@@ -109,15 +109,15 @@ pub enum DmlOpKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Insert {
-    pub target: Expr,
-    pub values: Expr,
+    pub target: Box<Expr>,
+    pub values: Box<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct InsertValue {
-    pub target: Expr,
-    pub value: Expr,
-    pub index: Option<Expr>,
+    pub target: Box<Expr>,
+    pub value: Box<Expr>,
+    pub index: Option<Box<Expr>>,
     pub on_conflict: Option<OnConflict>,
 }
 
@@ -128,13 +128,13 @@ pub struct Set {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Remove {
-    pub target: Expr,
+    pub target: Box<Expr>,
 }
 
 /// `ON CONFLICT <expr> <conflict_action>`
 #[derive(Clone, Debug, PartialEq)]
 pub struct OnConflict {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
     pub conflict_action: ConflictAction,
 }
 
@@ -152,7 +152,7 @@ pub enum ConflictActionKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Query {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -588,7 +588,7 @@ pub struct Call {
 #[derive(Clone, Debug, PartialEq)]
 pub struct CallAgg {
     pub func_name: SymbolPrimitive,
-    args: Vec<Box<Expr>>,
+    args: Vec<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -660,7 +660,7 @@ pub enum PathStepKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PathExpr {
-    pub index: Expr,
+    pub index: Box<Expr>,
     pub case: CaseSensitivity,
 }
 
@@ -722,12 +722,12 @@ pub enum ProjectItemKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProjectAll {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ProjectExpr {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
     pub as_alias: Option<SymbolPrimitive>,
 }
 
@@ -739,7 +739,7 @@ pub struct Let {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct LetBinding {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
     pub name: SymbolPrimitive,
 }
 
@@ -843,7 +843,7 @@ pub struct GroupKeyList {
 /// <expr> [AS <symbol>]
 #[derive(Clone, Debug, PartialEq)]
 pub struct GroupKey {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
     pub as_alias: Option<SymbolPrimitive>,
 }
 
@@ -936,7 +936,7 @@ pub enum ColumnComponentKind {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ReturningColumn {
-    pub expr: Expr,
+    pub expr: Box<Expr>,
 }
 
 /// ( MODIFIED | ALL ) ( NEW | OLD )
@@ -973,8 +973,8 @@ pub struct Ident {
 /// an assignment operation and *not* the equality operator.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Assignment {
-    pub target: Expr,
-    pub value: Expr,
+    pub target: Box<Expr>,
+    pub value: Box<Expr>,
 }
 
 /// Represents all possible PartiQL data types.

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -14,7 +14,7 @@ fn test_ast_init() {
                         kind: NumericLitKind::Int32Lit(Int32Lit { value: 12 }),
                     }),
                 }),
-            })
+            }),
         }),
     };
 

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -8,13 +8,13 @@ fn test_ast_init() {
 
     let _i = Item {
         kind: ItemKind::Query(Query {
-            expr: Expr {
+            expr: Box::new(Expr {
                 kind: ExprKind::Lit(Lit {
                     kind: LitKind::NumericLit(NumericLit {
                         kind: NumericLitKind::Int32Lit(Int32Lit { value: 12 }),
                     }),
                 }),
-            },
+            })
         }),
     };
 

--- a/partiql-parser/src/lalr/partiql.lalrpop
+++ b/partiql-parser/src/lalr/partiql.lalrpop
@@ -100,10 +100,10 @@ SelectClause: ast::Projection = {
 
 Projection: ast::ProjectItem = {
     <expr:ExprQuery>
-        => ast::ProjectItem{ kind: ast::ProjectItemKind::ProjectExpr( ast::ProjectExpr{ expr: *expr, as_alias: None } ) },
+        => ast::ProjectItem{ kind: ast::ProjectItemKind::ProjectExpr( ast::ProjectExpr{ expr, as_alias: None } ) },
     <expr:ExprQuery> "AS" <ident:"Identifier"> => {
         let as_alias = Some( ast::SymbolPrimitive{ value:ident} );
-        ast::ProjectItem{ kind: ast::ProjectItemKind::ProjectExpr( ast::ProjectExpr{ expr: *expr, as_alias } ) }
+        ast::ProjectItem{ kind: ast::ProjectItemKind::ProjectExpr( ast::ProjectExpr{ expr, as_alias } ) }
     },
 
 }
@@ -260,9 +260,9 @@ GroupStrategy: ast::GroupingStrategy = {
 }
 GroupKey: ast::GroupKey = {
     <expr:ExprQuery>
-        => ast::GroupKey{ expr: *expr, as_alias: None },
+        => ast::GroupKey{ expr, as_alias: None },
     <expr:ExprQuery> "AS" <ident:"Identifier">
-        => ast::GroupKey{ expr: *expr, as_alias: Some( ast::SymbolPrimitive{ value:ident} ) },
+        => ast::GroupKey{ expr, as_alias: Some( ast::SymbolPrimitive{ value:ident} ) },
 }
 #[inline]
 GroupAlias: ast::SymbolPrimitive = {
@@ -504,7 +504,7 @@ PathExpr: ast::Path = {
         let step = ast::PathStep{
             kind: ast::PathStepKind::PathExpr(
                 ast::PathExpr{
-                    index: ast::Expr{ kind: ast::ExprKind::VarRef( var_ref(ident, false, false) ) },
+                    index: Box::new(ast::Expr{ kind: ast::ExprKind::VarRef( var_ref(ident, false, false) ) }),
                     case: ast::CaseSensitivity{ kind: ast::CaseSensitivityKind::CaseInsensitive }
                 }
             )

--- a/partiql-parser/src/peg/ast_builder.rs
+++ b/partiql-parser/src/peg/ast_builder.rs
@@ -89,10 +89,7 @@ pub(crate) fn build_group_by_clause(pairs: Pairs<Rule>) -> ParserResult<Box<ast:
             let as_alias = parts.next().map(|pair| ast::SymbolPrimitive {
                 value: pair.as_str().trim_matches('"').to_string(),
             });
-            expr.map(|expr| ast::GroupKey {
-                expr,
-                as_alias,
-            })
+            expr.map(|expr| ast::GroupKey { expr, as_alias })
         })
         .collect::<ParserResult<Vec<_>>>()?;
     let key_list = ast::GroupKeyList { keys };

--- a/partiql-parser/src/peg/ast_builder.rs
+++ b/partiql-parser/src/peg/ast_builder.rs
@@ -90,7 +90,7 @@ pub(crate) fn build_group_by_clause(pairs: Pairs<Rule>) -> ParserResult<Box<ast:
                 value: pair.as_str().trim_matches('"').to_string(),
             });
             expr.map(|expr| ast::GroupKey {
-                expr: *expr,
+                expr,
                 as_alias,
             })
         })
@@ -197,7 +197,7 @@ pub(crate) fn build_select_clause(mut pairs: Pairs<Rule>) -> ParserResult<ast::P
                         });
                         expr.map(|expr| ast::ProjectItem {
                             kind: ast::ProjectItemKind::ProjectExpr(ast::ProjectExpr {
-                                expr: *expr,
+                                expr,
                                 as_alias,
                             }),
                         })


### PR DESCRIPTION
*Issue #, if available:* 62

*Description of changes:*

PR Issue: https://github.com/partiql/partiql-lang-rust/issues/63

Considered two approaches:
1. Apply the changes as recommended by clippy
2. Box Exprs to reduce the overall size.

This PR applies the second approach.

Benchmark results:
$ cargo bench
...
Gnuplot not found, using plotters backend
peg-simple              time:   [2.2424 us 2.2828 us 2.3286 us]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

peg-ion                 time:   [12.924 us 13.084 us 13.269 us]
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

peg-group               time:   [29.023 us 29.692 us 30.459 us]
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

peg-complex             time:   [979.09 us 985.52 us 993.10 us]
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe

peg-ast-simple          time:   [3.1068 us 3.1730 us 3.2435 us]
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe

peg-ast-ion             time:   [13.263 us 13.530 us 13.782 us]
Found 13 outliers among 100 measurements (13.00%)
  12 (12.00%) high mild
  1 (1.00%) high severe

peg-ast-group           time:   [35.045 us 35.837 us 36.714 us]
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) high mild
  12 (12.00%) high severe

peg-ast-complex         time:   [989.52 us 998.31 us 1.0089 ms]
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) high mild
  12 (12.00%) high severe

logos-simple            time:   [31.314 ns 31.812 ns 32.430 ns]
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

logos-ion               time:   [275.96 ns 277.70 ns 279.59 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

logos-group             time:   [977.72 ns 998.78 ns 1.0209 us]
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

logos-complex           time:   [2.8933 us 2.9764 us 3.0694 us]

lalr-simple             time:   [561.62 ns 567.40 ns 574.27 ns]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe

lalr-ion                time:   [3.0657 us 3.1270 us 3.1918 us]

lalr-group              time:   [10.222 us 10.302 us 10.400 us]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

lalr-complex            time:   [21.932 us 22.234 us 22.591 us]
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
