### PR TITLE
Parse TIME w/o TIME ZONE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,80 +1,58 @@
-# Created by https://www.toptal.com/developers/gitignore/api/c,c++,rust,clion,cmake,valgrind,visualstudiocode,intellij,emacs
-# Edit at https://www.toptal.com/developers/gitignore?templates=c,c++,rust,clion,cmake,valgrind,visualstudiocode,intellij,emacs
+# Created by https://www.toptal.com/developers/gitignore/api/emacs,rust,vim,macos,intellij+all,intellij+iml
+# Edit at https://www.toptal.com/developers/gitignore?templates=emacs,rust,vim,macos,intellij+all,intellij+iml
 
-### C ###
-# Prerequisites
-*.d
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
 
-# Object files
-*.o
-*.ko
-*.obj
-*.elf
+# Org-mode
+.org-id-locations
+*_archive
 
-# Linker output
-*.ilk
-*.map
-*.exp
+# flymake-mode
+*_flymake.*
 
-# Precompiled Headers
-*.gch
-*.pch
+# eshell files
+/eshell/history
+/eshell/lastdir
 
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
+# elpa packages
+/elpa/
 
-# Shared objects (inc. Windows DLLs)
-*.dll
-*.so
-*.so.*
-*.dylib
+# reftex files
+*.rel
 
-# Executables
-*.exe
-*.out
-*.app
-*.i*86
-*.x86_64
-*.hex
+# AUCTeX auto folder
+/auto/
 
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
+# cask packages
+.cask/
+dist/
 
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
+# Flycheck
+flycheck_*.el
 
-### C++ ###
-# Prerequisites
+# server auth directory
+/server/
 
-# Compiled Object files
-*.slo
+# projectiles files
+.projectile
 
-# Precompiled Headers
+# directory configuration
+.dir-locals.el
 
-# Compiled Dynamic libraries
+# network security
+/network-security.data
 
-# Fortran module files
-*.mod
-*.smod
 
-# Compiled Static libraries
-*.lai
-
-# Executables
-
-### CLion ###
+### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
@@ -153,105 +131,16 @@ fabric.properties
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
 
-### CLion Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+.idea/*
 
-# Sonarlint plugin
-# https://plugins.jetbrains.com/plugin/7973-sonarlint
-.idea/**/sonarlint/
+!.idea/codeStyles
+!.idea/runConfigurations
 
-# SonarQube Plugin
-# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
-.idea/**/sonarIssues.xml
-
-# Markdown Navigator plugin
-# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
-.idea/**/markdown-navigator.xml
-.idea/**/markdown-navigator-enh.xml
-.idea/**/markdown-navigator/
-
-# Cache file creation bug
-# See https://youtrack.jetbrains.com/issue/JBR-2257
-.idea/$CACHE_FILE$
-
-# CodeStream plugin
-# https://plugins.jetbrains.com/plugin/12206-codestream
-.idea/codestream.xml
-
-### CMake ###
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
-
-### CMake Patch ###
-# External projects
-*-prefix/
-
-### Emacs ###
-# -*- mode: gitignore; -*-
-*~
-\#*\#
-/.emacs.desktop
-/.emacs.desktop.lock
-*.elc
-auto-save-list
-tramp
-.\#*
-
-# Org-mode
-.org-id-locations
-*_archive
-
-# flymake-mode
-*_flymake.*
-
-# eshell files
-/eshell/history
-/eshell/lastdir
-
-# elpa packages
-/elpa/
-
-# reftex files
-*.rel
-
-# AUCTeX auto folder
-/auto/
-
-# cask packages
-.cask/
-dist/
-
-# Flycheck
-flycheck_*.el
-
-# server auth directory
-/server/
-
-# projectiles files
-.projectile
-
-# directory configuration
-.dir-locals.el
-
-# network security
-/network-security.data
-
-
-### Intellij ###
+### Intellij+iml ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
@@ -300,28 +189,46 @@ flycheck_*.el
 
 # Android studio 3.1+ serialized cache file
 
-### Intellij Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+### Intellij+iml Patch ###
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
 
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
 
-# Sonarlint plugin
-# https://plugins.jetbrains.com/plugin/7973-sonarlint
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
 
