### PR TITLE
Update all crates to edition = "2021"

### DIFF
--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/partiql-irgen/Cargo.toml
+++ b/partiql-irgen/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/partiql-rewriter/Cargo.toml
+++ b/partiql-rewriter/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pest-ion/Cargo.toml
+++ b/pest-ion/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2018"
+edition = "2021"
 version = "0.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Fixes #69 

Updates all crates to `edition = "2021"`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
