### PR TITLE
Strip `ast::Query` when it only encloses a `ast::Expr`

### DIFF
--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -2,6 +2,8 @@
 
 //! Provides the [`parse_partiql`] function to parse a PartiQL query.
 
+mod parse_util;
+
 use crate::error::{ParseError, UnexpectedTokenData};
 use crate::lexer;
 use crate::preprocessor::{built_ins, FnExprSet, PreprocessingPartiqlLexer};

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -1,0 +1,25 @@
+use partiql_ast::ast;
+
+// if this is just a parenthesized expr, lift it out of the query AST, otherwise return input
+//      e.g. `(1+2)` should be a ExprKind::Expr, not wrapped deep in a ExprKind::Query
+pub(crate) fn strip_query(q: Box<ast::Expr>) -> Box<ast::Expr> {
+    if let ast::ExprKind::Query(ast::AstNode {
+        node:
+            ast::Query {
+                set:
+                    ast::AstNode {
+                        node: ast::QuerySet::Expr(e),
+                        ..
+                    },
+                order_by: None,
+                limit: None,
+                offset: None,
+            },
+        ..
+    }) = q.kind
+    {
+        e
+    } else {
+        q
+    }
+}

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -11,6 +11,8 @@ use partiql_ast::ast::ToAstNode;
 
 use partiql_source_map::location::{ByteOffset, BytePosition, Location, ToLocated};
 
+use crate::parse::parse_util::{strip_query};
+
 
 grammar<'input, 'err>(input: &'input str,
                       errors: &'err mut Vec<ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>>);
@@ -784,7 +786,7 @@ ExprPrecedence01: ast::Expr = {
 };
 
 ExprTerm: ast::Expr = {
-    "(" <q:Query> ")" => *q,
+    "(" <q:Query> ")" =>  *strip_query(q),
     <lo:@L> <lit:Literal> <hi:@R> => ast::Expr{ kind: ast::ExprKind::Lit( lit.ast(lo..hi) ) },
     <VarRefExpr>,
     <ExprTermCollection>,


### PR DESCRIPTION
e.g., when parsing `((4/2)+(7*7)-2)`

### before
![before](https://user-images.githubusercontent.com/36067/179884205-660b5dbf-ccc5-4971-9254-8be0f8ff0c2e.png)
### after
![after](https://user-images.githubusercontent.com/36067/179884202-f9fd0a2e-bc51-4ed6-a004-93ed5bef419a.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