-# SonarQube Plugin
-# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+# Icon must end with two \r
+Icon
 
-# Markdown Navigator plugin
-# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
 
-# Cache file creation bug
-# See https://youtrack.jetbrains.com/issue/JBR-2257
+# Thumbnails
+._*
 
-# CodeStream plugin
-# https://plugins.jetbrains.com/plugin/12206-codestream
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 ### Rust ###
 # Generated by Cargo
@@ -337,45 +244,26 @@ Cargo.lock
 **/*.rs.bk
 
 # MSVC Windows builds of rustc generate these, which store debugging information
+*.pdb
 
-### Valgrind ###
-# Callgrind output files
-callgrind.out
-callgrind.out.*
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
 
-# Cachegrind output files
-cachegrind.out
-cachegrind.out.*
+# Session
+Session.vim
+Sessionx.vim
 
-# Massif output files
-massif.out
-massif.out.*
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
 
-# BBV output files
-bb.out
-bb.out.*
-
-
-
-### VisualStudioCode ###
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
-
-# Local History for Visual Studio Code
-.history/
-
-# Built Visual Studio Code Extensions
-*.vsix
-
-### VisualStudioCode Patch ###
-# Ignore all local history of files
-.history
-.ionide
-
-# Support for Project snippet scope
-
-# End of https://www.toptal.com/developers/gitignore/api/c,c++,rust,clion,cmake,valgrind,visualstudiocode,intellij,emacs
+# End of https://www.toptal.com/developers/gitignore/api/emacs,rust,vim,macos,intellij+all,intellij+iml

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -40,4 +40,3 @@ serde = [
   "rust_decimal/serde-with-str",
   "rust_decimal/serde"
 ]
-

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -347,7 +347,7 @@ pub enum ExprKind {
     Path(PathAst),
     Call(CallAst),
     CallAgg(CallAggAst),
-
+    /// Expression representing a type, e.g. `TIME` in `'20:34' IS TIME`
     Type(TypeAst),
 
     /// Query, e.g. `UNION` | `EXCEPT` | `INTERSECT` | `SELECT` and their parts.
@@ -975,7 +975,7 @@ pub enum Type {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TimeType {
     pub precision: Option<u32>,
-    pub tz: bool,
+    pub with_tz: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -971,14 +971,13 @@ pub enum Type {
     CustomType(CustomType),
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TimeType {
     pub precision: Option<u32>,
     pub tz: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CharacterType {

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -258,6 +258,7 @@ pub type SexpAst = AstBytePos<Sexp>;
 pub type SimpleCaseAst = AstBytePos<SimpleCase>;
 pub type SortSpecAst = AstBytePos<SortSpec>;
 pub type StructAst = AstBytePos<Struct>;
+pub type TypeAst = AstBytePos<Type>;
 pub type UniOpAst = AstBytePos<UniOp>;
 pub type VarRefAst = AstBytePos<VarRef>;
 
@@ -319,6 +320,8 @@ pub enum ExprKind {
     Call(CallAst),
     CallAgg(CallAggAst),
 
+    Type(TypeAst),
+
     /// Query, e.g. `UNION` | `EXCEPT` | `INTERSECT` | `SELECT` and their parts.
     Query(QueryAst),
 
@@ -363,7 +366,7 @@ pub enum CollectionLit {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum DateTimeLit {
     DateLit(String),
-    TimeLit(String),
+    TimeLit {value: Option<String>, type_spec: TimeType},
     TimestampLit(String),
 }
 
@@ -850,14 +853,14 @@ pub enum Type {
     DoublePrecisionType,
     TimestampType,
     CharacterType,
-    CharacterVaryingType,
+    CharacterVaryingType(CharacterVaryingType),
     MissingType,
     StringType,
     SymbolType,
     BlobType,
     ClobType,
     DateType,
-    TimeType,
+    TimeType(TimeType),
     ZonedTimestampType,
     StructType,
     TupleType,
@@ -870,13 +873,19 @@ pub enum Type {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct TimeType {
+    pub precision: Option<u32>,
+    pub tz: bool
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct CharacterType {
     pub length: Option<LongPrimitive>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct CharacterVaryingType {
-    pub length: Option<LongPrimitive>,
+    pub length: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/partiql-conformance-tests/src/bin/generate_comparison_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_comparison_report.rs
@@ -11,7 +11,7 @@ struct CTSReport {
     commit_hash: String,
     passing: Vec<String>,
     failing: Vec<String>,
-    ignored: Vec<String>
+    ignored: Vec<String>,
 }
 
 /// Compares two conformance reports generated from [`generate_cts_report`], generating a comparison

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -606,6 +606,8 @@ pub enum Token<'input> {
     Right,
     #[regex("(?i:Select)")]
     Select,
+    #[regex("(?i:Table)")]
+    Table,
     #[regex("(?i:Time)")]
     Time,
     #[regex("(?i:Timestamp)")]
@@ -680,6 +682,7 @@ impl<'input> Token<'input> {
                 | Token::Preserve
                 | Token::Right
                 | Token::Select
+                | Token::Table
                 | Token::Time
                 | Token::Timestamp
                 | Token::Then
@@ -789,6 +792,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Preserve
             | Token::Right
             | Token::Select
+            | Token::Table
             | Token::Time
             | Token::Timestamp
             | Token::Then
@@ -826,7 +830,7 @@ mod tests {
             "WiTH Where Value uSiNg Unpivot UNION True Select right Preserve pivoT Outer Order Or \
              On Offset Nulls Null Not Natural Missing Limit Like Left Lateral Last Join \
              Intersect Is Inner In Having Group From For Full First False Except Escape Desc \
-             Cross Time Timestamp Date By Between At As And Asc All Values Case When Then Else End";
+             Cross Table Time Timestamp Date By Between At As And Asc All Values Case When Then Else End";
         let symbols = symbols.split(' ').chain(primitives.split(' '));
         let keywords = keywords.split(' ');
 
@@ -846,9 +850,9 @@ mod tests {
             "LATERAL", ".", "LAST", "||", "JOIN", ":", "INTERSECT", "--", "IS", "/**/", "INNER",
             "<unquoted_ident:UNQUOTED_IDENT>", "IN", "<quoted_ident:QUOTED_IDENT>", "HAVING",
             "<unquoted_atident:UNQUOTED_ATIDENT>", "GROUP", "<quoted_atident:QUOTED_ATIDENT>",
