### PR TITLE
Resolve parser conformance tests (initial PR)

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -481,12 +481,14 @@ pub struct Path {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Call {
     pub func_name: SymbolPrimitive,
+    pub setq: Option<SetQuantifier>,
     pub args: Vec<Box<Expr>>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CallAgg {
     pub func_name: SymbolPrimitive,
+    pub setq: Option<SetQuantifier>,
     pub args: Vec<Box<Expr>>,
 }
 
@@ -521,7 +523,6 @@ pub struct Coalesce {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Select {
-    pub setq: Option<SetQuantifier>,
     pub project: ProjectionAst,
     pub from: Option<FromClauseAst>,
     pub from_let: Option<LetAst>,
@@ -565,9 +566,15 @@ pub enum CaseSensitivity {
     CaseInsensitive,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct Projection {
+    pub kind: ProjectionKind,
+    pub setq: Option<SetQuantifier>,
+}
+
 /// Indicates the type of projection in a SFW query.
 #[derive(Clone, Debug, PartialEq)]
-pub enum Projection {
+pub enum ProjectionKind {
     ProjectStar,
     ProjectList(Vec<ProjectItemAst>),
     ProjectPivot { key: Box<Expr>, value: Box<Expr> },

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -514,6 +514,8 @@ pub enum Token<'input> {
     Cross,
     #[regex("(?i:Desc)")]
     Desc,
+    #[regex("(?i:Distinct)")]
+    Distinct,
     #[regex("(?i:Escape)")]
     Escape,
     #[regex("(?i:Except)")]
@@ -649,6 +651,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::By
             | Token::Cross
             | Token::Desc
+            | Token::Distinct
             | Token::Escape
             | Token::Except
             | Token::False

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -156,10 +156,12 @@ FromClause: ast::FromClauseAst = {
             .unwrap() // safe, because we know there's at least 1 input
     }
 }
+
 TableReference: ast::FromClauseAst = {
     <TableNonJoin>,
     <TableJoined>,
 }
+
 TableNonJoin: ast::FromClauseAst = {
     <lo:@L> <t:TableBaseReference> <hi:@R> => ast::FromClause::FromLet( t ).ast(lo..hi),
     <lo:@L> <t:TableUnpivot> <hi:@R> => ast::FromClause::FromLet( t ).ast(lo..hi),

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -42,7 +42,6 @@ SfwClauses: ast::Select = {
     <limit:LimitClause?>
     <offset:OffsetByClause?> => {
         ast::Select {
-            setq: None,
             project,
             from,
             from_let: None,
@@ -69,7 +68,6 @@ FwsClauses: ast::Select = {
     <offset:OffsetByClause?>
     <project:SelectClause> => {
         ast::Select {
-            setq: None,
             project,
             from: Some(from),
             from_let: None,
@@ -93,12 +91,33 @@ WithClause: () = {}
 //                                    SELECT                                      //
 // ------------------------------------------------------------------------------ //
 SelectClause: ast::ProjectionAst = {
-    <lo:@L> "SELECT" "*" <hi:@R> => ast::Projection::ProjectStar.ast(lo..hi),
-    <lo:@L> "SELECT" <project_items:CommaSepPlus<Projection>> <hi:@R> => ast::Projection::ProjectList(project_items).ast(lo..hi),
-    <lo:@L> "SELECT" "VALUE" <value:ExprQuery> <hi:@R> => ast::Projection::ProjectValue(value).ast(lo..hi),
-    <lo:@L> "PIVOT" <value:ExprQuery> "AT" <key:ExprQuery> <hi:@R> => {
-        ast::Projection::ProjectPivot { key, value }.ast(lo..hi)
-    },
+    <lo:@L> "SELECT" <strategy: SetQuantifierStrategy> "*" <hi:@R> => ast::Projection {
+        kind: ast::ProjectionKind::ProjectStar,
+        setq: Some(strategy)
+    }.ast(lo..hi),
+    <lo:@L> "SELECT" <strategy: SetQuantifierStrategy> <project_items:CommaSepPlus<Projection>> <hi:@R> => ast::Projection {
+        kind: ast::ProjectionKind::ProjectList(project_items),
+        setq: Some(strategy),
+    }.ast(lo..hi),
+    <lo:@L> "SELECT" <strategy: SetQuantifierStrategy> "VALUE" <value:ExprQuery> <hi:@R> => ast::Projection {
+        kind: ast::ProjectionKind::ProjectValue(value),
+        setq: Some(strategy),
+    }.ast(lo..hi),
+    <lo:@L> "PIVOT" <value:ExprQuery> "AT" <key:ExprQuery> <hi:@R> => ast::Projection {
+        kind: ast::ProjectionKind::ProjectPivot { key, value },
+        setq: None
+    }.ast(lo..hi),
+}
+
+#[inline]
+SetQuantifierStrategy: ast::SetQuantifier = {
+    "ALL" => ast::SetQuantifier::All,
+    <distinct: "DISTINCT"?> => {
+        match distinct {
+            Some(_) => ast::SetQuantifier::Distinct,
+            None => ast::SetQuantifier::All,
+        }
+    }
 }
 
 #[inline]
@@ -669,8 +688,24 @@ ExprPair: ast::ExprPair = {
 
 #[inline]
 FunctionCall: ast::Call = {
-    <func_name:"Identifier"> "("  <args:CommaSepPlus<ExprQuery>> ")" =>
-        ast::Call{ func_name: ast::SymbolPrimitive{ value: func_name.to_owned() }, args }
+    <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> ")" =>
+        ast::Call {
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            args: Vec::new(),
+            setq: Some(strategy)
+        },
+     <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> "*" ")" =>
+         ast::Call {
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            args: Vec::new(),
+            setq: Some(strategy)
+         },
+    <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> <args:CommaSepPlus<ExprQuery>> ")" =>
+        ast::Call {
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            args,
+            setq: Some(strategy)
+        },
 }
 
 PathExpr: ast::Path = {
@@ -901,6 +936,7 @@ extern {
         "BY" => lexer::Token::By,
         "CROSS" => lexer::Token::Cross,
         "DESC" => lexer::Token::Desc,
+        "DISTINCT" => lexer::Token::Distinct,
         "ESCAPE" => lexer::Token::Escape,
         "EXCEPT" => lexer::Token::Except,
         "FALSE" => lexer::Token::False,


### PR DESCRIPTION
*Issue #, if available:* #108 

*Description of changes:*

This PR resolves the comments in [PR-109](https://github.com/partiql/partiql-lang-rust/pull/109).

The changes involve are:
- Creation of `Distinct` keyword.
- Creation of `SetQuantifierStrategy` for making statements with `SetQuantifier` parsable.
- Fixes parsing of general function calls (excluding functions like `substring` for now).

The reason for creating a new PR is that the previous PR is polluted with commits from other merges.

Conformance test report:
https://paste.debian.net/1239858/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
