### PR TITLE
Add details to Parse test asserts

### DIFF
--- a/partiql-conformance-test-generator/src/generator.rs
+++ b/partiql-conformance-test-generator/src/generator.rs
@@ -43,13 +43,14 @@ fn test_case_to_function(test_case: &TestCase) -> Function {
     match &test_case.test_kind {
         Parse(ParseTestCase { parse_assertions }) => {
             let mut test_fn: Function = Function::new(&test_case.test_name);
-            test_fn.attr("test").line(format!(
-                "let parse_result = partiql_parser::parse_partiql(r#\"{}\"#);",
-                &test_case.statement
-            ));
+            test_fn.attr("test");
+            test_fn.line(format!("let query = r#\"{}\"#;", &test_case.statement));
+            test_fn.line("let res = partiql_parser::parse_partiql(query);");
             match parse_assertions {
-                ParseAssertions::ParsePass => test_fn.line("assert!(parse_result.is_ok());"),
-                ParseAssertions::ParseFail => test_fn.line("assert!(parse_result.is_err());"),
+                ParseAssertions::ParsePass => test_fn
+                    .line(r#"assert!(res.is_ok(), "For `{}`, expected `Ok(_)`, but was `{:#?}`", query, res);"#),
+                ParseAssertions::ParseFail => test_fn
+                    .line(r#"assert!(res.is_err(), "For `{}`, expected `Err(_)`, but was `{:#?}`", query, res);"#),
             };
             test_fn
         }


### PR DESCRIPTION
#108 

Add some details to conformance test assert output.

Old output:
```
assertion failed: partiql_result.is_ok()
```

New output:
```
For `COUNT(DISTINCT a)`, expected `Ok(_)`, but was `Err(
    [
        UnexpectedToken(
            Located {
                inner: UnexpectedTokenData {
                    token: "<IDENTIFIER>",
                },
                location: Location {
                    start: LineAndColumn {
                        line: 1,
                        column: 16,
                    },
                    end: LineAndColumn {
                        line: 1,
                        column: 17,
                    },
                },
            },
        ),
    ],
)`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