-            "FROM", "FOR", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC", "CROSS", "TIME",
-            "TIMESTAMP", "DATE", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES", "CASE",
-            "WHEN", "THEN", "ELSE", "END"
+            "FROM", "FOR", "FULL", "FIRST", "FALSE", "EXCEPT", "ESCAPE", "DESC", "CROSS", "TABLE",
+            "TIME", "TIMESTAMP", "DATE", "BY", "BETWEEN", "AT", "AS", "AND", "ASC", "ALL", "VALUES",
+            "CASE", "WHEN", "THEN", "ELSE", "END"
         ];
         let displayed = toks
             .into_iter()

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -302,12 +302,12 @@ mod tests {
 
         #[test]
         fn query() {
-            parse!(r#"(SELECT a FROM table).a"#);
-            parse!(r#"(SELECT a FROM table).'a'"#);
-            parse!(r#"(SELECT a FROM table)."a""#);
-            parse!(r#"(SELECT a FROM table)['a']"#);
-            parse!(r#"(SELECT a FROM table).*"#);
-            parse!(r#"(SELECT a FROM table)[*]"#);
+            parse!(r#"(SELECT a FROM t).a"#);
+            parse!(r#"(SELECT a FROM t).'a'"#);
+            parse!(r#"(SELECT a FROM t)."a""#);
+            parse!(r#"(SELECT a FROM t)['a']"#);
+            parse!(r#"(SELECT a FROM t).*"#);
+            parse!(r#"(SELECT a FROM t)[*]"#);
         }
 
         #[test]
@@ -317,6 +317,7 @@ mod tests {
             parse!(r#"foo(x, y)[*]"#);
             parse!(r#"foo(x, y)[5]"#);
             parse!(r#"foo(x, y).a.*"#);
+            parse!(r#"foo(x, y)[*].*.b[5]"#);
         }
 
         #[test]

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -177,6 +177,12 @@ mod tests {
         }
 
         #[test]
+        fn time() {
+            parse!("time '22:12'");
+            parse!("time(10) '22:12'");
+        }
+
+        #[test]
         fn ion() {
             parse!(r#" `[{'a':1, 'b':1}, {'a':2}, "foo"]` "#);
             parse!(r#" `[{'a':1, 'b':1}, {'a':2}, "foo", 'a`b', "a`b", '''`s''', {{"a`b"}}]` "#);
@@ -546,6 +552,8 @@ mod tests {
             parse!(r#"CAST(9 AS b)"#);
             parse!(r#"CAST(a AS VARCHAR)"#);
             parse!(r#"CAST(a AS VARCHAR(20))"#);
+            parse!(r#"CAST(a AS TIME)"#);
+            parse!(r#"CAST(a AS TIME(20))"#);
             parse!(r#"CAST( TRUE AS INTEGER)"#);
             parse!(r#"CAST( (4 in (1,2,3,4)) AS INTEGER)"#);
         }

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -561,7 +561,10 @@ mod tests {
             parse!(r#"CAST(a AS TIME(20))"#);
             parse!(r#"CAST( TRUE AS INTEGER)"#);
             parse!(r#"CAST( (4 in (1,2,3,4)) AS INTEGER)"#);
-            // TODO ensure the following parse
+            // TODO ensure the following parses correctly
+            // currently the test doesn't pass b/c as a result of
+            // we end up w/ `UnexpectedTokenData` error on `AS`
+            // keyword
             // parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
         }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -750,11 +750,37 @@ ExprPrecedence03: ast::Expr = {
     <ExprPrecedence02>,
 }
 
+ExprPrecedence02: ast::Expr = {
+     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
+        kind: ast::ExprKind::Path( expr.ast(lo..hi) )
+      },
+    <ExprPrecedence01>,
+}
+
 PathExpr: ast::Path = {
     <l:ExprPrecedence01> "." <steps:PathSteps> => ast::Path { root:Box::new(l), steps },
-    <l:ExprPrecedence01> "." "*" => ast::Path {
-        root:Box::new(l), steps:vec![ast::PathStep::PathUnpivot]
-     },
+    <l:ExprPrecedence01> "[" "*" "]" "." <s:PathSteps> => {
+        let mut steps = vec![ast::PathStep::PathWildCard];
+        steps.extend(s);
+        ast::Path {
+            root:Box::new(l),
+            steps
+        }
+    },
+    <l:ExprPrecedence01> "[" <expr:ExprQuery> "]" "." <s:PathSteps> => {
+       let step = ast::PathStep::PathExpr(
+        ast::PathExpr{
+                index: Box::new(*expr),
+            }
+        );
+
+        let mut steps = vec![step];
+        steps.extend(s);
+        ast::Path {
+            root:Box::new(l),
+            steps
+        }
+    },
     <l:ExprPrecedence01> "[" "*" "]" => ast::Path {
         root:Box::new(l), steps:vec![ast::PathStep::PathWildCard]
     },
@@ -769,13 +795,6 @@ PathExpr: ast::Path = {
         }
     },
 };
-
-ExprPrecedence02: ast::Expr = {
-     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
-        kind: ast::ExprKind::Path( expr.ast(lo..hi) )
-      },
-    <ExprPrecedence01>,
-}
 
 #[inline]
 ExprPrecedence01: ast::Expr = {
@@ -954,15 +973,13 @@ PathSteps: Vec<ast::PathStep> = {
         let mut steps = path;
         steps.push(step);
         steps
-        // ast::Path{ root:path.root, steps }
     },
-    <lo:@L> <path:PathSteps>  "[" "*" "]" <hi:@R> => {
+    <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
          let step = ast::PathStep::PathWildCard;
 
          let mut steps = path;
          steps.push(step);
          steps
-         // ast::Path{ root:path.root, steps }
     },
     <lo:@L> <path:PathSteps>  "." "*" <hi:@R> => {
          let step = ast::PathStep::PathUnpivot;
@@ -983,7 +1000,21 @@ PathSteps: Vec<ast::PathStep> = {
         let mut steps = path;
         steps.push(step);
         steps
-        // ast::Path{ root:path.root, steps }
+    },
+    "[" "*" "]" => {
+        let steps = vec![ast::PathStep::PathWildCard];
+        steps
+    },
+    "[" <expr:ExprQuery> "]" => {
+        let steps = vec![ast::PathStep::PathExpr(
+            ast::PathExpr{
+            index: Box::new(*expr),
+        })];
+        steps
+    },
+    "*" => {
+        let steps = vec![ast::PathStep::PathUnpivot];
+        steps
     },
     <v:PathExprVarRef> => {
         let step = ast::PathStep::PathExpr(
@@ -992,7 +1023,6 @@ PathSteps: Vec<ast::PathStep> = {
             });
         let steps = vec![step];
         steps
-        // ast::Path{ root: Box::new(v), steps: vec![] }
     },
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -751,9 +751,9 @@ ExprPrecedence03: ast::Expr = {
 }
 
 ExprPrecedence02: ast::Expr = {
-     <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
+    <lo:@L> <expr:PathExpr> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::Path( expr.ast(lo..hi) )
-      },
+    },
     <ExprPrecedence01>,
 }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1199,14 +1199,14 @@ Type: ast::TypeAst = {
 TimeType: ast::TimeType = {
     <lo:@L> <t:"TIME"> <timezone:TimeZone?> <hi:@R> =>? {
         let splits: Vec<_> = t.split(':').collect();
-        let tz = match timezone {
+        let with_tz = match timezone {
             Some(v) => v,
             None => false
         };
         match splits.len() {
-            1 => Ok(ast::TimeType {precision: None, tz}),
+            1 => Ok(ast::TimeType {precision: None, with_tz}),
             2 => splits[1].parse::<u32>()
-                .map(|n| ast::TimeType {precision: Some(n), tz})
+                .map(|n| ast::TimeType {precision: Some(n), with_tz})
                 .map_err(|_| lpop::ParseError::User {
                     error: ParseError::SyntaxError(
                     "Invalid TIME precision argument".to_string().to_located(BytePosition::from(lo)..BytePosition::from(hi)))

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -922,7 +922,11 @@ FunctionArgPositional: ast::CallArgAst = {
 
 #[inline]
 FunctionArgNamed: ast::CallArgAst = {
-    <lo:@L> <name:FunctionArgName> ":" <value:ExprQuery> <hi:@R> => ast::CallArg::Named{name, value: Some(value)}.ast(lo..hi)
+    <lo:@L> <name:FunctionArgName> ":" <value:ExprQuery> <hi:@R> => ast::CallArg::Named{name, value: Some(value)}.ast(lo..hi),
+    <lo:@L> <name:FunctionArgName> ":" <value:Type> <hi:@R> => {
+        let v = Box::new(ast::Expr{ kind: ast::ExprKind::Type(value)});
+        ast::CallArg::Named{name, value: Some(v)}.ast(lo..hi)
+    }
 }
 
 #[inline]
@@ -1137,7 +1141,9 @@ LiteralIon: ast::Lit = {
 #[inline]
 LiteralDateTime: ast::Lit = {
     "DATE" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::DateLit(s.to_owned())),
-    "TIME" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::TimeLit(s.to_owned())),
+    <lo:@L> <t:TimeType> <s:"String"> <hi:@R> =>? {
+        Ok(ast::Lit::DateTimeLit(ast::DateTimeLit::TimeLit {value: Some(s.to_owned()), type_spec: t}))
+    },
     "TIMESTAMP" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::TimestampLit(s.to_owned())),
 }
 
@@ -1213,6 +1219,53 @@ AtIdent: ast::SymbolPrimitive = {
 
 ByIdent: ast::SymbolPrimitive = {
     "BY" <SymbolPrimitive>
+}
+
+Type: ast::TypeAst = {
+    <lo:@L> <t:TimeType> <hi:@R> => (ast::Type::TimeType(t)).ast(lo..hi),
+}
+
+
+TimeType: ast::TimeType = {
+    <lo:@L> <t:"TIME"> <timezone:TimeZone?> <hi:@R> =>? {
+        let splits: Vec<_> = t.split(':').collect();
+        let tz = match timezone {
+            Some(v) => v,
+            None => false
+        };
+        match splits.len() {
+            1 => Ok(ast::TimeType {precision: None, tz}),
+            2 => splits[1].parse::<u32>()
+                .map(|n| ast::TimeType {precision: Some(n), tz})
+                .map_err(|_| lpop::ParseError::User {
+                    error: ParseError::SyntaxError(
+                    "Invalid TIME precision argument".to_string().to_located(BytePosition::from(lo)..BytePosition::from(hi)))
+                 }),
+            _ => Err(lpop::ParseError::User {
+                    error: ParseError::SyntaxError(
+                    "Invalid TIME type".to_string().to_located(BytePosition::from(lo)..BytePosition::from(hi)))
+                 })
+        }
+    },
+}
+
+TimeZone: bool = {
+    <lo:@L> <w:WithTz> <t:"TIME"> "ZONE" <hi:@R> =>? {
+        let splits: Vec<_> = t.split(':').collect();
+        if splits.len() == 1 && splits[0] == "TIME" {
+            Ok(w)
+        } else {
+          Err(lpop::ParseError::User {
+              error: ParseError::SyntaxError(
+                  "invalid time zone type spec".to_string().to_located(BytePosition::from(lo)..BytePosition::from(hi)))
+           })
+        }
+    }
+}
+
+WithTz: bool = {
+    "WITH" => true,
+    "WITHOUT" => false
 }
 
 // ------------------------------------------------------------------------------ //
@@ -1325,7 +1378,7 @@ extern {
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
         "TABLE" => lexer::Token::Table,
-        "TIME" => lexer::Token::Time,
+        "TIME" => lexer::Token::Time(<String>),
         "TIMESTAMP" => lexer::Token::Timestamp,
         "THEN" => lexer::Token::Then,
         "TRUE" => lexer::Token::True,
@@ -1337,5 +1390,7 @@ extern {
         "WHEN" => lexer::Token::When,
         "WHERE" => lexer::Token::Where,
         "WITH" => lexer::Token::With,
+        "WITHOUT" => lexer::Token::Without,
+        "ZONE" => lexer::Token::Zone,
     }
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1324,7 +1324,7 @@ extern {
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
-        "Table" => lexer::Token::Table,
+        "TABLE" => lexer::Token::Table,
         "TIME" => lexer::Token::Time,
         "TIMESTAMP" => lexer::Token::Timestamp,
         "THEN" => lexer::Token::Then,

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1294,6 +1294,7 @@ extern {
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
         "SELECT" => lexer::Token::Select,
+        "Table" => lexer::Token::Table,
         "TIME" => lexer::Token::Time,
         "TIMESTAMP" => lexer::Token::Timestamp,
         "THEN" => lexer::Token::Then,


### PR DESCRIPTION
*Issue #, if available:* 
#108 #149 

*Description of changes:*
Ensure the following statements parse:
- TIME WITH TIME ZONE <string-literal>
- TIME(10) WITH TIME ZONE <string-literal>
- TIME WITHOUT TIME ZONE <string-literal>
- TIME (20) WITHOUT TIME ZONE <string-literal>
- CAST(a AS TIME)
- CAST(b AS TIME(10))

Note: the annotated conformance test report is inaccurate. I'm preparing a subsequent PR to update the partiql-tests and once that PR merge, I'll update the submodule in this repo, here is the current failures:

```bash
failures:
    partiql_tests::partiql_tests_data::fail::syntax::query::select::select::select_query_missing_from_test
    partiql_tests::partiql_tests_data::fail::syntax::query::select::select::select_without_comma_between_projection_items_test
    partiql_tests::partiql_tests_data::success::syntax::primitives::parameter::parameter_expression_test
    partiql_tests::partiql_tests_data::success::syntax::primitives::parameter::select_with_parameter_and_literals_test
    partiql_tests::partiql_tests_data::success::syntax::primitives::time_constructor::time_no_space_between_keyword_and_quote_test
```

In the above `time_no_space_between_keyword_and_quote_test` is wrong pending a PR for correction:
```
{
    name: "TIME no space between keyword and quote",
    statement: "TIME'02:30:59",
    assert: [
        {
            result: SyntaxSuccess
        },
    ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
