### PR TITLE
Cleanup the Parser API and add some documentation

### DIFF
--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -27,5 +27,4 @@ derive_builder = "~0.11.1"
 rust_decimal = "~1.22.0"
 
 [dev-dependencies]
-rstest = "~0.12.0"
 

--- a/partiql-ast/src/experimental/ast.rs
+++ b/partiql-ast/src/experimental/ast.rs
@@ -1,5 +1,5 @@
 //! An experimental PartiQL abstract syntax tree (AST) module, see the following for motivation:
-//! https://github.com/partiql/partiql-lang-rust/issues/52
+//! <https://github.com/partiql/partiql-lang-rust/issues/52>
 //!
 //! This module contains the structures for the language AST.
 //! Two main entities in the module are [`Item`] and [`ItemKind`]. `Item` represents an AST element
@@ -46,11 +46,13 @@ pub trait ToAstNode {
 }
 
 /// Implements [ToAstNode] for all types within this crate, read further [here][1].
+///
 /// [1]: https://doc.rust-lang.org/book/ch10-02-traits.html#using-trait-bounds-to-conditionally-implement-methods
 impl<T> ToAstNode for T {}
 
 /// Represents an AST node. [AstNode] uses [derive_builder][1] to expose a Builder
 /// for creating the node. See [ToAstNode] for more details on the usage.
