### PR TITLE
Make usage of `serde` optional behind feature flag `serde`

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -112,7 +112,7 @@ jobs:
         continue-on-error: true
         run: cargo test --verbose --package partiql-conformance-tests --features "conformance_test" -- -Z unstable-options --format json > cargo_test_results.json
       # Create a conformance report from the `cargo test` json file
-      - run: ./target/debug/generate_cts_report cargo_test_results.json ${GITHUB_SHA} cts_report.json
+      - run: cargo run --features report_tool --bin generate_cts_report cargo_test_results.json ${GITHUB_SHA} cts_report.json
       # Upload conformance report for comparison with future runs
       - name: Upload cts_report.json
         uses: actions/upload-artifact@v3
@@ -164,7 +164,7 @@ jobs:
         if: ${{ steps.download-report.outcome == 'failure' }}
         run: mkdir -p artifact && cp -r ./partiql-conformance-tests/backup_conformance_report.json ./artifact/cts_report.json
       # Run conformance report comparison. Generates cts-comparison-report.md
-      - run: ./target/debug/generate_comparison_report ./artifact/cts_report.json cts_report.json cts-comparison-report.md
+      - run: cargo run --features report_tool --bin generate_comparison_report ./artifact/cts_report.json cts_report.json cts-comparison-report.md
       # Print conformance report to GitHub actions workflow summary page
       - name: print markdown in run
         run: cat cts-comparison-report.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2022-01-10
+          toolchain: nightly-2022-06-11
           override: true
       - name: Cargo Test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ members = [
   "partiql-eval",
   "partiql-irgen",
   "partiql-parser",
-  "partiql-playground",
   "partiql-rewriter",
+]
+
+exclude = [
+  "partiql-playground",
   "partiql-cli"
 ]
+

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -24,8 +24,20 @@ path = "src/lib.rs"
 partiql-source-map = { path = "../partiql-source-map" }
 
 derive_builder = "~0.11.1"
-rust_decimal = "~1.22.0"
-serde = { version = "~1.0.137", features = ["derive"] }
+rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
+
+serde = { version = "1.*", features = ["derive"], optional = true }
+
 
 [dev-dependencies]
+
+
+[features]
+default = []
+serde = [
+  "dep:serde",
+  "partiql-source-map/serde",
+  "rust_decimal/serde-with-str",
+  "rust_decimal/serde"
+]
 

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -9,10 +9,13 @@
 
 use partiql_source_map::location::{ByteOffset, BytePosition, Location};
 use rust_decimal::Decimal as RustDecimal;
