### PR TITLE
Update `partiql-tests` submodule; add feature to `partiql-conformance-tests` crate

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -36,11 +36,21 @@ jobs:
         with:
           command: build
           args: --verbose --workspace
-      - name: Cargo Test
+      - name: Cargo Test excluding conformance tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --verbose --workspace
+      # Currently just runs the conformance tests and won't fail the build for a conformance test failure (more details
+      # on the 'continue-on-error' workflow syntax can be found here:
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
+      # Further conformance report generation will be part of https://github.com/partiql/partiql-lang-rust/issues/79.
+      - name: Cargo Test of the conformance tests (can fail)
+        uses: actions-rs/cargo@v1
+        continue-on-error: true
+        with:
+          command: test
+          args: --verbose --package partiql-conformance-tests --features "conformance_test"
       - name: Rustfmt Check
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -41,10 +41,13 @@ jobs:
         with:
           command: test
           args: --verbose --workspace
-      # Currently just runs the conformance tests and won't fail the build for a conformance test failure (more details
-      # on the 'continue-on-error' workflow syntax can be found here:
+      # Currently just runs the conformance tests. Further conformance report generation will be part of
+      # https://github.com/partiql/partiql-lang-rust/issues/79.
+      # Uses the 'continue-on-error' workflow syntax which means the GitHub Actions build will succeed even if the
+      # workflow step failed. Results are still viewable (example run:
+      # https://github.com/partiql/partiql-lang-rust/runs/6186121711?check_suite_focus=true#step:8:686)
+      # More details on the 'continue-on-error' workflow syntax can be found here:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
-      # Further conformance report generation will be part of https://github.com/partiql/partiql-lang-rust/issues/79.
       - name: Cargo Test of the conformance tests (can fail)
         uses: actions-rs/cargo@v1
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ You can also initialize the submodules as follows:
 $ git submodule update --init --recursive
 ```
 
+## Running the conformance tests
+Running `cargo test` from the `partiql-lang-rust` root will not run the conformance tests by default.
+
+To run all the tests (including conformance tests), you will need to run `cargo test` with the "conformance_test" `--features` flag:
+
+```shell
+cargo test --features "conformance_test"
+```
+
+Or to run just the conformance tests:
+
+```shell
+cargo test --package partiql-conformance-tests --features "conformance_test"
+```
+
+More details on running individual tests can be found in the `partiql-conformance-tests` crate [README](partiql-conformance-tests/README.md).
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -172,7 +172,7 @@ fn parse_assertions(assertions: &Vec<&OwnedElement>) -> ParseAssertions {
                 let r_as_str = r.as_str().expect("as_str()");
                 return match r_as_str {
                     "ParseOk" => ParseAssertions::ParsePass,
-                    "ParserError" => ParseAssertions::ParseFail,
+                    "ParseError" => ParseAssertions::ParseFail,
                     _ => panic!("Unexpected parse result {}", r_as_str),
                 };
             }

--- a/partiql-conformance-test-generator/src/util.rs
+++ b/partiql-conformance-test-generator/src/util.rs
@@ -79,7 +79,7 @@ pub fn dir_to_mods(dir: &Path) {
     for module in modules_in_dir {
         mod_rs_file
             .write_all(format!("mod {};\n", module.to_str().expect("to str")).as_bytes())
-            .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
+            .expect("Failure when writing to file");
     }
 }
 

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -25,3 +25,6 @@ partiql-conformance-test-generator = { path = "../partiql-conformance-test-gener
 
 [dependencies]
 partiql-parser = { path = "../partiql-parser" }
+
+[features]
+conformance_test=[]

--- a/partiql-conformance-tests/README.md
+++ b/partiql-conformance-tests/README.md
@@ -2,7 +2,13 @@
 
 Running `cargo test` from the `partiql-lang-rust` root will not run the conformance tests by default.
 
-To run the tests, you will need to run `cargo test` with the "conformance_test" `--features` flag:
+To run all the tests (including conformance tests), you will need to run `cargo test` with the "conformance_test" `--features` flag:
+
+```shell
+cargo test --features "conformance_test"
+```
+
+Or to run just the conformance tests:
 
 ```shell
 cargo test --package partiql-conformance-tests --features "conformance_test"

--- a/partiql-conformance-tests/README.md
+++ b/partiql-conformance-tests/README.md
@@ -1,0 +1,20 @@
+## Running the Tests
+
+Running `cargo test` from the `partiql-lang-rust` root will not run the conformance tests by default.
+
+To run the tests, you will need to run `cargo test` with the "conformance_test" `--features` flag:
+
+```shell
+cargo test --package partiql-conformance-tests --features "conformance_test"
+```
+
+---
+
+Running an individual test (or subset of tests) can vary by the IDE being used. Using CLion, you may need to first edit
+the test run configuration and enable the "Use all features in test" checkbox or explicitly add the 
+`--features "conformance_test"` test option.
+
+Using the command line, you can run an individual test with the following:
+```shell
+cargo test --package partiql-conformance-tests --test <test name or full mod path> --features "conformance_test" -- --exact
+```

