### PR TITLE
Update git submodule following conformance refactor; refactor schema objects + generation

### DIFF
--- a/partiql-conformance-test-generator/src/generator.rs
+++ b/partiql-conformance-test-generator/src/generator.rs
@@ -54,7 +54,7 @@ fn test_case_to_function(test_case: &TestCase) -> Function {
             }
             Assertion::NotYetImplemented => {
                 // for `NotYetImplemented` assertions, add the 'ignore' annotation to the test case
-                test_fn.attr("ignore");
+                test_fn.attr("ignore = \"not yet implemented\"");
             }
         }
     }

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -2,9 +2,8 @@ pub mod generator;
 mod schema;
 pub mod util;
 
-use crate::schema::TestCaseKind::{NotYetImplemented, Parse};
 use crate::schema::{
-    Namespace, Namespaces, ParseAssertions, ParseTestCase, TestCase, TestCases, TestDocument,
+    Assertion, Assertions, Namespace, Namespaces, TestCase, TestCases, TestDocument,
 };
 use crate::util::StringExt;
 use ion_rs::value::owned::OwnedElement;
@@ -108,14 +107,12 @@ pub fn test_namespace(element: &OwnedElement) -> Namespace {
     }
 }
 
-/// Parses the given IonStruct to a `TestCase`. Requires for there to be an annotation indicating
-/// the test case category (currently limited to just 'parse'). The IonStruct requires two string
-/// fields with the 'name' and 'statement'.
+/// Parses the given IonStruct to a `TestCase`. The IonStruct requires two string fields with the
+/// 'name' and 'statement' in addition to an 'assert' field containing one or more `Assertions`.
 ///
