### PR TITLE
Model UNPIVOT correctly in grammar.

### DIFF
--- a/partiql-parser/src/lalr/mod.rs
+++ b/partiql-parser/src/lalr/mod.rs
@@ -212,6 +212,7 @@ mod tests {
 
     mod sfw {
         use super::*;
+        use crate::lalr::lexer::Token;
 
         #[test]
         fn selectstar() {
@@ -295,6 +296,20 @@ mod tests {
             AS deltas FROM SOURCE_VIEW_DELTA_FULL_TRANSACTIONS delta_full_transactions
             "#;
             parse!(q)
+        }
+
+        #[test]
+        fn improper_at() {
+            let res = parse_partiql(r#"SELECT * FROM a AS a AT b"#);
+            assert!(res.is_err());
+            let error = res.unwrap_err();
+            assert!(matches!(
+                error,
+                lalrpop_util::ParseError::UnrecognizedToken {
+                    token: (21, Token::At, 23),
+                    ..
+                }
+            ));
         }
     }
 }

--- a/partiql-parser/src/lalr/partiql.lalrpop
+++ b/partiql-parser/src/lalr/partiql.lalrpop
@@ -155,23 +155,21 @@ TableBaseReference: ast::FromLet = {
             at_alias: None,
             by_alias: None
         }
-    },
-    <e:ExprQuery> "AS"? <ident_as:"Identifier"> "AT" <ident_at:"Identifier"> => {
-        ast::FromLet {
-            expr: e,
-            kind: ast::FromLetKind::Scan,
-            as_alias: Some(ast::SymbolPrimitive{ value: ident_as }),
-            at_alias: Some(ast::SymbolPrimitive{ value: ident_at }),
-            by_alias: None
-        }
     }
 }
 
 TableUnpivot: ast::FromLet = {
-    "UNPIVOT" <table:TableBaseReference> => {
-        ast::FromLet{ kind: ast::FromLetKind::Unpivot, ..table }
+    "UNPIVOT" <e:ExprQuery> "AS"? <ident_as:"Identifier"> "AT" <ident_at:"Identifier"> => {
+        ast::FromLet {
+            expr: e,
+            kind: ast::FromLetKind::Unpivot,
+            as_alias: Some(ast::SymbolPrimitive{ value: ident_as }),
+            at_alias: Some(ast::SymbolPrimitive{ value: ident_at }),
+            by_alias: None,
+        }
     }
 }
+
 TableJoined: ast::FromClause = {
     <TableCrossJoin>,
     <TableQualifiedJoin>,


### PR DESCRIPTION
#58

`AT` is only allowed in an `UNPIVOT`  From clause.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
