### PR TITLE
Fixes parser for GROUP `ALL`|`PARTIAL`

### DIFF
--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -568,6 +568,8 @@ pub enum Token<'input> {
     Order,
     #[regex("(?i:Outer)")]
     Outer,
+    #[regex("(?i:Partial)")]
+    Partial,
     #[regex("(?i:Pivot)")]
     Pivot,
     #[regex("(?i:Preserve)")]
@@ -672,6 +674,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Or
             | Token::Order
             | Token::Outer
+            | Token::Partial
             | Token::Pivot
             | Token::Preserve
             | Token::Right

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -247,7 +247,7 @@ WhereClause: Box<ast::Expr> = { "WHERE" <ExprQuery> }
 //                                   GROUP BY                                     //
 // ------------------------------------------------------------------------------ //
 GroupClause: Box<ast::GroupByExpr> = {
-    "GROUP" "BY" <strategy: GroupStrategy> <keys:CommaSep<GroupKey>> <group_as_alias:GroupAlias?> => {
+    "GROUP" <strategy: GroupStrategy> "BY" <keys:CommaSep<GroupKey>> <group_as_alias:GroupAlias?> => {
         Box::new(ast::GroupByExpr{
             strategy,
             key_list: ast::GroupKeyList{ keys },
@@ -257,10 +257,11 @@ GroupClause: Box<ast::GroupByExpr> = {
 }
 #[inline]
 GroupStrategy: ast::GroupingStrategy = {
-    <all:"ALL"?> => {
-        match all {
-            Some(_) => ast::GroupingStrategy::GroupFull,
-            None => ast::GroupingStrategy::GroupPartial,
+    "ALL" => ast::GroupingStrategy::GroupFull,
+    <partial:"PARTIAL"?> => {
+        match partial {
+            Some(_) => ast::GroupingStrategy::GroupPartial,
+            None => ast::GroupingStrategy::GroupFull,
         }
     }
 }
@@ -880,6 +881,7 @@ extern {
         "OR" => lexer::Token::Or,
         "ORDER" => lexer::Token::Order,
         "OUTER" => lexer::Token::Outer,
+        "PARTIAL" => lexer::Token::Partial,
         "PIVOT" => lexer::Token::Pivot,
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,


### PR DESCRIPTION
#108 

Fixes parsing of `GROUP [ALL|PARTIAL] BY...`

Makes the following pass:
- https://github.com/partiql/partiql-tests/blob/main/partiql-test-data/pass/parser/query/select/group-by.ion#L16-L22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
