### PR TITLE
Add remaining location to remaining AstNodes

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -216,27 +216,39 @@ pub struct Expr {
     pub kind: ExprKind,
 }
 
-type AstBPos<T> = AstNode<T, BytePosition>;
+/// Represents an AST Node of type T with BytePosition Location
+type AstBytePos<T> = AstNode<T, BytePosition>;
 
-type LitAst = AstBPos<Lit>;
-type StructAst = AstBPos<Struct>;
-type BagAst = AstBPos<Bag>;
-type ListAst = AstBPos<List>;
-type SexpAst = AstBPos<Sexp>;
-type BinOpAst = AstBPos<BinOp>;
-type UniOpAst = AstBPos<UniOp>;
-type LikeAst = AstBPos<Like>;
-type BetweenAst = AstBPos<Between>;
-type InAst = AstBPos<In>;
+type LitAst = AstBytePos<Lit>;
+type VarRefAst = AstBytePos<VarRef>;
+type ParamAst = AstBytePos<VarRef>;
+type StructAst = AstBytePos<Struct>;
+type BagAst = AstBytePos<Bag>;
+type ListAst = AstBytePos<List>;
+type SexpAst = AstBytePos<Sexp>;
+type BinOpAst = AstBytePos<BinOp>;
+type UniOpAst = AstBytePos<UniOp>;
+type LikeAst = AstBytePos<Like>;
+type BetweenAst = AstBytePos<Between>;
+type InAst = AstBytePos<In>;
+type SimpleCaseAst = AstBytePos<SimpleCase>;
+type SearchCaseAst = AstBytePos<SearchCase>;
+type UnionAst = AstBytePos<Union>;
+type ExceptAst = AstBytePos<Except>;
+type IntersectAst = AstBytePos<Intersect>;
+type PathAst = AstBytePos<Path>;
+type CallAst = AstBytePos<Call>;
+type CallAggAst = AstBytePos<CallAgg>;
+type SelectAst = AstBytePos<Select>;
 
 /// The expressions that can result in values.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExprKind {
     Lit(LitAst),
     /// Variable reference
-    VarRef(VarRef),
+    VarRef(VarRefAst),
     /// A parameter, i.e. `?`
-    Param(Param),
+    Param(ParamAst),
     /// Binary operator
     BinOp(BinOpAst),
     /// Unary operators
