### PR TITLE
Add clippy

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -48,7 +48,7 @@ jobs:
           args: --verbose -- --check
       # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
       # permissions, the behavior of the Action is different depending on the source of the PR. If the
-      # PR comes from the ion-rust project itself, any suggestions will be added to the PR as comments.
+      # PR comes from the partiql-lang-rust project itself, any suggestions will be added to the PR as comments.
       # If the PR comes from a fork, any suggestions will be added to the Action's STDOUT for review.
       # For details, see: https://github.com/actions-rs/clippy-check/issues/2
       - name: Install Clippy

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -46,4 +46,21 @@ jobs:
         with:
           command: fmt
           args: --verbose -- --check
-
+      # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
+      # permissions, the behavior of the Action is different depending on the source of the PR. If the
+      # PR comes from the ion-rust project itself, any suggestions will be added to the PR as comments.
+      # If the PR comes from a fork, any suggestions will be added to the Action's STDOUT for review.
+      # For details, see: https://github.com/actions-rs/clippy-check/issues/2
+      - name: Install Clippy
+        # The clippy check depends on setup steps defined above, but we don't want it to run
+        # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
+        # only running on the Linux test. (The choice of OS was arbitrary.)
+        if: matrix.os == 'ubuntu-latest'
+        run: rustup component add clippy
+      - name: Run Clippy
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/clippy-check@v1
+        with:
+          # Adding comments to the PR requires the GITHUB_TOKEN secret.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/partiql-parser/src/peg/ast_builder.rs
+++ b/partiql-parser/src/peg/ast_builder.rs
@@ -492,8 +492,8 @@ pub(crate) fn build_expr_query(pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr
             parts.pop().unwrap(),
         );
         let new_operands = vec![lhs, rhs];
-        let op = *operator;
-        let new_op = if let ast::Expr { kind } = op {
+        let ast::Expr { kind } = *operator;
+        let new_op = {
             match kind {
                 ast::ExprKind::And(ast::And { .. }) => ast::Expr {
                     kind: ast::ExprKind::And(ast::And {
@@ -518,8 +518,6 @@ pub(crate) fn build_expr_query(pairs: Pairs<Rule>) -> ParserResult<Box<ast::Expr
                 },
                 _ => todo!("Unhandled operator kind [{:?}]", kind),
             }
-        } else {
-            todo!("Unhandled operator [{:?}]", op)
         };
         Box::new(new_op)
     } else {


### PR DESCRIPTION
*Issue #, if available:* 66

*Description of changes:*

- Adds Clippy GitHub Actions step
- Resolves irrefutable _if let_ pattern clippy warnings

We have the following remaining warnings. For _lex_partiql_ we'll resolve the warning once we're final with our _lexer_ impl. when finalizing M1.

```bash
warning: use of deprecated function `lalr::lex_partiql`: prototypical lexer implementation
  --> partiql-parser/src/lib.rs:17:15
   |
17 | pub use lalr::lex_partiql as logos_lex;
   |               ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `lalr::lex_partiql`: prototypical lexer implementation
  --> partiql-parser/src/lalr/mod.rs:35:17
   |
35 |     let lexer = lex_partiql(s);
   |                 ^^^^^^^^^^^

warning: associated function is never used: `at`
  --> partiql-parser/src/result.rs:26:19
   |
26 |     pub(crate) fn at(line: usize, column: usize) -> Self {
   |                   ^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: `partiql-parser` (lib) generated 3 warnings
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