--- a/partiql-conformance-tests/build.rs
+++ b/partiql-conformance-tests/build.rs
@@ -48,10 +48,16 @@ fn main() -> io::Result<()> {
 
     let sub_tests_dir = "partiql_tests";
     let sub_tests_path = Path::new(sub_tests_dir);
-    dir_to_mods( &tests_path.join(sub_tests_path));
+    dir_to_mods(&tests_path.join(sub_tests_path));
     File::create(&tests_path.join("mod.rs"))
         .expect("mod.rs created in root test folder")
-        .write_all(format!("#[cfg(feature = \"conformance_test\")]\nmod {};\n", sub_tests_dir).as_bytes())
+        .write_all(
+            format!(
+                "#[cfg(feature = \"conformance_test\")]\n#[rustfmt::skip]\nmod {};\n",
+                sub_tests_dir
+            )
+            .as_bytes(),
+        )
         .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
     Ok(())
 }

--- a/partiql-conformance-tests/build.rs
+++ b/partiql-conformance-tests/build.rs
@@ -5,6 +5,7 @@ use partiql_conformance_test_generator::util::{all_ion_files_in, dir_to_mods, St
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{fs, io};
 
 /// TODO: once APIs are more stable, include documentation on what this build script is doing
@@ -28,8 +29,7 @@ fn main() -> io::Result<()> {
 
         let test_document = ion_data_to_test_document(all_ion_data);
         let test_generator = Generator { test_document };
-        let mut scope = test_generator.generate_scope().to_string();
-        scope.push_str("\n");
+        let scope = test_generator.generate_scope().to_string();
 
         let dest_path_non_escaped = Path::new("tests").join(file.with_extension(""));
         let dest_path_escaped: PathBuf = dest_path_non_escaped
@@ -43,21 +43,30 @@ fn main() -> io::Result<()> {
         File::create(dest_path)
             .expect("File creation failed")
             .write_all(scope.as_bytes())
-            .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
+            .expect("Failure when writing to file");
     }
 
     let sub_tests_dir = "partiql_tests";
     let sub_tests_path = Path::new(sub_tests_dir);
     dir_to_mods(&tests_path.join(sub_tests_path));
+    // Creates the top-level mod.rs file in the tests/ directory and adds the "conformance_test"
+    // flag to this mod
     File::create(&tests_path.join("mod.rs"))
         .expect("mod.rs created in root test folder")
         .write_all(
             format!(
-                "#[cfg(feature = \"conformance_test\")]\n#[rustfmt::skip]\nmod {};\n",
+                "#[cfg(feature = \"conformance_test\")]\nmod {};\n",
                 sub_tests_dir
             )
             .as_bytes(),
         )
-        .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
+        .expect("Failure when writing to file");
+
+    Command::new("cargo")
+        .arg("fmt")
+        .arg("--verbose")
+        .arg("--")
+        .spawn()
+        .expect("cargo fmt of tests/ failed");
     Ok(())
 }

--- a/partiql-conformance-tests/build.rs
+++ b/partiql-conformance-tests/build.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
 
     // TODO: consider first moving directory and deleting once test generation is successful
     if tests_path.exists() {
-        fs::remove_dir_all("tests/").expect("removal of tests/ before test generation");
+        fs::remove_dir_all(tests_dir).expect("removal of tests/ before test generation");
     }
 
     let file_dir = "partiql-tests";
@@ -46,6 +46,12 @@ fn main() -> io::Result<()> {
             .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
     }
 
-    dir_to_mods(tests_path);
+    let sub_tests_dir = "partiql_tests";
+    let sub_tests_path = Path::new(sub_tests_dir);
+    dir_to_mods( &tests_path.join(sub_tests_path));
+    File::create(&tests_path.join("mod.rs"))
+        .expect("mod.rs created in root test folder")
+        .write_all(format!("#[cfg(feature = \"conformance_test\")]\nmod {};\n", sub_tests_dir).as_bytes())
+        .unwrap_or_else(|error| panic!("Failure when writing to file: {:?}", error));
     Ok(())
 }


### PR DESCRIPTION
Changes as part of this PR:
- Updates `partiql-tests` submodule following latest test additions in https://github.com/partiql/partiql-tests/pull/10.
- Disables running the conformance tests by default (i.e. `cargo test`) and adds a feature flag to `partiql-conformance-tests` that can be set to run the conformance tests
  - More details included in the `partiql-conformance-tests` `README.md`
- Adds a GitHub actions workflow step that runs the conformance tests separately using the [continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error) flag
  - This will allow the GitHub Actions build to succeed even if a conformance test fails
  - Further conformance report generation will be done as part of #79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
