### PR TITLE
Add remaining path navigation to parser

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -576,7 +576,6 @@ pub enum PathStep {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PathExpr {
     pub index: Box<Expr>,
-    pub case: CaseSensitivity,
 }
 
 /// Is used to determine if variable lookup should be case-sensitive or not.
@@ -871,6 +870,8 @@ pub struct CustomType {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SymbolPrimitive {
     pub value: String,
+    // Quoted denotes a symbol in double quotes. e.g. "date"
+    pub dbl_quoted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -870,7 +870,7 @@ pub struct CustomType {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SymbolPrimitive {
     pub value: String,
-    // Quoted denotes a symbol in double quotes. e.g. "date"
+    // E.g. "date"
     pub dbl_quoted: bool,
 }
 

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -22,6 +22,7 @@ fn test_ast_init() {
 
     let span_only = ast::SymbolPrimitive {
         value: "symbol1".to_string(),
+        dbl_quoted: false,
     }
     .to_node()
     .location(Location {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -741,7 +741,7 @@ ExprPrecedence01: ast::Expr = {
     <casexpr:CaseExpr> => ast::Expr {
         kind: ast::ExprKind::Case(casexpr)
     },
-    <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
+    <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr { kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
     <ExprTerm>,
 };
 
@@ -846,6 +846,11 @@ FunctionCall: ast::Call = {
         },
 }
 
+// ------------------------------------------------------------------------------ //
+//                                                                                //
+//                               Path Navigation                                  //
+//                                                                                //
+// ------------------------------------------------------------------------------ //
 // Implementation of Path Navigation as specified by PartiQL Specification Section 4:
 // https://partiql.org/assets/PartiQL-Specification.pdf
 //
@@ -857,7 +862,7 @@ FunctionCall: ast::Call = {
 // a.b.c
 // "a".b
 // "a"."b"
-// { 'a': 1, 'b': 2}.a
+// { 'a': 1, 'b': 2 }.a
 // [1, 2][1]
 // foo(x, y).a
 // (SELECT a from en).b
@@ -913,6 +918,13 @@ PathExpr: ast::Path = {
          steps.push(step);
          ast::Path{ root:path.root, steps }
     },
+    <lo:@L> <path:PathExpr>  "." "*" <hi:@R> => {
+         let step = ast::PathStep::PathUnpivot;
+
+         let mut steps = path.steps;
+         steps.push(step);
+         ast::Path{ root:path.root, steps }
+    },
     // TODO Add path expression with CAST E.g. {'attr': 1, 'b':2}[CAST('at' || 'tr' AS STRING)]
     // once https://github.com/partiql/partiql-lang-rust/pull/122 is merged
     <lo:@L> <path:PathExpr>  "[" <expr:ExprQuery> "]" <hi:@R> => {
@@ -924,13 +936,6 @@ PathExpr: ast::Path = {
         let mut steps = path.steps;
         steps.push(step);
         ast::Path{ root:path.root, steps }
-    },
-    <lo:@L> <path:PathExpr>  "." "*" <hi:@R> => {
-         let step = ast::PathStep::PathUnpivot;
-
-         let mut steps = path.steps;
-         steps.push(step);
-         ast::Path{ root:path.root, steps }
     },
     <v:VarRefExpr> => {
         ast::Path{ root: Box::new(v), steps: vec![] }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -198,9 +198,8 @@ SetQuantifierStrategy: ast::SetQuantifier = {
 Projection: ast::ProjectItemAst = {
     <lo:@L> <expr:ExprQuery> <hi:@R>
         => ast::ProjectItem::ProjectExpr( ast::ProjectExpr{ expr, as_alias: None } ).ast(lo..hi),
-    <lo:@L> <expr:ExprQuery> "AS"? <ident:"Identifier"> <hi:@R> => {
-        let as_alias = Some( ast::SymbolPrimitive{ value:ident.to_owned()} );
-        ast::ProjectItem::ProjectExpr( ast::ProjectExpr{ expr, as_alias } ).ast(lo..hi)
+    <lo:@L> <expr:ExprQuery> "AS"? <as_alias:SymbolPrimitive> <hi:@R> => {
+        ast::ProjectItem::ProjectExpr( ast::ProjectExpr{ expr, as_alias: Some(as_alias) } ).ast(lo..hi)
     },
 }
 
@@ -252,11 +251,11 @@ TableBaseReference: ast::FromLetAst = {
             by_alias: None
         }.ast(lo..hi)
     },
-    <lo:@L> <e:ExprQuery> "AS"? <ident_as:"Identifier"> <hi:@R> => {
+    <lo:@L> <e:ExprQuery> "AS"? <as_alias:SymbolPrimitive> <hi:@R> => {
         ast::FromLet {
             expr: e,
             kind: ast::FromLetKind::Scan,
-            as_alias: Some(ast::SymbolPrimitive{ value: ident_as.to_owned() }),
+            as_alias: Some(as_alias),
             at_alias: None,
             by_alias: None
         }.ast(lo..hi)
@@ -265,12 +264,12 @@ TableBaseReference: ast::FromLetAst = {
 
 #[inline]
 TableUnpivot: ast::FromLetAst = {
-    <lo:@L> "UNPIVOT" <e:ExprQuery> "AS"? <ident_as:"Identifier"> "AT" <ident_at:"Identifier"> <hi:@R> => {
+    <lo:@L> "UNPIVOT" <e:ExprQuery> "AS"? <ident_as:SymbolPrimitive> "AT" <ident_at:SymbolPrimitive> <hi:@R> => {
         ast::FromLet {
             expr: e,
             kind: ast::FromLetKind::Unpivot,
-            as_alias: Some(ast::SymbolPrimitive{ value: ident_as.to_owned() }),
-            at_alias: Some(ast::SymbolPrimitive{ value: ident_at.to_owned() }),
+            as_alias: Some(ident_as),
+            at_alias: Some(ident_at),
             by_alias: None,
         }.ast(lo..hi)
     }
@@ -373,12 +372,12 @@ GroupStrategy: ast::GroupingStrategy = {
 GroupKey: ast::GroupKeyAst = {
     <lo:@L> <expr:ExprQuery> <hi:@R>
         => ast::GroupKey{ expr, as_alias: None }.ast(lo..hi),
-    <lo:@L> <expr:ExprQuery> "AS" <ident:"Identifier"> <hi:@R>
-        => ast::GroupKey{ expr, as_alias: Some( ast::SymbolPrimitive{ value:ident.to_owned()} ) }.ast(lo..hi),
+    <lo:@L> <expr:ExprQuery> "AS" <as_alias:SymbolPrimitive> <hi:@R>
+        => ast::GroupKey{ expr, as_alias: Some(as_alias) }.ast(lo..hi),
 }
 #[inline]
 GroupAlias: ast::SymbolPrimitive = {
-    "GROUP" "AS" <ident:"Identifier"> => ast::SymbolPrimitive{ value:ident.to_owned() }
+    "GROUP" "AS" <SymbolPrimitive>
 }
 
 // ------------------------------------------------------------------------------ //
@@ -734,7 +733,6 @@ ExprPrecedence03: ast::Expr = {
 
 #[inline]
 ExprPrecedence02: ast::Expr = {
-    <lo:@L> <call:FunctionCall> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Call( call.ast(lo..hi) ) },
     <ExprPrecedence01>,
 }
 
@@ -743,8 +741,15 @@ ExprPrecedence01: ast::Expr = {
     <casexpr:CaseExpr> => ast::Expr {
         kind: ast::ExprKind::Case(casexpr)
     },
+    <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
     <ExprTerm>,
 };
+
+pub ExprTerm: ast::Expr = {
+    <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
+    <ExprTermBag>,
+    ! => { errors.push(<>); ast::Expr{ kind: ast::ExprKind::Error} },
+}
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -791,16 +796,6 @@ ExprPairWhenThen: ast::ExprPair = {
     <lo:@L> "WHEN" <first:ExprQuery> "THEN" <second:ExprQuery> <hi:@R> => ast::ExprPair { first, second },
 };
 
-pub ExprTerm: ast::Expr = {
-    "(" <q:Query> ")" => *q,
-    <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
-    <lo:@L> <path:PathExpr> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Path( path.ast(lo..hi) ) },
-    <ExprTermArray>,
-    <ExprTermBag>,
-    <ExprTermTuple>,
-    ! => { errors.push(<>); ast::Expr{ kind: ast::ExprKind::Error} },
-}
-
 #[inline]
 ExprTermArray: ast::Expr = {
     <ExprTermArrayBrackets>,
@@ -831,66 +826,146 @@ ExprPair: ast::ExprPair = {
 
 #[inline]
 FunctionCall: ast::Call = {
-    <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> ")" =>
+    <func_name:"UnquotedIdent"> "(" <strategy: SetQuantifierStrategy> ")" =>
         ast::Call {
-            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned(), dbl_quoted: false },
             args: Vec::new(),
             setq: Some(strategy)
         },
-     <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> "*" ")" =>
+     <func_name:"UnquotedIdent"> "(" <strategy: SetQuantifierStrategy> "*" ")" =>
          ast::Call {
-            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned(), dbl_quoted: false },
             args: Vec::new(),
             setq: Some(strategy)
          },
-    <func_name:"Identifier"> "(" <strategy: SetQuantifierStrategy> <args:CommaSepPlus<ExprQuery>> ")" =>
+    <func_name:"UnquotedIdent"> "(" <strategy: SetQuantifierStrategy> <args:CommaSepPlus<ExprQuery>> ")" =>
         ast::Call {
-            func_name: ast::SymbolPrimitive{ value: func_name.to_owned() },
+            func_name: ast::SymbolPrimitive{ value: func_name.to_owned(), dbl_quoted: false },
             args,
             setq: Some(strategy)
         },
 }
 
+// Implementation of Path Navigation as specified by PartiQL Specification Section 4:
+// https://partiql.org/assets/PartiQL-Specification.pdf
+//
+// Examples:
+// a.b
+// a.*
+// a.[*]
+// a[*]
+// a.b.c
+// "a".b
+// "a"."b"
+// { 'a': 1, 'b': 2}.a
+// [1, 2][1]
+// foo(x, y).a
+// (SELECT a from en).b
+//
+// See the path expression conformance tests under `partiql-tests` for more examples.
 PathExpr: ast::Path = {
-    <lo:@L> <path:PathExpr> "." <ident:"Identifier"> <hi:@R> => {
+    <path:PathExpr>  "." <v:VarRefExpr> => {
         let step = ast::PathStep::PathExpr(
             ast::PathExpr{
-                index: Box::new(ast::Expr{
-                    kind: ast::ExprKind::VarRef(ast::VarRef {
-                        name: ast::SymbolPrimitive { value: ident.to_owned() },
-                        case: ast::CaseSensitivity::CaseInsensitive,
-                        qualifier: ast::ScopeQualifier::Unqualified
-                    }.ast(lo..hi)),
-                }),
-                case: ast::CaseSensitivity::CaseInsensitive,
+                index: Box::new(v),
             });
 
         let mut steps = path.steps;
         steps.push(step);
         ast::Path{ root:path.root, steps }
     },
-    <lo:@L> <ident:"Identifier"> <hi:@R> => {
-        let root = ast::Expr{
-            kind: ast::ExprKind::VarRef(ast::VarRef {
-                name: ast::SymbolPrimitive { value: ident.to_owned() },
-                case: ast::CaseSensitivity::CaseInsensitive,
-                qualifier: ast::ScopeQualifier::Unqualified
-            }.ast(lo..hi)),
-        };
+    <lo:@L> <path:PathExpr>  "." <s:"String"> <hi:@R> => {
+        let step = ast::PathStep::PathExpr(
+            ast::PathExpr{
+                index: Box::new(ast::Expr{
+                    kind: ast::ExprKind::VarRef(ast::VarRef {
+                        name: ast::SymbolPrimitive { value: s.to_owned(), dbl_quoted: false },
+                        case: ast::CaseSensitivity::CaseSensitive,
+                        qualifier: ast::ScopeQualifier::Unqualified
+                    }.ast(lo..hi)),
+                }),
+            });
+
+        let mut steps = path.steps;
+        steps.push(step);
+        ast::Path{ root:path.root, steps }
+    },
+    <lo:@L> <path:PathExpr>  "." "[" <s:"String"> "]" <hi:@R> => {
+        let step = ast::PathStep::PathExpr(
+            ast::PathExpr{
+                index: Box::new(ast::Expr{
+                    kind: ast::ExprKind::VarRef(ast::VarRef {
+                        name: ast::SymbolPrimitive { value: s.to_owned(), dbl_quoted: false },
+                        case: ast::CaseSensitivity::CaseSensitive,
+                        qualifier: ast::ScopeQualifier::Unqualified
+                    }.ast(lo..hi)),
+                }),
+            });
+
+        let mut steps = path.steps;
+        steps.push(step);
+        ast::Path{ root:path.root, steps }
+    },
+    <lo:@L> <path:PathExpr>  "[" "*" "]" <hi:@R> => {
+         let step = ast::PathStep::PathWildCard;
+
+         let mut steps = path.steps;
+         steps.push(step);
+         ast::Path{ root:path.root, steps }
+    },
+    // TODO Add path expression with CAST E.g. {'attr': 1, 'b':2}[CAST('at' || 'tr' AS STRING)]
+    // once https://github.com/partiql/partiql-lang-rust/pull/122 is merged
+    <lo:@L> <path:PathExpr>  "[" <expr:ExprQuery> "]" <hi:@R> => {
+        let step = ast::PathStep::PathExpr(
+            ast::PathExpr{
+                index: Box::new(*expr),
+            });
+
+        let mut steps = path.steps;
+        steps.push(step);
+        ast::Path{ root:path.root, steps }
+    },
+    <lo:@L> <path:PathExpr>  "." "*" <hi:@R> => {
+         let step = ast::PathStep::PathUnpivot;
+
+         let mut steps = path.steps;
+         steps.push(step);
+         ast::Path{ root:path.root, steps }
+    },
+    <v:VarRefExpr> => {
+        ast::Path{ root: Box::new(v), steps: vec![] }
+    },
+    <t:ExprTermTuple> => {
+        ast::Path{ root: Box::new(t), steps: vec![] }
+    },
+    <a:ExprTermArray> => {
+        ast::Path{ root: Box::new(a), steps: vec![] }
+    },
+    <lo:@L> <call:FunctionCall> <hi:@R> => {
+        let root = ast::Expr { kind: ast::ExprKind::Call( call.ast(lo..hi) ) };
         ast::Path{ root: Box::new(root), steps: vec![] }
     },
-    <lo:@L> <ident:"AtIdentifier"> <hi:@R> => {
-        let root = ast::Expr{
-            kind: ast::ExprKind::VarRef(ast::VarRef {
-                name: ast::SymbolPrimitive { value: ident.to_owned() },
-                case: ast::CaseSensitivity::CaseInsensitive,
-                qualifier: ast::ScopeQualifier::Qualified
-            }.ast(lo..hi)),
-        };
-        ast::Path{ root: Box::new(root), steps: vec![] }
+    "(" <q:Query> ")"  => {
+        ast::Path{ root: Box::new(*q), steps: vec![] }
     },
 }
 
+VarRefExpr: ast::Expr = {
+    <lo:@L> <ident:"UnquotedIdent"> <hi:@R> => ast::Expr {
+        kind: ast::ExprKind::VarRef(ast::VarRef {
+            name: ast::SymbolPrimitive { value: ident.to_owned(), dbl_quoted: false },
+            case: ast::CaseSensitivity::CaseInsensitive,
+            qualifier: ast::ScopeQualifier::Unqualified
+        }.ast(lo..hi)),
+    },
+    <lo:@L> <ident:"QuotedIdent"> <hi:@R> => ast::Expr {
+      kind: ast::ExprKind::VarRef(ast::VarRef {
+          name: ast::SymbolPrimitive { value: ident.to_owned(), dbl_quoted: false },
+          case: ast::CaseSensitivity::CaseSensitive,
+          qualifier: ast::ScopeQualifier::Unqualified
+      }.ast(lo..hi)),
+    },
+};
 
 // ------------------------------------------------------------------------------ //
 //                                                                                //
@@ -959,7 +1034,6 @@ LiteralIon: ast::Lit = {
     <ion:"Ion"> => ast::Lit::IonStringLit(ion.to_owned()),
 }
 
-
 // ------------------------------------------------------------------------------ //
 //                                                                                //
 //                                  Utilities                                     //
@@ -1009,6 +1083,17 @@ CommaSepPlus<T>: Vec<T> = {
         v.push(e);
         v
     }
+};
+
+SymbolPrimitive: ast::SymbolPrimitive = {
+    <ident:"UnquotedIdent"> => ast::SymbolPrimitive {
+        value: ident.to_owned(),
+        dbl_quoted: false,
+    },
+    <ident:"QuotedIdent"> => ast::SymbolPrimitive {
+        value: ident.to_owned(),
+        dbl_quoted: true,
+    },
 };
 
 // ------------------------------------------------------------------------------ //
@@ -1061,7 +1146,8 @@ extern {
 
 
         // Types
-        "Identifier" => lexer::Token::Identifier(<&'input str>),
+        "UnquotedIdent" => lexer::Token::UnquotedIdent(<&'input str>),
+        "QuotedIdent" => lexer::Token::QuotedIdent(<&'input str>),
         "AtIdentifier" => lexer::Token::AtIdentifier(<&'input str>),
         "Int" => lexer::Token::Int(<&'input str>),
         "Real" => lexer::Token::Real(<&'input str>),


### PR DESCRIPTION
*Issue #, if available:* #121 #108

*Description of changes:*
This PR includes changes for enabling Parser to parse
Path Navigations as specified in Section 4 of PartiQL
Specification. It ensures the following tests go through:
https://github.com/partiql/partiql-tests/blob/c76715ddb95ba6eec2d34ca500077b6e7eba9e35/partiql-test-data/pass/parser/primitives/path-expression.ion

In addition, the PR introduces `dbl_quoted` property to `SymbolPrimitive`
in order to cater for symbol primitives that are double quoted, e.g.
`AS "date".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
