### PR TITLE
Fix GitHub Actions conformance builds after adding ignored tests to report

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -127,7 +127,7 @@ jobs:
           path: ./*
           key: ${{ github.sha }}-conformance-report
   conformance-report-comparison:
-    name: Create comparison report for PRs
+    name: Create comparison report for `pull_request` event
     runs-on: ubuntu-latest
     needs: [conformance-report]
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Following adding the ignored test info to the conformance test report, https://github.com/partiql/partiql-lang-rust/pull/151, the GitHub Actions build failed on `push` events. The underlying cause was `pull_request` events related to comparing the conformance between commits was accidentally being run on `push` events.

This PR separates the conformance report generation (`push` and `pull_request` events) from the conformance report comparison (just `pull_request` events).

Tested on my fork (after pushing the change to `main`): https://github.com/alancai98/partiql-lang-rust/pull/12 and the report generation works properly again.

It's expected for the conformance report generation for this PR to fail. After it's merged to `main`, subsequent PR report generation should work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
