### PR TITLE
Parse case expr

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -235,7 +235,8 @@ pub type LikeAst = AstBytePos<Like>;
 pub type BetweenAst = AstBytePos<Between>;
 pub type InAst = AstBytePos<In>;
 pub type SimpleCaseAst = AstBytePos<SimpleCase>;
-pub type SearchCaseAst = AstBytePos<SearchCase>;
+pub type SearchedCaseAst = AstBytePos<SearchedCase>;
+pub type CaseAst = AstBytePos<Case>;
 pub type SetExprAst = AstBytePos<SetExpr>;
 pub type PathAst = AstBytePos<Path>;
 pub type CallAst = AstBytePos<Call>;
@@ -302,10 +303,7 @@ pub enum ExprKind {
     Like(LikeAst),
     Between(BetweenAst),
     In(InAst),
-    /// CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
-    SimpleCase(SimpleCaseAst),
-    /// CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
-    SearchedCase(SearchCaseAst),
+    Case(CaseAst),
     /// Constructors
     Struct(StructAst),
     Bag(BagAst),
@@ -440,6 +438,19 @@ pub struct In {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct Case {
+    pub kind: CaseKind,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum CaseKind {
+    /// CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
+    SimpleCase(SimpleCase),
+    /// CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
+    SearchedCase(SearchedCase),
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct SimpleCase {
     pub expr: Box<Expr>,
     pub cases: Vec<ExprPair>,
@@ -447,7 +458,7 @@ pub struct SimpleCase {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct SearchCase {
+pub struct SearchedCase {
     pub cases: Vec<ExprPair>,
     pub default: Option<Box<Expr>>,
 }

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -222,39 +222,39 @@ pub struct Expr {
 /// Represents an AST Node of type T with BytePosition Location
 pub type AstBytePos<T> = AstNode<T, BytePosition>;
 
-pub type LitAst = AstBytePos<Lit>;
-pub type VarRefAst = AstBytePos<VarRef>;
-pub type ParamAst = AstBytePos<VarRef>;
-pub type StructAst = AstBytePos<Struct>;
 pub type BagAst = AstBytePos<Bag>;
-pub type ListAst = AstBytePos<List>;
-pub type SexpAst = AstBytePos<Sexp>;
-pub type BinOpAst = AstBytePos<BinOp>;
-pub type UniOpAst = AstBytePos<UniOp>;
-pub type LikeAst = AstBytePos<Like>;
 pub type BetweenAst = AstBytePos<Between>;
-pub type InAst = AstBytePos<In>;
-pub type SimpleCaseAst = AstBytePos<SimpleCase>;
-pub type SearchedCaseAst = AstBytePos<SearchedCase>;
-pub type CaseAst = AstBytePos<Case>;
-pub type SetExprAst = AstBytePos<SetExpr>;
-pub type PathAst = AstBytePos<Path>;
-pub type CallAst = AstBytePos<Call>;
+pub type BinOpAst = AstBytePos<BinOp>;
 pub type CallAggAst = AstBytePos<CallAgg>;
-pub type SelectAst = AstBytePos<Select>;
-pub type ProjectionAst = AstBytePos<Projection>;
-pub type ProjectItemAst = AstBytePos<ProjectItem>;
+pub type CallAst = AstBytePos<Call>;
+pub type CaseAst = AstBytePos<Case>;
 pub type FromClauseAst = AstBytePos<FromClause>;
 pub type FromLetAst = AstBytePos<FromLet>;
+pub type GroupByExprAst = AstBytePos<GroupByExpr>;
+pub type GroupKeyAst = AstBytePos<GroupKey>;
+pub type InAst = AstBytePos<In>;
 pub type JoinAst = AstBytePos<Join>;
 pub type JoinSpecAst = AstBytePos<JoinSpec>;
 pub type LetAst = AstBytePos<Let>;
-pub type GroupByExprAst = AstBytePos<GroupByExpr>;
-pub type GroupKeyAst = AstBytePos<GroupKey>;
+pub type LikeAst = AstBytePos<Like>;
+pub type ListAst = AstBytePos<List>;
+pub type LitAst = AstBytePos<Lit>;
 pub type OrderByExprAst = AstBytePos<OrderByExpr>;
-pub type SortSpecAst = AstBytePos<SortSpec>;
+pub type ParamAst = AstBytePos<VarRef>;
+pub type PathAst = AstBytePos<Path>;
+pub type ProjectItemAst = AstBytePos<ProjectItem>;
+pub type ProjectionAst = AstBytePos<Projection>;
 pub type QueryAst = AstBytePos<Query>;
 pub type QuerySetAst = AstBytePos<QuerySet>;
+pub type SearchedCaseAst = AstBytePos<SearchedCase>;
+pub type SelectAst = AstBytePos<Select>;
+pub type SetExprAst = AstBytePos<SetExpr>;
+pub type SexpAst = AstBytePos<Sexp>;
+pub type SimpleCaseAst = AstBytePos<SimpleCase>;
+pub type SortSpecAst = AstBytePos<SortSpec>;
+pub type StructAst = AstBytePos<Struct>;
+pub type UniOpAst = AstBytePos<UniOp>;
+pub type VarRefAst = AstBytePos<VarRef>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Query {

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -600,6 +600,8 @@ pub enum Token<'input> {
     Using,
     #[regex("(?i:Value)")]
     Value,
+    #[regex("(?i:Values)")]
+    Values,
     #[regex("(?i:When)")]
     When,
     #[regex("(?i:Where)")]
@@ -704,6 +706,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Unpivot
             | Token::Using
             | Token::Value
+            | Token::Values
             | Token::When
             | Token::Where
             | Token::With => {
@@ -732,7 +735,7 @@ mod tests {
             "WiTH Where Value uSiNg Unpivot UNION True Select right Preserve pivoT Outer Order Or \
              On Offset Nulls Null Not Natural Missing Limit Like Left Lateral Last Join \
              Intersect Is Inner In Having Group From Full First False Except Escape Desc \
-             Cross By Between At As And Asc All Case When Then Else End";
+             Cross By Between At As And Asc All Values Case When Then Else End";
         let symbols = symbols.split(' ').chain(primitives.split(' '));
         let keywords = keywords.split(' ');
 
@@ -752,8 +755,8 @@ mod tests {
             "LIMIT", "/", "LIKE", "^", "LEFT", ".", "LATERAL", "||", "LAST", ":", "JOIN",
             "--", "INTERSECT", "/**/", "IS", "<ident:IDENT>", "INNER", "<atident:@IDENT>", "IN",
             "HAVING", "GROUP", "FROM", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC",
-            "CROSS", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "CASE", "WHEN", "THEN",
-            "ELSE", "END"
+            "CROSS", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES", "CASE", "WHEN",
+            "THEN", "ELSE", "END",
         ];
         let displayed = toks
             .into_iter()

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -510,12 +510,18 @@ pub enum Token<'input> {
     Between,
     #[regex("(?i:By)")]
     By,
+    #[regex("(?i:Case)")]
+    Case,
     #[regex("(?i:Cross)")]
     Cross,
     #[regex("(?i:Desc)")]
     Desc,
     #[regex("(?i:Distinct)")]
     Distinct,
+    #[regex("(?i:Else)")]
+    Else,
+    #[regex("(?i:End)")]
+    End,
     #[regex("(?i:Escape)")]
     Escape,
     #[regex("(?i:Except)")]
@@ -582,6 +588,8 @@ pub enum Token<'input> {
     Right,
     #[regex("(?i:Select)")]
     Select,
+    #[regex("(?i:Then)")]
+    Then,
     #[regex("(?i:True)")]
     True,
     #[regex("(?i:Union)")]
@@ -592,8 +600,8 @@ pub enum Token<'input> {
     Using,
     #[regex("(?i:Value)")]
     Value,
-    #[regex("(?i:Values)")]
-    Values,
+    #[regex("(?i:When)")]
+    When,
     #[regex("(?i:Where)")]
     Where,
     #[regex("(?i:With)")]
@@ -651,9 +659,12 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::At
             | Token::Between
             | Token::By
+            | Token::Case
             | Token::Cross
             | Token::Desc
             | Token::Distinct
+            | Token::Else
+            | Token::End
             | Token::Escape
             | Token::Except
             | Token::False
@@ -687,12 +698,13 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Preserve
             | Token::Right
             | Token::Select
+            | Token::Then
             | Token::True
             | Token::Union
             | Token::Unpivot
             | Token::Using
             | Token::Value
-            | Token::Values
+            | Token::When
             | Token::Where
             | Token::With => {
                 write!(f, "{}", format!("{:?}", self).to_uppercase())
@@ -720,7 +732,7 @@ mod tests {
             "WiTH Where Value uSiNg Unpivot UNION True Select right Preserve pivoT Outer Order Or \
              On Offset Nulls Null Not Natural Missing Limit Like Left Lateral Last Join \
              Intersect Is Inner In Having Group From Full First False Except Escape Desc \
-             Cross By Between At As And Asc All Values";
+             Cross By Between At As And Asc All Case When Then Else End";
         let symbols = symbols.split(' ').chain(primitives.split(' '));
         let keywords = keywords.split(' ');
 
@@ -740,7 +752,8 @@ mod tests {
             "LIMIT", "/", "LIKE", "^", "LEFT", ".", "LATERAL", "||", "LAST", ":", "JOIN",
             "--", "INTERSECT", "/**/", "IS", "<ident:IDENT>", "INNER", "<atident:@IDENT>", "IN",
             "HAVING", "GROUP", "FROM", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC",
-            "CROSS", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES"
+            "CROSS", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "CASE", "WHEN", "THEN",
+            "ELSE", "END"
         ];
         let displayed = toks
             .into_iter()

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -461,6 +461,12 @@ mod tests {
             parse!(r#"CASE WHEN id IS 1 THEN 2 WHEN titanId IS 2 THEN 3 ELSE 1 END"#);
             parse!(r#"CASE hello WHEN id IS NOT NULL THEN (SELECT * FROM data) ELSE 1 END"#);
         }
+
+        #[test]
+        #[should_panic]
+        fn searched_case_failure() {
+            parse!(r#"CASE hello WHEN id IS NOT NULL THEN SELECT * FROM data ELSE 1 END"#);
+        }
     }
 
     mod errors {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -91,16 +91,6 @@ pub SingleQuery: ast::QuerySetAst = {
         }
     },
     <lo:@L> <sfw:SfwQuery> <hi:@R> => ast::QuerySet::Select( Box::new(sfw) ).ast(lo..hi),
-    <lo:@L> <values:Values> <hi:@R> => values,
-}
-
-Values: ast::QuerySetAst = {
-    <lo:@L> "VALUES" <rows:CommaSepPlus<ValueRow>> <hi:@R> => ast::QuerySet::Values( rows ).ast(lo..hi)
-}
-
-#[inline]
-ValueRow: Box<ast::Expr> = {
-    <array:ExprTermArrayParens> => Box::new(array)
 }
 
 // ------------------------------------------------------------------------------ //
@@ -739,43 +729,64 @@ ExprPrecedence02: ast::Expr = {
 }
 
 #[inline]
-ExprPrecedence01: ast::Expr = {<ExprTerm>,}
+ExprPrecedence01: ast::Expr = {
+    <casexpr:CaseExpr> => ast::Expr {
+        kind: ast::ExprKind::Case(casexpr)
+    },
+    <ExprTerm>,
+};
+
+
+// ------------------------------------------------------------------------------ //
+//                                                                                //
+//                               Case Expression                                  //
+//                                                                                //
+// ------------------------------------------------------------------------------ //
+// Implements parsing for CASE expressions.
+//
+// Searched Case Example:
+// CASE WHEN titanId IS 1 THEN 2 WHEN titanId IS 2 THEN 3 ELSE 1 END
+//
+// Simple Case Example:
+// CASE hello WHEN titanId IS NOT NULL THEN (SELECT * FROM data) ELSE 1 END
+
+CaseExpr: ast::CaseAst = {
+    <lo:@L> "CASE" <expr:ExprQuery?> <cases:ExprPairWhenThen+> <elsexpr:ElseClause?> "END" <hi:@R> => {
+        match expr {
+            None => ast::Case {
+                kind: ast::CaseKind::SearchedCase(
+                    ast::SearchedCase { cases: Vec::new(), default: elsexpr }
+                )
+            }.ast(lo..hi),
+            Some(expr) => ast::Case {
+                kind: ast::CaseKind::SimpleCase(
+                    ast::SimpleCase { expr, cases: Vec::new(), default: elsexpr }
+                )
+            }.ast(lo..hi)
+        }
+    }
+};
+
+ElseClause: Box<ast::Expr> = {
+  "ELSE" <e:ExprQuery> => Box::new(*e)
+};
+
+ExprPairWhenThen: ast::ExprPair = {
+    <lo:@L> "WHEN" <first:ExprQuery> "THEN" <second:ExprQuery> <hi:@R> => ast::ExprPair { first, second },
+};
 
 pub ExprTerm: ast::Expr = {
     "(" <q:Query> ")" => *q,
     <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
     <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
-    <ExprTermArray>,
-    <ExprTermBag>,
-    <ExprTermTuple>,
+    <lo:@L> "{" <fields:CommaTermStar<ExprPairFromColon>> "}" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Struct( ast::Struct{fields}.ast(lo..hi) ) },
+    <lo:@L> "[" <values:CommaTermStar<ExprQuery>> "]" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
+    <lo:@L> "(" <values:CommaTermPlus<ExprQuery>> ")" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
+    <lo:@L> "<<" <values:CommaTermStar<ExprQuery>> ">>" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Bag( ast::Bag{values}.ast(lo..hi) ) },
     ! => { errors.push(<>); ast::Expr{ kind: ast::ExprKind::Error} },
 }
 
-#[inline]
-ExprTermArray: ast::Expr = {
-    <ExprTermArrayBrackets>,
-    <ExprTermArrayParens>
-}
-#[inline]
-ExprTermArrayBrackets: ast::Expr = {
-    <lo:@L> "[" <values:CommaTermStar<ExprQuery>> "]" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) }
-}
-#[inline]
-ExprTermArrayParens: ast::Expr = {
-    <lo:@L> "(" <values:CommaTermPlus<ExprQuery>> ")" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
-}
-
-#[inline]
-ExprTermBag: ast::Expr = {
-    <lo:@L> "<<" <values:CommaTermStar<ExprQuery>> ">>" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Bag( ast::Bag{values}.ast(lo..hi) ) },
-}
-
-#[inline]
-ExprTermTuple: ast::Expr = {
-    <lo:@L> "{" <fields:CommaTermStar<ExprPair>> "}" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Struct( ast::Struct{fields}.ast(lo..hi) ) }
-}
-
-ExprPair: ast::ExprPair = {
+ExprPairFromColon: ast::ExprPair = {
     <lo:@L> <first:ExprQuery> ":" <second:ExprQuery> <hi:@R> => ast::ExprPair{ first, second },
 }
 
@@ -840,7 +851,6 @@ PathExpr: ast::Path = {
         ast::Path{ root: Box::new(root), steps: vec![] }
     },
 }
-
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -908,7 +918,6 @@ LiteralNumber: ast::Lit = {
 LiteralIon: ast::Lit = {
     <ion:"Ion"> => ast::Lit::IonStringLit(ion.to_owned()),
 }
-
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -1027,9 +1036,12 @@ extern {
         "AT" => lexer::Token::At,
         "BETWEEN" => lexer::Token::Between,
         "BY" => lexer::Token::By,
+        "CASE" => lexer::Token::Case,
         "CROSS" => lexer::Token::Cross,
         "DESC" => lexer::Token::Desc,
         "DISTINCT" => lexer::Token::Distinct,
+        "ELSE" => lexer::Token::Else,
+        "END" => lexer::Token::End,
         "ESCAPE" => lexer::Token::Escape,
         "EXCEPT" => lexer::Token::Except,
         "FALSE" => lexer::Token::False,
@@ -1063,12 +1075,13 @@ extern {
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
+        "THEN" => lexer::Token::Then,
         "TRUE" => lexer::Token::True,
         "UNION" => lexer::Token::Union,
         "UNPIVOT" => lexer::Token::Unpivot,
         "USING" => lexer::Token::Using,
         "VALUE" => lexer::Token::Value,
-        "VALUES" => lexer::Token::Values,
+        "WHEN" => lexer::Token::When,
         "WHERE" => lexer::Token::Where,
         "WITH" => lexer::Token::With,
     }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -749,6 +749,14 @@ ExprPrecedence01: ast::Expr = {
 //
 // Simple Case Example:
 // CASE hello WHEN titanId IS NOT NULL THEN (SELECT * FROM data) ELSE 1 END
+//
+// The following is not allowed:
+// CASE hello WHEN titanId IS NOT NULL THEN SELECT * FROM data ELSE 1 END
+//
+// This becaue as per SQL-92 standard THEN <result> ultimately leads to
+// the following:
+// <subquery> ::= <left paren> <query expression> <right paren>
+
 
 CaseExpr: ast::CaseAst = {
     <lo:@L> "CASE" <expr:ExprQuery?> <cases:ExprPairWhenThen+> <elsexpr:ElseClause?> "END" <hi:@R> => {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -91,6 +91,16 @@ pub SingleQuery: ast::QuerySetAst = {
         }
     },
     <lo:@L> <sfw:SfwQuery> <hi:@R> => ast::QuerySet::Select( Box::new(sfw) ).ast(lo..hi),
+    <lo:@L> <values:Values> <hi:@R> => values,
+}
+
+Values: ast::QuerySetAst = {
+    <lo:@L> "VALUES" <rows:CommaSepPlus<ValueRow>> <hi:@R> => ast::QuerySet::Values( rows ).ast(lo..hi)
+}
+
+#[inline]
+ValueRow: Box<ast::Expr> = {
+    <array:ExprTermArrayParens> => Box::new(array)
 }
 
 // ------------------------------------------------------------------------------ //
@@ -200,7 +210,7 @@ Projection: ast::ProjectItemAst = {
 FromClause: ast::FromClauseAst = {
     <lo:@L> "FROM" <mut froms:(<TableReference> "," "LATERAL"?)*> <last:TableReference> <hi:@R> => {
         let total: Location<BytePosition> = Location::from(lo.into()..hi.into());
-	
+
         // use `reduce` to process the comma-seperated `TableReference`s
         //   as left-associative `CROSS JOIN`s
         froms.push(last);
@@ -736,7 +746,6 @@ ExprPrecedence01: ast::Expr = {
     <ExprTerm>,
 };
 
-
 // ------------------------------------------------------------------------------ //
 //                                                                                //
 //                               Case Expression                                  //
@@ -757,18 +766,17 @@ ExprPrecedence01: ast::Expr = {
 // the following:
 // <subquery> ::= <left paren> <query expression> <right paren>
 
-
 CaseExpr: ast::CaseAst = {
     <lo:@L> "CASE" <expr:ExprQuery?> <cases:ExprPairWhenThen+> <elsexpr:ElseClause?> "END" <hi:@R> => {
         match expr {
             None => ast::Case {
                 kind: ast::CaseKind::SearchedCase(
-                    ast::SearchedCase { cases: Vec::new(), default: elsexpr }
+                    ast::SearchedCase { cases, default: elsexpr }
                 )
             }.ast(lo..hi),
             Some(expr) => ast::Case {
                 kind: ast::CaseKind::SimpleCase(
-                    ast::SimpleCase { expr, cases: Vec::new(), default: elsexpr }
+                    ast::SimpleCase { expr, cases, default: elsexpr }
                 )
             }.ast(lo..hi)
         }
@@ -787,14 +795,37 @@ pub ExprTerm: ast::Expr = {
     "(" <q:Query> ")" => *q,
     <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
     <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
-    <lo:@L> "{" <fields:CommaTermStar<ExprPairFromColon>> "}" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Struct( ast::Struct{fields}.ast(lo..hi) ) },
-    <lo:@L> "[" <values:CommaTermStar<ExprQuery>> "]" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
-    <lo:@L> "(" <values:CommaTermPlus<ExprQuery>> ")" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
-    <lo:@L> "<<" <values:CommaTermStar<ExprQuery>> ">>" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Bag( ast::Bag{values}.ast(lo..hi) ) },
+    <ExprTermArray>,
+    <ExprTermBag>,
+    <ExprTermTuple>,
     ! => { errors.push(<>); ast::Expr{ kind: ast::ExprKind::Error} },
 }
 
-ExprPairFromColon: ast::ExprPair = {
+#[inline]
+ExprTermArray: ast::Expr = {
+    <ExprTermArrayBrackets>,
+    <ExprTermArrayParens>
+}
+#[inline]
+ExprTermArrayBrackets: ast::Expr = {
+    <lo:@L> "[" <values:CommaTermStar<ExprQuery>> "]" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) }
+}
+#[inline]
+ExprTermArrayParens: ast::Expr = {
+    <lo:@L> "(" <values:CommaTermPlus<ExprQuery>> ")" <hi:@R> => ast::Expr{ kind: ast::ExprKind::List( ast::List{values}.ast(lo..hi) ) },
+}
+
+#[inline]
+ExprTermBag: ast::Expr = {
+    <lo:@L> "<<" <values:CommaTermStar<ExprQuery>> ">>" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Bag( ast::Bag{values}.ast(lo..hi) ) },
+}
+
+#[inline]
+ExprTermTuple: ast::Expr = {
+    <lo:@L> "{" <fields:CommaTermStar<ExprPair>> "}" <hi:@R> => ast::Expr{ kind: ast::ExprKind::Struct( ast::Struct{fields}.ast(lo..hi) ) }
+}
+
+ExprPair: ast::ExprPair = {
     <lo:@L> <first:ExprQuery> ":" <second:ExprQuery> <hi:@R> => ast::ExprPair{ first, second },
 }
 
@@ -859,6 +890,7 @@ PathExpr: ast::Path = {
         ast::Path{ root: Box::new(root), steps: vec![] }
     },
 }
+
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -926,6 +958,7 @@ LiteralNumber: ast::Lit = {
 LiteralIon: ast::Lit = {
     <ion:"Ion"> => ast::Lit::IonStringLit(ion.to_owned()),
 }
+
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -1089,6 +1122,7 @@ extern {
         "UNPIVOT" => lexer::Token::Unpivot,
         "USING" => lexer::Token::Using,
         "VALUE" => lexer::Token::Value,
+        "VALUES" => lexer::Token::Values,
         "WHEN" => lexer::Token::When,
         "WHERE" => lexer::Token::Where,
         "WITH" => lexer::Token::With,


### PR DESCRIPTION
*Issue #, if available:* #119, #108

*Description of changes:*

Adds CASE expression parsing

GitHub Issue: #119

Adds the required constructs to enable CASE EXPRESSION parsing. The PR includes changes to `partiql-ast` and `partiql-parser` to handle`SearchedCase` and `SimpleCase` parsing.

See the mentioned GitHub issue for more details.

As a result of the changes in this PR, the conformance tests in the following pass:
https://github.com/partiql/partiql-tests/blob/main/partiql-test-data/pass/parser/primitives/case.ion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
