### PR TITLE
Fix downloaded conformance report directory

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -133,9 +133,9 @@ jobs:
           branch: main
       - name: backup case if download fails
         if: ${{ steps.download-report.outcome == 'failure' }}
-        run: mkdir -p main-branch-report && cp -r ./partiql-conformance-tests/backup_conformance_report.json ./main-branch-report/cts_report.json
+        run: mkdir -p artifact && cp -r ./partiql-conformance-tests/backup_conformance_report.json ./artifact/cts_report.json
       # Run conformance report comparison. Generates cts-comparison-report.md
-      - run: ./target/debug/generate_comparison_report ./main-branch-report/cts_report.json cts_report.json cts-comparison-report.md
+      - run: ./target/debug/generate_comparison_report ./artifact/cts_report.json cts_report.json cts-comparison-report.md
       # Print conformance report to GitHub actions workflow summary page
       - name: print markdown in run
         run: cat cts-comparison-report.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
GitHub actions failed for a previous build due to a mismatch between the downloaded conformance artifact directory and the expected path of the conformance artifact. Example build failure: https://github.com/partiql/partiql-lang-rust/runs/6780646755?check_suite_focus=true

This PR should fix the directory mismatch.

Still awaiting the result of the GitHub actions run to ensure the directory mismatch is resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
