### PR TITLE
Fix parsing for dot following arr and [*] path and add `TABLE` keyword

### DIFF
--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -606,6 +606,8 @@ pub enum Token<'input> {
     Right,
     #[regex("(?i:Select)")]
     Select,
+    #[regex("(?i:Table)")]
+    Table,
     #[regex("(?i:Time)")]
     Time,
     #[regex("(?i:Timestamp)")]
@@ -680,6 +682,7 @@ impl<'input> Token<'input> {
                 | Token::Preserve
                 | Token::Right
                 | Token::Select
+                | Token::Table
                 | Token::Time
                 | Token::Timestamp
                 | Token::Then
@@ -789,6 +792,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Preserve
             | Token::Right
             | Token::Select
+            | Token::Table
             | Token::Time
             | Token::Timestamp
             | Token::Then
@@ -826,7 +830,7 @@ mod tests {
             "WiTH Where Value uSiNg Unpivot UNION True Select right Preserve pivoT Outer Order Or \
              On Offset Nulls Null Not Natural Missing Limit Like Left Lateral Last Join \
              Intersect Is Inner In Having Group From For Full First False Except Escape Desc \
-             Cross Time Timestamp Date By Between At As And Asc All Values Case When Then Else End";
+             Cross Table Time Timestamp Date By Between At As And Asc All Values Case When Then Else End";
         let symbols = symbols.split(' ').chain(primitives.split(' '));
         let keywords = keywords.split(' ');
 
@@ -846,9 +850,9 @@ mod tests {
             "LATERAL", ".", "LAST", "||", "JOIN", ":", "INTERSECT", "--", "IS", "/**/", "INNER",
             "<unquoted_ident:UNQUOTED_IDENT>", "IN", "<quoted_ident:QUOTED_IDENT>", "HAVING",
             "<unquoted_atident:UNQUOTED_ATIDENT>", "GROUP", "<quoted_atident:QUOTED_ATIDENT>",
-            "FROM", "FOR", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC", "CROSS", "TIME",
-            "TIMESTAMP", "DATE", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES", "CASE",
-            "WHEN", "THEN", "ELSE", "END"
+            "FROM", "FOR", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC", "CROSS", "TABLE",
+            "TIME", "TIMESTAMP", "DATE", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES",
+            "CASE", "WHEN", "THEN", "ELSE", "END"
         ];
         let displayed = toks
             .into_iter()

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -302,12 +302,12 @@ mod tests {
 
         #[test]
         fn query() {
-            parse!(r#"(SELECT a FROM table).a"#);
-            parse!(r#"(SELECT a FROM table).'a'"#);
-            parse!(r#"(SELECT a FROM table)."a""#);
-            parse!(r#"(SELECT a FROM table)['a']"#);
-            parse!(r#"(SELECT a FROM table).*"#);
-            parse!(r#"(SELECT a FROM table)[*]"#);
+            parse!(r#"(SELECT a FROM t).a"#);
+            parse!(r#"(SELECT a FROM t).'a'"#);
+            parse!(r#"(SELECT a FROM t)."a""#);
+            parse!(r#"(SELECT a FROM t)['a']"#);
+            parse!(r#"(SELECT a FROM t).*"#);
+            parse!(r#"(SELECT a FROM t)[*]"#);
         }
 
         #[test]
@@ -317,6 +317,7 @@ mod tests {
             parse!(r#"foo(x, y)[*]"#);
             parse!(r#"foo(x, y)[5]"#);
             parse!(r#"foo(x, y).a.*"#);
+            parse!(r#"foo(x, y)[*].*.b[5]"#);
         }
 
         #[test]

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -750,11 +750,37 @@ ExprPrecedence03: ast::Expr = {
     <ExprPrecedence02>,
 }
 
+ExprPrecedence02: ast::Expr = {
+     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
+        kind: ast::ExprKind::Path( expr.ast(lo..hi) )
+      },
+    <ExprPrecedence01>,
+}
+
 PathExpr: ast::Path = {
     <l:ExprPrecedence01> "." <steps:PathSteps> => ast::Path { root:Box::new(l), steps },
-    <l:ExprPrecedence01> "." "*" => ast::Path {
-        root:Box::new(l), steps:vec![ast::PathStep::PathUnpivot]
-     },
+    <l:ExprPrecedence01> "[" "*" "]" "." <s:PathSteps> => {
+        let mut steps = vec![ast::PathStep::PathWildCard];
+        steps.extend(s);
+        ast::Path {
+            root:Box::new(l),
+            steps
+        }
+    },
+    <l:ExprPrecedence01> "[" <expr:ExprQuery> "]" "." <s:PathSteps> => {
+       let step = ast::PathStep::PathExpr(
+        ast::PathExpr{
+                index: Box::new(*expr),
+            }
+        );
+
+        let mut steps = vec![step];
+        steps.extend(s);
+        ast::Path {
+            root:Box::new(l),
+            steps
+        }
+    },
     <l:ExprPrecedence01> "[" "*" "]" => ast::Path {
         root:Box::new(l), steps:vec![ast::PathStep::PathWildCard]
     },
@@ -769,13 +795,6 @@ PathExpr: ast::Path = {
         }
     },
 };
-
-ExprPrecedence02: ast::Expr = {
-     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
-        kind: ast::ExprKind::Path( expr.ast(lo..hi) )
-      },
-    <ExprPrecedence01>,
-}
 
 #[inline]
 ExprPrecedence01: ast::Expr = {
@@ -954,15 +973,13 @@ PathSteps: Vec<ast::PathStep> = {
         let mut steps = path;
         steps.push(step);
         steps
-        // ast::Path{ root:path.root, steps }
     },
-    <lo:@L> <path:PathSteps>  "[" "*" "]" <hi:@R> => {
+    <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
          let step = ast::PathStep::PathWildCard;
 
          let mut steps = path;
          steps.push(step);
          steps
-         // ast::Path{ root:path.root, steps }
     },
     <lo:@L> <path:PathSteps>  "." "*" <hi:@R> => {
          let step = ast::PathStep::PathUnpivot;
@@ -983,7 +1000,21 @@ PathSteps: Vec<ast::PathStep> = {
         let mut steps = path;
         steps.push(step);
         steps
-        // ast::Path{ root:path.root, steps }
+    },
+    "[" "*" "]" => {
+        let steps = vec![ast::PathStep::PathWildCard];
+        steps
+    },
+    "[" <expr:ExprQuery> "]" => {
+        let steps = vec![ast::PathStep::PathExpr(
+            ast::PathExpr{
+            index: Box::new(*expr),
+        })];
+        steps
+    },
+    "*" => {
+        let steps = vec![ast::PathStep::PathUnpivot];
+        steps
     },
     <v:PathExprVarRef> => {
         let step = ast::PathStep::PathExpr(
@@ -992,7 +1023,6 @@ PathSteps: Vec<ast::PathStep> = {
             });
         let steps = vec![step];
         steps
-        // ast::Path{ root: Box::new(v), steps: vec![] }
     },
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -993,8 +993,7 @@ vec![ast::PathStep::PathWildCard];
         steps
     },
     "[" "*" "]" => {
-        let steps = vec![ast::PathStep::PathWildCard];
-        steps
+vec![ast::PathStep::PathWildCard];
     },
     "[" <expr:ExprQuery> "]" => {
 vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -751,9 +751,9 @@ ExprPrecedence03: ast::Expr = {
 }
 
 ExprPrecedence02: ast::Expr = {
-     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
+    <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::Path( expr.ast(lo..hi) )
-      },
+    },
     <ExprPrecedence01>,
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -760,11 +760,10 @@ ExprPrecedence02: ast::Expr = {
 PathExpr: ast::Path = {
     <l:ExprPrecedence01> "." <steps:PathSteps> => ast::Path { root:Box::new(l), steps },
     <l:ExprPrecedence01> "[" "*" "]" "." <s:PathSteps> => {
-        let mut steps = vec![ast::PathStep::PathWildCard];
-        steps.extend(s);
+        let step = ast::PathStep::PathWildCard;
         ast::Path {
-            root:Box::new(l),
-            steps
+            root: Box::new(l),
+            steps: std::iter::once(step).chain(s.into_iter()).collect()
         }
     },
     <l:ExprPrecedence01> "[" <expr:ExprQuery> "]" "." <s:PathSteps> => {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -967,9 +967,7 @@ PathSteps: Vec<ast::PathStep> = {
                 index: Box::new(v),
             });
 
-        let mut steps = path;
-        steps.push(step);
-        steps
+vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
     },
     <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
          let step = ast::PathStep::PathWildCard;

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -962,15 +962,10 @@ FunctionArgName: ast::SymbolPrimitive = {
 // See the path expression conformance tests under `partiql-tests` or parser unit-tests for more examples.
 PathSteps: Vec<ast::PathStep> = {
     <path:PathSteps> "." <v:PathExprVarRef> => {
-        let step = ast::PathStep::PathExpr(
-            ast::PathExpr{
-                index: Box::new(v),
-            });
-
-vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
+        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
     },
     <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
-vec![ast::PathStep::PathWildCard];
+        vec![ast::PathStep::PathWildCard]
     },
     <lo:@L> <path:PathSteps>  "." "*" <hi:@R> => {
          let step = ast::PathStep::PathUnpivot;
@@ -993,20 +988,16 @@ vec![ast::PathStep::PathWildCard];
         steps
     },
     "[" "*" "]" => {
-vec![ast::PathStep::PathWildCard];
+        vec![ast::PathStep::PathWildCard]
     },
     "[" <expr:ExprQuery> "]" => {
-vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
+        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
     },
     "*" => {
-vec![ast::PathStep::PathUnpivot]
+        vec![ast::PathStep::PathUnpivot]
     },
     <v:PathExprVarRef> => {
-        let step = ast::PathStep::PathExpr(
-            ast::PathExpr{
-                index: Box::new(v),
-            });
-vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
+        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
     },
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -773,11 +773,9 @@ PathExpr: ast::Path = {
             }
         );
 
-        let mut steps = vec![step];
-        steps.extend(s);
         ast::Path {
-            root:Box::new(l),
-            steps
+            root: Box::new(l),
+            steps: std::iter::once(step).chain(s.into_iter()).collect()
         }
     },
     <l:ExprPrecedence01> "[" "*" "]" => ast::Path {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -970,11 +970,7 @@ PathSteps: Vec<ast::PathStep> = {
 vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
     },
     <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
-         let step = ast::PathStep::PathWildCard;
-
-         let mut steps = path;
-         steps.push(step);
-         steps
+vec![ast::PathStep::PathWildCard];
     },
     <lo:@L> <path:PathSteps>  "." "*" <hi:@R> => {
          let step = ast::PathStep::PathUnpivot;

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1007,8 +1007,7 @@ vec![ast::PathStep::PathUnpivot]
             ast::PathExpr{
                 index: Box::new(v),
             });
-        let steps = vec![step];
-        steps
+vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
     },
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -997,11 +997,7 @@ vec![ast::PathStep::PathWildCard];
         steps
     },
     "[" <expr:ExprQuery> "]" => {
-        let steps = vec![ast::PathStep::PathExpr(
-            ast::PathExpr{
-            index: Box::new(*expr),
-        })];
-        steps
+vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
     },
     "*" => {
         let steps = vec![ast::PathStep::PathUnpivot];

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1000,8 +1000,7 @@ vec![ast::PathStep::PathWildCard];
 vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
     },
     "*" => {
-        let steps = vec![ast::PathStep::PathUnpivot];
-        steps
+vec![ast::PathStep::PathUnpivot]
     },
     <v:PathExprVarRef> => {
         let step = ast::PathStep::PathExpr(

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1324,7 +1324,7 @@ extern {
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
-        "Table" => lexer::Token::Table,
+        "TABLE" => lexer::Token::Table,
         "TIME" => lexer::Token::Time,
         "TIMESTAMP" => lexer::Token::Timestamp,
         "THEN" => lexer::Token::Then,

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1294,6 +1294,7 @@ extern {
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
+        "Table" => lexer::Token::Table,
         "TIME" => lexer::Token::Time,
         "TIMESTAMP" => lexer::Token::Timestamp,
         "THEN" => lexer::Token::Then,


### PR DESCRIPTION
*Issue #, if available:* #137 #108 

*Description of changes:*
- Fix parsing for path whildcard and array with a dot
    
    This change fixes parsing of expressions like the following:
    `foo(x, y)[*].*.b[5]`
    
    In the above expression a `.` follows a path whildcard

- Add `TABLE` keyword
    This is to ensure the following syntax conformance test passes:
    
```rust
    fn invalid_path_component_keyword_in_path_test() {
        let statement = r#"SELECT foo.id, foo.table FROM `[{id: 1, table: "foos"}]` AS foo"#;
        let res = partiql_parser::Parser::default().parse(statement);
        assert!(
            res.is_err(),
            "For `{}`, expected `Err(_)`, but was `{:#?}`",
            statement,
            res
        );
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
