### PR TITLE
Add Display formatting to Item

### DIFF
--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -10,8 +10,8 @@
 // https://github.com/partiql/partiql-lang-kotlin/blob/4bcfc7f73d3e6e54286bcc03a54d5f6425eec4cc/lang/resources/org/partiql/type-domains/partiql.ion
 
 // TODO Add documentation.
-// TODO Add Display formatting.
 
+use std::fmt;
 use rust_decimal::Decimal as RustDecimal;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -21,6 +21,13 @@ pub struct Item {
     // Candidate additional fields are `name: Ident`, `span: Span`, `attr: Vec<Attribute>`.
     // Also targeting on spinning up a parallel discussion with regards to AST versioning
     // and how it contributes to backward compatibility.
+}
+
+impl fmt::Display for Item {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Use Debug formatting for now
+        write!(f, "{:?}", self.kind)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -24,7 +24,7 @@ pub struct Item {
 }
 
 impl fmt::Display for Item {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Use Debug formatting for now
         write!(f, "{:?}", self.kind)
     }

--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -11,8 +11,8 @@
 
 // TODO Add documentation.
 
-use std::fmt;
 use rust_decimal::Decimal as RustDecimal;
+use std::fmt;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Item {


### PR DESCRIPTION
*Issue #, if available:* #60

*Description of changes:*

This change adds a Display formatting to the `Item` and re-uses Debug
formatting for now.

Example:
```bash
Query(Query { expr: Expr { kind: Lit(Lit { kind: NumericLit(NumericLit { kind: Int32Lit(Int32Lit { value: 12 }) }) }) } })
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