+///
 /// [1]: https://crates.io/crates/derive_builder
 #[derive(Builder, Clone, Eq, PartialEq, Debug)]
 pub struct AstNode<T> {
@@ -258,9 +260,9 @@ pub enum ExprKind {
 
 /// `Lit` is mostly inspired by SQL-92 Literals standard and PartiQL specification.
 /// See section 5.3 in the following:
-/// https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt
+/// <https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt>
 /// and Section 2 of the following (Figure 1: BNF Grammar for PartiQL Values):
-/// https://partiql.org/assets/PartiQL-Specification.pdf
+/// <https://partiql.org/assets/PartiQL-Specification.pdf>
 #[derive(Clone, Debug, PartialEq)]
 pub enum Lit {
     Null,
@@ -582,7 +584,7 @@ pub struct LetBinding {
 #[derive(Clone, Debug, PartialEq)]
 pub enum FromClause {
     FromLet(FromLet),
-    /// <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
+    /// <from_source> JOIN \[INNER | LEFT | RIGHT | FULL\] <from_source> ON <expr>
     Join(Join),
 }
 
@@ -643,7 +645,7 @@ pub struct ExprPairList {
     pub pairs: Vec<ExprPair>,
 }
 
-/// GROUP BY <grouping_strategy> <group_key_list>... [AS <symbol>]
+/// GROUP BY <grouping_strategy> <group_key_list>... \[AS <symbol>\]
 #[derive(Clone, Debug, PartialEq)]
 pub struct GroupByExpr {
     pub strategy: GroupingStrategy,

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -1,3 +1,9 @@
+//! The PartiQL Abstract Syntax Tree (AST).
+//!
+//! # Note
+//!
+//! This API is currently unstable and subject to change.
+
 pub mod experimental {
     pub mod ast;
 }

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -38,7 +38,6 @@ logos = "~0.12.0"
 itertools = "~0.10.3"
 
 [dev-dependencies]
-rstest = "~0.9.0"
 criterion = "0.3"
 
 [[bench]]

--- a/partiql-parser/benches/bench_parse.rs
+++ b/partiql-parser/benches/bench_parse.rs
@@ -23,10 +23,10 @@ const Q_COMPLEX: &str = r#"
 
 fn parse_bench(c: &mut Criterion) {
     let parse = parse_partiql;
-    c.bench_function("lalr-simple", |b| b.iter(|| parse(black_box(Q_STAR))));
-    c.bench_function("lalr-ion", |b| b.iter(|| parse(black_box(Q_ION))));
-    c.bench_function("lalr-group", |b| b.iter(|| parse(black_box(Q_GROUP))));
-    c.bench_function("lalr-complex", |b| b.iter(|| parse(black_box(Q_COMPLEX))));
+    c.bench_function("parse-simple", |b| b.iter(|| parse(black_box(Q_STAR))));
+    c.bench_function("parse-ion", |b| b.iter(|| parse(black_box(Q_ION))));
+    c.bench_function("parse-group", |b| b.iter(|| parse(black_box(Q_GROUP))));
+    c.bench_function("parse-complex", |b| b.iter(|| parse(black_box(Q_COMPLEX))));
 }
 
 criterion_group! {

--- a/partiql-parser/build.rs
+++ b/partiql-parser/build.rs
@@ -2,9 +2,9 @@ use std::env::current_dir;
 use std::io;
 
 fn main() -> io::Result<()> {
-    println!("cargo:rerun-if-changed=src/lalr/partiql.lalrpop");
+    println!("cargo:rerun-if-changed=src/parse/partiql.lalrpop");
 
-    let grammer_dir = current_dir()?.join("src").join("lalr");
+    let grammer_dir = current_dir()?.join("src").join("parse");
     lalrpop::Configuration::new()
         .set_in_dir(grammer_dir)
         .process_current_dir()

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -3,17 +3,30 @@
 //! Provides a parser for the [PartiQL][partiql] query language.
 //!
 //! # Usage
-//! TODO
+//!
+//! ```
+//! use partiql_parser::{parse_partiql, ParserError, ParserResult};
+//!
+//! let ast = parse_partiql("SELECT g FROM data GROUP BY a").expect("successful parse");
+//!
+//! let errs: Vec<ParserError> = parse_partiql("SELECT").expect_err("expected error");
+//! assert_eq!(errs[0].to_string(), "Unexpected end of input");
+//!
+//! let errs_at: Vec<ParserError> =
+//!     parse_partiql("SELECT * FROM a AS a CROSS JOIN c AS c AT q").unwrap_err();
+//! assert_eq!(errs_at[0].to_string(), "Unexpected token `AT` at `(1:40..1:42)`");
+//! ```
 //!
 //! [partiql]: https://partiql.org
 
-mod lalr;
+mod lexer;
+mod parse;
 mod result;
 
-use partiql_source_map::location::LineAndColumn;
+pub use result::LexError;
+pub use result::LexicalError;
+pub use result::ParseError;
+pub use result::ParserError;
+pub use result::ParserResult;
 
-pub type LexicalError<'input> = crate::result::LexicalError<'input>;
-pub type ParserError<'input> = crate::result::ParserError<'input, LineAndColumn>;
-pub use lalr::ParserResult;
-
-pub use lalr::parse_partiql;
+pub use parse::parse_partiql;

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1,14 +1,16 @@
-use std::str::FromStr;
+use crate::parse::lexer;
+use crate::result::ParseError;
+
 use lalrpop_util::ErrorRecovery;
+use std::str::FromStr;
 
 use partiql_ast::experimental::ast;
 
-use crate::lalr::lexer;
 use partiql_source_map::location::{ByteOffset, BytePosition};
-use crate::result::ParserError;
+
 
 grammar<'input, 'err>(input: &'input str,
-                      errors: &'err mut Vec<ErrorRecovery<ByteOffset, lexer::Token<'input>, ParserError<'input, BytePosition>>>);
+                      errors: &'err mut Vec<ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>>);
 
 pub Query: Box<ast::Expr> = {
     <ExprQuery>,
@@ -757,7 +759,7 @@ CommaSep<T>: Vec<T> = {
 // See also http://lalrpop.github.io/lalrpop/lexer_tutorial/002_writing_custom_lexer.html
 extern {
     type Location = ByteOffset;
-    type Error = ParserError<'input, BytePosition>;
+    type Error = ParseError<'input, BytePosition>;
 
     enum lexer::Token<'input> {
 

--- a/partiql-source-map/src/lib.rs
+++ b/partiql-source-map/src/lib.rs
@@ -1,2 +1,4 @@
+//! Source offset & position types and mapping-related helpers.
+
 pub mod line_offset_tracker;
 pub mod location;

--- a/partiql-source-map/src/line_offset_tracker.rs
+++ b/partiql-source-map/src/line_offset_tracker.rs
@@ -1,3 +1,5 @@
+//! [`LineOffsetTracker`] and related types for mapping locations in source `str`s.
+
 use crate::location::{ByteOffset, BytePosition, LineAndCharPosition, LineOffset};
 use smallvec::{smallvec, SmallVec};
 use std::ops::Range;

--- a/partiql-source-map/src/location.rs
+++ b/partiql-source-map/src/location.rs
@@ -38,11 +38,13 @@ macro_rules! impl_pos {
             }
         }
         impl $pos_type {
+            /// Constructs from a `usize`
             #[inline(always)]
             pub fn from_usize(n: usize) -> Self {
                 Self(n as $primitive)
             }
 
+            /// Converts to a `usize`
             #[inline(always)]
             pub fn to_usize(&self) -> usize {
                 self.0 as usize
@@ -80,7 +82,7 @@ impl_pos!(CharOffset, u32);
 
 /// A 0-indexed byte absolute position (i.e., relative to the start of a &str)
 ///
-/// This type is small (u16 currently) to allow it to be included in ASTs and other
+/// This type is small (u32 currently) to allow it to be included in ASTs and other
 /// data structures.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct BytePosition(pub ByteOffset);
@@ -109,11 +111,14 @@ impl fmt::Display for BytePosition {
 /// ## Example
 /// ```
 /// # use partiql_source_map::location::LineAndCharPosition;
-/// println!("Beginning of &str: {:?}", LineAndCharPosition::new(0, 0));
+/// assert_eq!("Beginning of &str: LineAndCharPosition { line: LineOffset(0), char: CharOffset(0) }",
+///             format!("Beginning of &str: {:?}", LineAndCharPosition::new(0, 0)));
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct LineAndCharPosition {
+    /// The 0-indexed line absolute position (i.e., relative to the start of a &str)
     pub line: LineOffset,
+    /// The 0-indexed character absolute position (i.e., relative to the start of a &str)
     pub char: CharOffset,
 }
 
@@ -128,18 +133,20 @@ impl LineAndCharPosition {
     }
 }
 
-/// A line and column location intended for usage in errors/warnings/lints/etc.
+/// A 1-indexed line and column location intended for usage in errors/warnings/lints/etc.
 ///
 /// Both line and column are 1-indexed, as that is how most people think of lines and columns.
 ///
 /// ## Example
 /// ```
 /// # use partiql_source_map::location::LineAndColumn;
-/// println!("Beginning of a document: {}", LineAndColumn::new(1, 1).unwrap());
+/// assert_eq!("Beginning of &str: 1:1",format!("Beginning of &str: {}", LineAndColumn::new(1, 1).unwrap()));
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct LineAndColumn {
+    /// The 1-indexed line absolute position (i.e., relative to the start of a &str)
     pub line: NonZeroUsize,
+    /// The 1-indexed character absolute position (i.e., relative to the start of a &str)
     pub column: NonZeroUsize,
 }
 


### PR DESCRIPTION
Fixes #77

- Add documentation 
- Export types that should be public
- Rename some Error/Result types for better consistency

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
