### PR TITLE
Minor AST refactor

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -402,7 +402,6 @@ pub enum DateTimeLit {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VarRef {
     pub name: SymbolPrimitive,
-    pub case: CaseSensitivity,
     pub qualifier: ScopeQualifier,
 }
 
@@ -479,7 +478,8 @@ pub struct Between {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct In {
-    pub operands: Vec<Box<Expr>>,
+    pub lhs: Box<Expr>,
+    pub rhs: Box<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -548,13 +548,6 @@ pub struct Date {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LitTime {
     pub value: TimeValue,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Path {
-    pub root: Box<Expr>,
-    pub steps: Vec<PathStep>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -641,6 +634,13 @@ pub struct TimeValue {
     pub precision: i32,
     pub with_time_zone: bool,
     pub tz_minutes: Option<i32>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Path {
+    pub root: Box<Expr>,
+    pub steps: Vec<PathStep>,
 }
 
 /// A "step" within a path expression; that is the components of the expression following the root.

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -637,9 +637,9 @@ ExprPrecedence09: ast::Expr = {
        )}
     },
     <lo:@L> <l:ExprPrecedence09> "IN" <r:ExprPrecedence08> <hi:@R> =>
-       ast::Expr{ kind: ast::ExprKind::In( ast::In{ operands: vec![Box::new(l),Box::new(r)] }.ast(lo..hi) ) },
+       ast::Expr{ kind: ast::ExprKind::In( ast::In{ lhs: Box::new(l), rhs: Box::new(r) }.ast(lo..hi) ) },
     <lo:@L> <l:ExprPrecedence09> "NOT" "IN" <r:ExprPrecedence08> <hi:@R> => {
-       let in_expr = ast::Expr{ kind: ast::ExprKind::In( ast::In{ operands: vec![Box::new(l),Box::new(r)] }.ast(lo..hi) ) };
+       let in_expr = ast::Expr{ kind: ast::ExprKind::In( ast::In{ lhs: Box::new(l), rhs: Box::new(r) }.ast(lo..hi) ) };
        ast::Expr{ kind: ast::ExprKind::UniOp(
            ast::UniOp {
                kind: ast::UniOpKind::Not,
@@ -1006,8 +1006,7 @@ PathSteps: Vec<ast::PathStep> = {
 PathExprVarRef: ast::Expr = {
     <lo:@L> <s:"String"> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::VarRef(ast::VarRef {
-            name: ast::SymbolPrimitive { value: s.to_owned(), case: None },
-            case: ast::CaseSensitivity::CaseInsensitive,
+            name: ast::SymbolPrimitive { value: s.to_owned(), case: Some(ast::CaseSensitivity::CaseInsensitive) },
             qualifier: ast::ScopeQualifier::Unqualified
         }.ast(lo..hi)),
     },
@@ -1018,28 +1017,24 @@ VarRefExpr: ast::Expr = {
     <lo:@L> <ident:"UnquotedIdent"> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::VarRef(ast::VarRef {
             name: ast::SymbolPrimitive { value: ident.to_owned(), case: Some(ast::CaseSensitivity::CaseInsensitive) },
-            case: ast::CaseSensitivity::CaseInsensitive,
             qualifier: ast::ScopeQualifier::Unqualified
         }.ast(lo..hi)),
     },
     <lo:@L> <ident:"QuotedIdent"> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::VarRef(ast::VarRef {
             name: ast::SymbolPrimitive { value: ident.to_owned(), case: Some(ast::CaseSensitivity::CaseSensitive) },
-            case: ast::CaseSensitivity::CaseSensitive,
             qualifier: ast::ScopeQualifier::Unqualified
       }.ast(lo..hi)),
     },
     <lo:@L> <ident:"UnquotedAtIdentifier"> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::VarRef(ast::VarRef {
             name: ast::SymbolPrimitive { value: ident.to_owned(), case: Some(ast::CaseSensitivity::CaseInsensitive) },
-            case: ast::CaseSensitivity::CaseInsensitive,
             qualifier: ast::ScopeQualifier::Unqualified
         }.ast(lo..hi)),
     },
     <lo:@L> <ident:"QuotedAtIdentifier"> <hi:@R> => ast::Expr {
         kind: ast::ExprKind::VarRef(ast::VarRef {
             name: ast::SymbolPrimitive { value: ident.to_owned(), case: Some(ast::CaseSensitivity::CaseSensitive) },
-            case: ast::CaseSensitivity::CaseInsensitive,
             qualifier: ast::ScopeQualifier::Unqualified
         }.ast(lo..hi)),
     },


### PR DESCRIPTION
- remove redundant `CaseSensitivity`
- treat `in` more like a binary operator

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