-/// For test case categories that are not supported, will create a `NotYetImplemented` test case.
+/// For test assertions that are not supported (e.g. StaticAnalysisFail), the assertion of
+/// `NotYetImplemented` will be used.
 fn test_case(element: &OwnedElement) -> TestCase {
-    let annot: Vec<_> = element.annotations().map(|a| a.text().expect("")).collect();
-
     let test_struct = element.as_struct().expect("struct");
     let test_name = test_struct
         .get("name")
@@ -131,61 +128,47 @@ fn test_case(element: &OwnedElement) -> TestCase {
         .expect("as_str()")
         .to_string();
 
-    if annot.contains(&"parse") {
-        TestCase {
-            test_name,
-            statement,
-            test_kind: Parse(parse_test_case(element)),
-        }
-    } else {
-        TestCase {
-            test_name,
-            statement,
-            test_kind: NotYetImplemented,
-        }
-    }
-}
-
-/// Converts the IonStruct into a `ParseTestCase`. Requires the 'assert' field to be present in the
-/// struct and for it to be an IonStruct or IonList.
-fn parse_test_case(element: &OwnedElement) -> ParseTestCase {
-    let parse_struct = element.as_struct().expect("struct");
-    let assert_field = parse_struct.get("assert").expect("assert");
-    let assertions: Vec<_> = match assert_field.ion_type() {
+    let assert_field = test_struct.get("assert").expect("assert");
+    let assertions_vec: Vec<_> = match assert_field.ion_type() {
         IonType::Struct => vec![assert_field],
         IonType::List => assert_field
             .as_sequence()
             .expect("as_sequence")
             .iter()
             .collect(),
-        _ => panic!("Invalid IonType for the parse test case assertions"),
+        _ => panic!("Invalid IonType for the test case assertions"),
     };
-
-    ParseTestCase {
-        parse_assertions: parse_assertions(&assertions),
+    let assertions = assertions(&assertions_vec);
+    TestCase {
+        test_name,
+        statement,
+        assertions,
     }
 }
 
-/// Converts the vector of Ion values into `ParseAssertions`. Checks that a result field is provided
-/// in the vector and has the symbol 'ParseOk' or 'ParserError', which correspond to
-/// `ParseAssertions::ParsePass` and `ParseAssertions::ParseFail` respectively.
-fn parse_assertions(assertions: &Vec<&OwnedElement>) -> ParseAssertions {
+/// Converts the vector of Ion values into `Assertions`. Checks that a result field is provided
+/// in the vector and has the symbol 'SyntaxSuccess' or 'SyntaxFail', which correspond to
+/// `Assertion::SyntaxSuccess` and `Assertion::SyntaxFail` respectively. Other assertion symbols
+/// will default to `Assertion::NotYetImplemented`
+fn assertions(assertions: &Vec<&OwnedElement>) -> Assertions {
+    let mut test_case_assertions: Assertions = Vec::new();
     for assertion in assertions {
         let assertion_struct = assertion.as_struct().expect("as_struct()");
         let parse_result = assertion_struct.get("result");
         match parse_result {
             Some(r) => {
                 let r_as_str = r.as_str().expect("as_str()");
-                return match r_as_str {
-                    "ParseOk" => ParseAssertions::ParsePass,
-                    "ParseError" => ParseAssertions::ParseFail,
-                    _ => panic!("Unexpected parse result {}", r_as_str),
+                let assertion = match r_as_str {
+                    "SyntaxSuccess" => Assertion::SyntaxSuccess,
+                    "SyntaxFail" => Assertion::SyntaxFail,
+                    _ => Assertion::NotYetImplemented,
                 };
+                test_case_assertions.push(assertion);
             }
             None => (),
         }
     }
-    panic!("Expected a parse result field");
+    test_case_assertions
 }
 
 #[cfg(test)]

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -128,7 +128,7 @@ fn test_case(element: &OwnedElement) -> TestCase {
         .expect("as_str()")
         .to_string();
 
-    let assert_field = test_struct.get("assert").expect("assert");
+    let assert_field = test_struct.get("assert").expect("assert field missing");
     let assertions_vec: Vec<_> = match assert_field.ion_type() {
         IonType::Struct => vec![assert_field],
         IonType::List => assert_field

--- a/partiql-conformance-test-generator/src/schema.rs
+++ b/partiql-conformance-test-generator/src/schema.rs
@@ -1,7 +1,9 @@
 /// Conformance test document containing namespaces and/or tests
-/// TODO: once test ISL is defined in `partiql-tests` (https://github.com/partiql/partiql-tests/issues/3),
-///  add link to ISL. Also, when `ion-schema-rust` supports schema code generation based on .isl,
-///  replace these objects.
+///
+/// Follows the `partiql-tests-data` specified in https://github.com/partiql/partiql-tests/blob/main/partiql-tests-data/partiql-tests-schema.isl.
+///
+/// TODO: when `ion-schema-rust` supports schema code generation based on .isl, replace these
+///  objects.
 pub struct TestDocument {
     pub(crate) namespaces: Namespaces,
     pub(crate) test_cases: TestCases,
@@ -16,32 +18,26 @@ pub struct Namespace {
 }
 pub type TestCases = Vec<TestCase>;
 
-/// Test cases have a `test_name` and a PartiQL `statement` along with additional test fields stored
-/// depending on the `test_kind`.
+/// Test cases have a `test_name` and a PartiQL `statement` along with the `assertions` to check for
+/// expected behavior(s). In the future, additional fields will be added the `TestCase` struct for
+/// additional testing configurations.
 pub struct TestCase {
     pub(crate) test_name: String,
     pub(crate) statement: String,
-    pub(crate) test_kind: TestCaseKind,
+    pub(crate) assertions: Assertions,
 }
+pub type Assertions = Vec<Assertion>;
 
-/// Test case kind
+/// Assertion specifies expected behaviors to be checked in the given test case.
 ///
-/// Currently, just supports `Parse` test cases. In the future, other test case variants will be
-/// added (e.g. evaluation, type-checking). For now, the other test case variants will be
+/// Currently just supports 'Syntax'-related assertions. In the future, other assertion variants
+/// will be added (e.g. static analysis, evaluation). For now, the other assertions will be
 /// `NotYetImplemented`.
-pub enum TestCaseKind {
-    Parse(ParseTestCase),
+pub enum Assertion {
+    /// Asserts statement is syntactically correct
+    SyntaxSuccess,
+    /// Asserts statement has at least one syntax error
+    SyntaxFail,
+    /// Assertion that has yet to be implemented
     NotYetImplemented,
-}
-
-/// Test case to test the parsing behavior of a PartiQL statement
-pub struct ParseTestCase {
-    pub(crate) parse_assertions: ParseAssertions,
-}
-
-/// Indicates whether a parsing test passes (`ParsePass`) without errors or fails (`ParseFail`) with
-/// a parsing-related error
-pub enum ParseAssertions {
-    ParsePass,
-    ParseFail,
 }


### PR DESCRIPTION
Updates the conformance test runner following https://github.com/partiql/partiql-tests/pull/18 and some other commits, which
- updated the test schema (i.e. `parse` -> `syntax`, `semantic` -> `static analysis` and remove test annotation)
- added some data/time tests
- moved some `IN` clause tests from `syntax` to `static analysis`

Due to the updated test schema, I had to update the parsing of the test data. I also did a slight refactor of the test data schema objects and the test generator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