@@ -246,28 +258,25 @@ pub enum ExprKind {
     Between(BetweenAst),
     In(InAst),
     /// CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
-    SimpleCase(SimpleCase),
+    SimpleCase(SimpleCaseAst),
     /// CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
-    SearchedCase(SearchCase),
+    SearchedCase(SearchCaseAst),
     /// Constructors
     Struct(StructAst),
     Bag(BagAst),
     List(ListAst),
     Sexp(SexpAst),
-    /// Constructors for DateTime types
-    Date(Date),
-    LitTime(LitTime),
     /// Set operators
-    Union(Union),
-    Except(Except),
-    Intersect(Intersect),
+    Union(UnionAst),
+    Except(ExceptAst),
+    Intersect(IntersectAst),
     /// Other expression types
-    Path(Path),
-    Call(Call),
-    CallAgg(CallAgg),
+    Path(PathAst),
+    Call(CallAst),
+    CallAgg(CallAggAst),
 
     /// `SELECT` and its parts.
-    Select(Select),
+    Select(SelectAst),
 
     /// Indicates an error occurred during query processing; The exact error details are out of band of the AST
     Error,
@@ -392,13 +401,13 @@ pub struct In {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimpleCase {
     pub expr: Box<Expr>,
-    pub cases: ExprPairList,
+    pub cases: Vec<ExprPair>,
     pub default: Option<Box<Expr>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SearchCase {
-    pub cases: ExprPairList,
+    pub cases: Vec<ExprPair>,
     pub default: Option<Box<Expr>>,
 }
 
@@ -647,13 +656,6 @@ pub enum JoinKind {
 pub struct ExprPair {
     pub first: Box<Expr>,
     pub second: Box<Expr>,
-}
-
-/// A list of expr_pair. Used in the `pub struct`, `searched_case` and `simple_case`
-/// expr variants above.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ExprPairList {
-    pub pairs: Vec<ExprPair>,
 }
 
 /// GROUP BY <grouping_strategy> <group_key_list>... \[AS <symbol>\]

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -15,7 +15,7 @@ grammar<'input, 'err>(input: &'input str,
 
 pub Query: Box<ast::Expr> = {
     <ExprQuery>,
-    <sfw:SfwQuery> => Box::new( ast::Expr{ kind: ast::ExprKind::Select(sfw) } )
+    <lo:@L> <sfw:SfwQuery> <hi:@R> => Box::new( ast::Expr{ kind: ast::ExprKind::Select(sfw.ast(lo..hi)) } )
 }
 
 // ------------------------------------------------------------------------------ //
@@ -620,7 +620,7 @@ ExprPrecedence03: ast::Expr = {
 
 #[inline]
 ExprPrecedence02: ast::Expr = {
-    <call:FunctionCall> => ast::Expr{ kind: ast::ExprKind::Call( call ) },
+    <lo:@L> <call:FunctionCall> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Call( call.ast(lo..hi) ) },
     <ExprPrecedence01>,
 }
 
@@ -630,7 +630,7 @@ ExprPrecedence01: ast::Expr = {<ExprTerm>,}
 pub ExprTerm: ast::Expr = {
     "(" <q:Query> ")" => *q,
     <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
-    <path:PathExpr> => ast::Expr{ kind: ast::ExprKind::Path( path ) },
+    <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
     <lo:@L> "{" <fields:CommaTerm<ExprPair>> "}" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Struct( ast::Struct{fields}.ast(lo..hi) ) },
     <lo:@L> "[" <values:CommaTerm<ExprQuery>> "]" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
     <lo:@L> "<<" <values:CommaTerm<ExprQuery>> ">>" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Bag( ast::Bag{values}.ast(lo..hi) ) },
@@ -648,7 +648,7 @@ FunctionCall: ast::Call = {
 }
 
 PathExpr: ast::Path = {
-    <path:PathExpr> "." <ident:"Identifier"> => {
+    <lo:@L> <path:PathExpr> "." <ident:"Identifier"> <hi:@R> => {
         let step = ast::PathStep::PathExpr(
             ast::PathExpr{
                 index: Box::new(ast::Expr{
@@ -656,7 +656,7 @@ PathExpr: ast::Path = {
                         name: ast::SymbolPrimitive { value: ident.to_owned() },
                         case: ast::CaseSensitivity::CaseInsensitive,
                         qualifier: ast::ScopeQualifier::Unqualified
-                    }),
+                    }.ast(lo..hi)),
                 }),
                 case: ast::CaseSensitivity::CaseInsensitive,
             });
@@ -665,23 +665,23 @@ PathExpr: ast::Path = {
         steps.push(step);
         ast::Path{ root:path.root, steps }
     },
-    <ident:"Identifier"> => {
+    <lo:@L> <ident:"Identifier"> <hi:@R> => {
         let root = ast::Expr{
             kind: ast::ExprKind::VarRef(ast::VarRef {
                 name: ast::SymbolPrimitive { value: ident.to_owned() },
                 case: ast::CaseSensitivity::CaseInsensitive,
                 qualifier: ast::ScopeQualifier::Unqualified
-            }),
+            }.ast(lo..hi)),
         };
         ast::Path{ root: Box::new(root), steps: vec![] }
     },
-    <ident:"AtIdentifier"> => {
+    <lo:@L> <ident:"AtIdentifier"> <hi:@R> => {
         let root = ast::Expr{
             kind: ast::ExprKind::VarRef(ast::VarRef {
                 name: ast::SymbolPrimitive { value: ident.to_owned() },
                 case: ast::CaseSensitivity::CaseInsensitive,
                 qualifier: ast::ScopeQualifier::Qualified
-            }),
+            }.ast(lo..hi)),
         };
         ast::Path{ root: Box::new(root), steps: vec![] }
     },


### PR DESCRIPTION
*Issue #, if available:* #95

*Description of changes:*

See PR #103 for more context on adding location data `AstNode`.
In this commit we make the following changes:

- Add the remaining `ExprKind` to AstNode and modify the parser
 to include the location information to the corresponding AstNodes.

- Remove ExprPairList and use the Vec<Expr> directly.

- Remove redundant Date and Time structures
   We already have the DateTime Literal so removing the redundant ones
   in the AST.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
