### PR TITLE
Move AST out of experimental

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -1,15 +1,11 @@
-//! An experimental PartiQL abstract syntax tree (AST) module, see the following for motivation:
-//! <https://github.com/partiql/partiql-lang-rust/issues/52>
+//! A PartiQL abstract syntax tree (AST).
 //!
 //! This module contains the structures for the language AST.
 //! Two main entities in the module are [`Item`] and [`ItemKind`]. `Item` represents an AST element
 //! and `ItemKind` represents a concrete type with the data specific to the type of the item.
 
-// Structures in this module are mostly from the current `partiql-ir-generator` spec. and comments
-// are excerpts from the spec definition.
-// https://github.com/partiql/partiql-lang-kotlin/blob/4bcfc7f73d3e6e54286bcc03a54d5f6425eec4cc/lang/resources/org/partiql/type-domains/partiql.ion
-
-// TODO Add documentation.
+// As more changes to this AST are expected, unless explicitly advised, using the structures exposed
+// in this crate directly is not recommended.
 
 use partiql_source_map::location::BytePosition;
 use rust_decimal::Decimal as RustDecimal;
@@ -21,7 +17,7 @@ pub trait ToAstNode {
     /// further [AstNode] construction.
     /// ## Example:
     /// ```
-    /// use partiql_ast::experimental::ast::{Span, SymbolPrimitive, ToAstNode};
+    /// use partiql_ast::ast::{Span, SymbolPrimitive, ToAstNode};
     /// use partiql_source_map::location::BytePosition;
     ///
     /// let p = SymbolPrimitive {

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -4,9 +4,7 @@
 //!
 //! This API is currently unstable and subject to change.
 
-pub mod experimental {
-    pub mod ast;
-}
+pub mod ast;
 
 #[macro_use]
 extern crate derive_builder;

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use partiql_ast::experimental::ast;
-use partiql_ast::experimental::ast::*;
+use partiql_ast::ast;
+use partiql_ast::ast::*;
 use partiql_source_map::location::BytePosition;
 
 #[test]

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -6,7 +6,7 @@ use crate::lexer;
 use crate::lexer::PartiqlLexer;
 use crate::result::{ParseError, ParserResult, UnexpectedTokenData};
 use lalrpop_util as lpop;
-use partiql_ast::experimental::ast;
+use partiql_ast::ast;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
 use partiql_source_map::location::{ByteOffset, BytePosition, LineAndColumn, ToLocated};
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -4,7 +4,7 @@ use crate::result::ParseError;
 use lalrpop_util::ErrorRecovery;
 use std::str::FromStr;
 
-use partiql_ast::experimental::ast;
+use partiql_ast::ast;
 
 use partiql_source_map::location::{ByteOffset, BytePosition};
 

--- a/partiql-parser/src/result.rs
+++ b/partiql-parser/src/result.rs
@@ -5,7 +5,7 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 
-use partiql_ast::experimental::ast;
+use partiql_ast::ast;
 use partiql_source_map::location::{LineAndColumn, Located};
 use thiserror::Error;
 


### PR DESCRIPTION
*Issue #, if available:* #81

*Description of changes:*

This change moves the AST out of experimental module. Based on the recent
changes made, while we still consider future changes to the AST we've agreed
to move the AST out of experimental module as a requirement for M1 milestone.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