-use serde::{Deserialize, Serialize};
+
 use std::fmt;
 use std::fmt::Display;
 use std::ops::Range;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Provides the required methods for AstNode conversations.
 pub trait ToAstNode: Sized {
@@ -68,7 +71,8 @@ impl<T> ToAstNode for T {}
 /// for creating the node. See [ToAstNode] for more details on the usage.
 ///
 /// [1]: https://crates.io/crates/derive_builder
-#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AstNode<T, Loc: Display> {
     pub node: T,
     #[builder(setter(strip_option), default)]
@@ -83,7 +87,8 @@ impl<T: PartialEq, Loc: Display> PartialEq for AstNode<T, Loc> {
 
 impl<T: Eq, Loc: Display> Eq for AstNode<T, Loc> {}
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Item {
     pub kind: ItemKind,
     // We can/require to extend the fields as we get more clarity on the path forward.
@@ -97,7 +102,8 @@ impl fmt::Display for Item {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ItemKind {
     // Data Definition Language statements
     Ddl(Ddl),
@@ -107,18 +113,21 @@ pub enum ItemKind {
     Query(Query),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ddl {
     pub op: DdlOp,
 }
 
 /// A data definition operation.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DdlOp {
     pub kind: DdlOpKind,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DdlOpKind {
     /// `CREATE TABLE <symbol>`
     CreateTable(CreateTable),
@@ -131,35 +140,41 @@ pub enum DdlOpKind {
     DropIndex(DropIndex),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CreateTable {
     pub table_name: SymbolPrimitive,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DropTable {
     pub table_name: SymbolPrimitive,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CreateIndex {
     pub index_name: Ident,
     pub fields: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DropIndex {
     pub table: Ident,
     pub keys: Ident,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dml {
     pub op: DmlOp,
 }
 
 /// A Data Manipulation Operation.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DmlOp {
     pub kind: DmlOpKind,
     pub from_clause: Option<FromClause>,
@@ -167,7 +182,8 @@ pub struct DmlOp {
     pub returning: Option<ReturningExpr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DmlOpKind {
     /// `INSERT INTO <expr> <expr>`
     Insert(Insert),
@@ -181,13 +197,15 @@ pub enum DmlOpKind {
     Delete,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Insert {
     pub target: Box<Expr>,
     pub values: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InsertValue {
     pub target: Box<Expr>,
     pub value: Box<Expr>,
@@ -195,30 +213,35 @@ pub struct InsertValue {
     pub on_conflict: Option<OnConflict>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Set {
     pub assignment: Assignment,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Remove {
     pub target: Box<Expr>,
 }
 
 /// `ON CONFLICT <expr> <conflict_action>`
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OnConflict {
     pub expr: Box<Expr>,
     pub conflict_action: ConflictAction,
 }
 
 /// `CONFLICT_ACTION <action>`
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ConflictAction {
     DoNothing,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Expr {
     pub kind: ExprKind,
 }
@@ -261,7 +284,8 @@ pub type StructAst = AstBytePos<Struct>;
 pub type UniOpAst = AstBytePos<UniOp>;
 pub type VarRefAst = AstBytePos<VarRef>;
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Query {
     pub set: QuerySetAst,
     pub order_by: Option<Box<OrderByExprAst>>,
@@ -269,7 +293,8 @@ pub struct Query {
     pub offset: Option<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum QuerySet {
     SetOp(Box<SetExprAst>),
     Select(Box<SelectAst>),
@@ -277,7 +302,8 @@ pub enum QuerySet {
     Values(Vec<Box<Expr>>),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SetExpr {
     pub setop: SetOperator,
     pub setq: SetQuantifier,
@@ -285,7 +311,8 @@ pub struct SetExpr {
     pub rhs: Box<QuerySetAst>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SetOperator {
     Union,
     Except,
@@ -293,7 +320,8 @@ pub enum SetOperator {
 }
 
 /// The expressions that can result in values.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ExprKind {
     Lit(LitAst),
     /// Variable reference
@@ -331,7 +359,8 @@ pub enum ExprKind {
 /// <https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt>
 /// and Section 2 of the following (Figure 1: BNF Grammar for PartiQL Values):
 /// <https://partiql.org/assets/PartiQL-Specification.pdf>
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Lit {
     Null,
     Missing,
@@ -354,39 +383,45 @@ pub enum Lit {
     CollectionLit(CollectionLit),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CollectionLit {
     ArrayLit(String),
     BagLit(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DateTimeLit {
     DateLit(String),
     TimeLit(String),
     TimestampLit(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VarRef {
     pub name: SymbolPrimitive,
     pub case: CaseSensitivity,
     pub qualifier: ScopeQualifier,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Param {
     pub index: i32,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BinOp {
     pub kind: BinOpKind,
     pub lhs: Box<Expr>,
     pub rhs: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum BinOpKind {
     // Arithmetic
     Add,
@@ -410,44 +445,51 @@ pub enum BinOpKind {
     Is,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UniOp {
     pub kind: UniOpKind,
     pub expr: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UniOpKind {
     Pos,
     Neg,
     Not,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Like {
     pub value: Box<Expr>,
     pub pattern: Box<Expr>,
     pub escape: Option<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Between {
     pub value: Box<Expr>,
     pub from: Box<Expr>,
     pub to: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct In {
     pub operands: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Case {
     pub kind: CaseKind,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CaseKind {
     /// CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END
     SimpleCase(SimpleCase),
@@ -455,64 +497,75 @@ pub enum CaseKind {
     SearchedCase(SearchedCase),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SimpleCase {
     pub expr: Box<Expr>,
     pub cases: Vec<ExprPair>,
     pub default: Option<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SearchedCase {
     pub cases: Vec<ExprPair>,
     pub default: Option<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Struct {
     pub fields: Vec<ExprPair>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Bag {
     pub values: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct List {
     pub values: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Sexp {
     pub values: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Date {
     pub year: i32,
     pub month: i32,
     pub day: i32,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LitTime {
     pub value: TimeValue,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Path {
     pub root: Box<Expr>,
     pub steps: Vec<PathStep>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Call {
     pub func_name: SymbolPrimitive,
     pub args: Vec<CallArgAst>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CallArg {
     /// `*` used as an argument to a function call (e.g., in `count(*)`)
     Star(),
@@ -525,43 +578,50 @@ pub enum CallArg {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CallAgg {
     pub func_name: SymbolPrimitive,
     pub setq: Option<SetQuantifier>,
     pub args: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cast {
     pub value: Box<Expr>,
     pub as_type: Type,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CanCast {
     pub value: Box<Expr>,
     pub as_type: Type,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CanLossLessCast {
     pub value: Box<Expr>,
     pub as_type: Type,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NullIf {
     pub expr1: Box<Expr>,
     pub expr2: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coalesce {
     pub args: Vec<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Select {
     pub project: ProjectionAst,
     pub from: Option<FromClauseAst>,
@@ -571,7 +631,8 @@ pub struct Select {
     pub having: Option<Box<Expr>>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TimeValue {
     pub hour: i32,
     pub minute: i32,
@@ -583,33 +644,38 @@ pub struct TimeValue {
 }
 
 /// A "step" within a path expression; that is the components of the expression following the root.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PathStep {
     PathExpr(PathExpr),
     PathWildCard,
     PathUnpivot,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PathExpr {
     pub index: Box<Expr>,
 }
 
 /// Is used to determine if variable lookup should be case-sensitive or not.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CaseSensitivity {
     CaseSensitive,
     CaseInsensitive,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Projection {
     pub kind: ProjectionKind,
     pub setq: Option<SetQuantifier>,
 }
 
 /// Indicates the type of projection in a SFW query.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ProjectionKind {
     ProjectStar,
     ProjectList(Vec<ProjectItemAst>),
@@ -618,46 +684,53 @@ pub enum ProjectionKind {
 }
 
 /// An item to be projected in a `SELECT`-list.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ProjectItem {
     /// For `.*` in SELECT list
-    ProjectAll(ProjectAll),
+    ProjectAll(ProjectAll), // TODO remove this?
     /// For `<expr> [AS <id>]`
     ProjectExpr(ProjectExpr),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProjectAll {
     pub expr: Box<Expr>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProjectExpr {
     pub expr: Box<Expr>,
     pub as_alias: Option<SymbolPrimitive>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Let {
     /// A list of LET bindings
     pub let_bindings: Vec<LetBinding>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LetBinding {
     pub expr: Box<Expr>,
     pub name: SymbolPrimitive,
 }
 
 /// FROM clause of an SFW query
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FromClause {
     FromLet(FromLetAst),
     /// <from_source> JOIN \[INNER | LEFT | RIGHT | FULL\] <from_source> ON <expr>
     Join(JoinAst),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FromLet {
     pub expr: Box<Expr>,
     pub kind: FromLetKind,
@@ -666,7 +739,8 @@ pub struct FromLet {
     pub by_alias: Option<SymbolPrimitive>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Join {
     pub kind: JoinKind,
     pub left: Box<FromClauseAst>,
@@ -674,7 +748,8 @@ pub struct Join {
     pub predicate: Option<JoinSpecAst>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum JoinSpec {
     On(Box<Expr>),
     Using(Vec<Path>),
@@ -683,14 +758,16 @@ pub enum JoinSpec {
 
 /// Indicates the type of FromLet, see the following for more details:
 /// https:///github.com/partiql/partiql-lang-kotlin/issues/242
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum FromLetKind {
     Scan,
     Unpivot,
 }
 
 /// Indicates the logical type of join.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum JoinKind {
     Inner,
     Left,
@@ -701,14 +778,16 @@ pub enum JoinKind {
 
 /// A generic pair of expressions. Used in the `pub struct`, `searched_case`
 /// and `simple_case` expr variants above.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExprPair {
     pub first: Box<Expr>,
     pub second: Box<Expr>,
 }
 
 /// GROUP BY <grouping_strategy> <group_key_list>... \[AS <symbol>\]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupByExpr {
     pub strategy: GroupingStrategy,
     pub key_list: GroupKeyList,
@@ -717,46 +796,53 @@ pub struct GroupByExpr {
 
 /// Desired grouping qualifier:  ALL or PARTIAL.  Note: the `group_` prefix is
 /// needed to avoid naming clashes.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GroupingStrategy {
     GroupFull,
     GroupPartial,
 }
 
 /// <group_key>[, <group_key>]...
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupKeyList {
     pub keys: Vec<GroupKeyAst>,
 }
 
 /// <expr> [AS <symbol>]
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupKey {
     pub expr: Box<Expr>,
     pub as_alias: Option<SymbolPrimitive>,
 }
 
 /// ORDER BY <sort_spec>...
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OrderByExpr {
     pub sort_specs: Vec<SortSpecAst>,
 }
 
 /// <expr> [ASC | DESC] ?
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SortSpec {
     pub expr: Box<Expr>,
     pub ordering_spec: Option<OrderingSpec>,
     pub null_ordering_spec: Option<NullOrderingSpec>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OrderingSpec {
     Asc,
     Desc,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NullOrderingSpec {
     First,
     Last,
@@ -764,7 +850,8 @@ pub enum NullOrderingSpec {
 
 /// Indicates scope search order when resolving variables.
 /// Has no effect except within `FROM` sources.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ScopeQualifier {
     /// Use the default search order.
     Unqualified,
@@ -773,38 +860,44 @@ pub enum ScopeQualifier {
 }
 
 /// Indicates if a set should be reduced to its distinct elements or not.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SetQuantifier {
     All,
     Distinct,
 }
 
 /// `RETURNING (<returning_elem> [, <returning_elem>]...)`
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReturningExpr {
     pub elems: Vec<ReturningElem>,
 }
 
 /// `<returning mapping> (<expr> [, <expr>]...)`
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReturningElem {
     pub mapping: ReturningMapping,
     pub column: ColumnComponent,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ColumnComponent {
     ReturningWildcard,
     ReturningColumn(ReturningColumn),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReturningColumn {
     pub expr: Box<Expr>,
 }
 
 /// ( MODIFIED | ALL ) ( NEW | OLD )
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ReturningMapping {
     ModifiedNew,
     ModifiedOld,
@@ -822,7 +915,8 @@ pub enum ReturningMapping {
 /// an element of a type.  (Even though in the Kotlin code each varaint is its own type.)  Hence, we
 /// define an `Ident` type above which can be used without opening up an element's domain to
 /// all of `expr`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ident {
     pub name: SymbolPrimitive,
     pub case: CaseSensitivity,
@@ -830,14 +924,16 @@ pub struct Ident {
 
 /// Represents `<expr> = <expr>` in a DML SET operation.  Note that in this case, `=` is representing
 /// an assignment operation and *not* the equality operator.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Assignment {
     pub target: Box<Expr>,
     pub value: Box<Expr>,
 }
 
 /// Represents all possible PartiQL data types.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Type {
     NullType,
     BooleanType,
@@ -869,29 +965,34 @@ pub enum Type {
     CustomType(CustomType),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CharacterType {
     pub length: Option<LongPrimitive>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CharacterVaryingType {
     pub length: Option<LongPrimitive>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CustomType {
     pub name: SymbolPrimitive,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SymbolPrimitive {
     pub value: String,
     // Optional because string literal symbols don't have case sensitivity
     pub case: Option<CaseSensitivity>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LongPrimitive {
     pub value: i32,
 }

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! This API is currently unstable and subject to change.
 
-pub mod ast;
-
 #[macro_use]
 extern crate derive_builder;
+
+pub mod ast;

--- a/partiql-cli/Cargo.toml
+++ b/partiql-cli/Cargo.toml
@@ -17,16 +17,22 @@ exclude = [
 edition = "2021"
 version = "0.0.0"
 
+[workspace]
+
 # Example of customizing binaries in Cargo.toml.
 [[bin]]
 name = "partiql-cli"
 test = false
 bench = false
 
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+partiql-parser = { path = "../partiql-parser" }
+partiql-source-map = { path = "../partiql-source-map" }
+partiql-ast = { path = "../partiql-ast" }
+
+
 rustyline = "9.1.2"
 syntect = "5.0"
 owo-colors = "3.4.0"

--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -23,5 +23,4 @@ edition = "2021"
 walkdir = "2.3"
 ion-rs = "0.6.0"
 codegen = "0.1.3"
-partiql-parser = { path = "../partiql-parser" }
 Inflector = "0.11.4"

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -15,6 +15,14 @@ exclude = [
 version = "0.0.0"
 edition = "2021"
 
+[[bin]]
+name = "generate_comparison_report"
+required-features = ["report_tool"]
+
+[[bin]]
+name = "generate_cts_report"
+required-features = ["report_tool"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
@@ -25,8 +33,12 @@ partiql-conformance-test-generator = { path = "../partiql-conformance-test-gener
 
 [dependencies]
 partiql-parser = { path = "../partiql-parser" }
-serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+
+serde = { version = "1.*", features = ["derive"], optional = true }
+serde_json = { version = "1.*", optional = true }
 
 [features]
+default = []
 conformance_test=[]
+report_tool = ["serde"]
+serde = ["dep:serde", "dep:serde_json"]

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "~1.0.24"
 num-traits = "~0.2.14"
 num-bigint = "~0.4.0"
 bigdecimal = "~0.2.0"
-rust_decimal = "~1.22.0"
+rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 
 lalrpop-util = "~0.19.7"
 logos = "~0.12.0"
@@ -40,10 +40,19 @@ itertools = "~0.10.3"
 regex = "~1.5.5"
 lazy_static = "~1.4.0"
 
-serde = { version = "~1.0.137", features = ["derive"] }
+serde = { version = "1.*", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+
+[features]
+default = []
+serde = [
+  "dep:serde",
+  "rust_decimal/serde-with-str",
+  "partiql-ast/serde",
+  "partiql-source-map/serde"
+]
 
 [[bench]]
 name = "bench_parse"

--- a/partiql-parser/src/error.rs
+++ b/partiql-parser/src/error.rs
@@ -8,13 +8,15 @@ use std::fmt::{Debug, Display};
 use partiql_source_map::location::Located;
 use thiserror::Error;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 /// Errors in the lexical structure of a PartiQL query.
 ///
 /// ### Notes
 /// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
-#[derive(Error, Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum LexError<'input> {
     /// Generic invalid input; likely an unrecognizable token.
@@ -35,7 +37,8 @@ pub enum LexError<'input> {
 ///
 /// ### Notes
 /// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
-#[derive(Error, Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ParseError<'input, Loc>
 where
@@ -66,7 +69,8 @@ where
     IllegalState(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UnexpectedTokenData<'input> {
     /// The unexpected token
     pub token: Cow<'input, str>,

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -31,13 +31,14 @@ use partiql_ast::ast;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
 use partiql_source_map::location::BytePosition;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// [`Error`] type for errors in the lexical structure for the PartiQL parser.
 pub type LexicalError<'input> = error::LexError<'input>;
 
 /// [`Error`] type for errors in the syntactic structure for the PartiQL parser.
 pub type ParseError<'input> = error::ParseError<'input, BytePosition>;
-
-use serde::{Deserialize, Serialize};
 
 /// General [`Result`] type for the PartiQL [`Parser`].
 pub type ParserResult<'input> = Result<Parsed<'input>, ParserError<'input>>;
@@ -64,7 +65,8 @@ impl Parser {
 
 /// The output of parsing PartiQL statement strings: an AST and auxiliary data.
 #[non_exhaustive]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[allow(dead_code)]
 pub struct Parsed<'input> {
     pub text: &'input str,
@@ -75,7 +77,8 @@ pub struct Parsed<'input> {
 /// The output of errors when parsing PartiQL statement strings: an errors and auxiliary data.
 #[non_exhaustive]
 #[allow(dead_code)]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ParserError<'input> {
     pub text: &'input str,
     pub offsets: LineOffsetTracker,

--- a/partiql-playground/Cargo.toml
+++ b/partiql-playground/Cargo.toml
@@ -15,12 +15,14 @@ exclude = [
 edition = "2021"
 version = "0.0.0"
 
+[workspace]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-partiql-parser = { path = "../partiql-parser" }
-serde_json = "1.0.81"
+partiql-parser = { path = "../partiql-parser", features=["serde"] }
+serde_json = "1.*"
 wasm-bindgen = "0.2"

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -18,5 +18,13 @@ version = "0.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smallvec = { version = "~1.8.0", features = ["serde"] }
-serde = { version = "~1.0.137", features = ["derive"] }
+smallvec = { version = "~1.8.0" }
+serde = { version = "1.*", features = ["derive"], optional = true }
+
+
+[dev-dependencies]
+
+
+[features]
+default = []
+serde = ["dep:serde", "smallvec/serde"]

--- a/partiql-source-map/src/line_offset_tracker.rs
+++ b/partiql-source-map/src/line_offset_tracker.rs
@@ -1,9 +1,11 @@
 //! [`LineOffsetTracker`] and related types for mapping locations in source `str`s.
 
 use crate::location::{ByteOffset, BytePosition, LineAndCharPosition, LineOffset};
-use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 use std::ops::Range;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Keeps track of source offsets of newlines for the purposes of later calculating
 /// line and column information
@@ -28,7 +30,8 @@ use std::ops::Range;
 /// assert_eq!(tracker.at(source, ByteOffset(30).into()), Ok(LineAndCharPosition::new(3,4)));
 /// assert_eq!(tracker.at(source, ByteOffset(300).into()), Err(LineOffsetError::EndOfInput));
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineOffsetTracker {
     line_starts: SmallVec<[ByteOffset; 16]>,
 }
@@ -43,6 +46,7 @@ impl Default for LineOffsetTracker {
 
 /// Errors that can be encountered when indexing by byte offset.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LineOffsetError {
     /// Requested `offset` is past end of input
     EndOfInput,

--- a/partiql-source-map/src/location.rs
+++ b/partiql-source-map/src/location.rs
@@ -7,6 +7,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::num::NonZeroUsize;
 use std::ops::{Add, Range, Sub};
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 macro_rules! impl_pos {
@@ -64,16 +65,14 @@ macro_rules! impl_pos {
 ///
 /// This type is small (u32 currently) to allow it to be included in ASTs and other
 /// data structures.
-#[derive(
-    Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize,
-)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ByteOffset(pub u32);
 impl_pos!(ByteOffset, u32);
 
 /// A 0-indexed line offset, relative to some other position.
-#[derive(
-    Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize,
-)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineOffset(pub u32);
 impl_pos!(LineOffset, u32);
 
@@ -82,9 +81,8 @@ impl_pos!(LineOffset, u32);
 /// This value represents the number of unicode codepoints seen, so will differ
 /// from [`ByteOffset`] for a given location in a &str if the string contains
 /// non-ASCII unicode characters
-#[derive(
-    Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize,
-)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CharOffset(pub u32);
 impl_pos!(CharOffset, u32);
 
@@ -92,7 +90,8 @@ impl_pos!(CharOffset, u32);
 ///
 /// This type is small (u32 currently) to allow it to be included in ASTs and other
 /// data structures.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BytePosition(pub ByteOffset);
 
 impl From<ByteOffset> for BytePosition {
@@ -123,6 +122,7 @@ impl fmt::Display for BytePosition {
 ///             format!("Beginning of &str: {:?}", LineAndCharPosition::new(0, 0)));
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineAndCharPosition {
     /// The 0-indexed line absolute position (i.e., relative to the start of a &str)
     pub line: LineOffset,
@@ -150,7 +150,8 @@ impl LineAndCharPosition {
 /// # use partiql_source_map::location::LineAndColumn;
 /// assert_eq!("Beginning of &str: 1:1",format!("Beginning of &str: {}", LineAndColumn::new(1, 1).unwrap()));
 /// ```
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineAndColumn {
     /// The 1-indexed line absolute position (i.e., relative to the start of a &str)
     pub line: NonZeroUsize,
@@ -200,7 +201,8 @@ impl fmt::Display for LineAndColumn {
 /// A range with an inclusive start and exclusive end.
 ///
 /// Basically, a [`Range`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Location<Loc: Display> {
     /// The start the range (inclusive).
     pub start: Loc,
@@ -232,7 +234,8 @@ where
 }
 
 /// A wrapper type that holds an `inner` value and a `location` for it
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Located<T, Loc: Display> {
     /// The item that has a location attached
     pub inner: T,


### PR DESCRIPTION
- Make usage of `serde` optional behind feature flag `serde`
- exclude CLI and playground from main workspace
- use more broadly compatible version requirement for `serde`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
