### PR TITLE
Parse SQL-style typed-literal strings

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -381,6 +381,7 @@ pub enum Lit {
     HexStringLit(String),
     DateTimeLit(DateTimeLit),
     CollectionLit(CollectionLit),
+    /// E.g. `TIME WITH TIME ZONE` in `SELECT TIME WITH TIME ZONE '12:00' FROM ...` 
     TypedLit(String, Type),
 }
 

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -560,6 +560,7 @@ pub enum CallArg {
         value: Box<Expr>,
     },
 
+    /// E.g. `AS: VARCHAR` in `CAST('abc' AS VARCHAR`
     NamedType {
         name: SymbolPrimitive,
         ty: Type,

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -381,7 +381,7 @@ pub enum Lit {
     HexStringLit(String),
     DateTimeLit(DateTimeLit),
     CollectionLit(CollectionLit),
-    /// E.g. `TIME WITH TIME ZONE` in `SELECT TIME WITH TIME ZONE '12:00' FROM ...` 
+    /// E.g. `TIME WITH TIME ZONE` in `SELECT TIME WITH TIME ZONE '12:00' FROM ...`
     TypedLit(String, Type),
 }
 
@@ -562,10 +562,7 @@ pub enum CallArg {
     },
 
     /// E.g. `AS: VARCHAR` in `CAST('abc' AS VARCHAR`
-    NamedType {
-        name: SymbolPrimitive,
-        ty: Type,
-    },
+    NamedType { name: SymbolPrimitive, ty: Type },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -923,7 +923,9 @@ pub enum CustomTypeParam {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CustomTypePart {
+    /// E.g. any of `WITH`, `TIME`, and`ZONE` in `TIME(20) WITH TIME ZONE`
     Name(SymbolPrimitive),
+    /// E.g. `TIME(20) in `TIME(20) WITH TIME ZONE`
     Parameterized(SymbolPrimitive, Vec<CustomTypeParam>),
 }
 

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -553,6 +553,7 @@ pub enum CallArg {
     /// positional argument to a function call (e.g., all arguments in `foo(1, 'a', 3)`)
     Positional(Box<Expr>),
 
+    /// E.g. `INT` in `foo(INT)`
     PositionalType(Type),
     /// named argument to a function call (e.g., the `"from" : 2` in `substring(a, "from":2)`
     Named {

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -919,7 +919,9 @@ pub enum Type {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CustomTypeParam {
+    /// E.g. `2` in `VARCHAR(2)`
     Lit(Lit),
+    /// E.g. `INT` in `FooType(INT)`
     Type(Type),
 }
 

--- a/partiql-cli/src/visualize/ast_to_dot.rs
+++ b/partiql-cli/src/visualize/ast_to_dot.rs
@@ -185,6 +185,7 @@ impl ToDot<ast::Expr> for AstToDot {
     }
 }
 
+#[inline]
 fn lit_to_str(ast: &Lit) -> String {
     match ast {
         Lit::Null => "NULL".to_string(),
@@ -219,32 +220,39 @@ fn lit_to_str(ast: &Lit) -> String {
     }
 }
 
+#[inline]
+fn custom_type_param_to_str(param: &ast::CustomTypeParam) -> String {
+    match param {
+        CustomTypeParam::Lit(lit) => lit_to_str(lit),
+        CustomTypeParam::Type(ty) => type_to_str(ty),
+    }
+}
+
+#[inline]
+fn custom_type_part_to_str(part: &ast::CustomTypePart) -> String {
+    match part {
+        CustomTypePart::Name(name) => symbol_primitive_to_label(name),
+        CustomTypePart::Parameterized(name, args) => {
+            let name = symbol_primitive_to_label(name);
+            let args = args
+                .iter()
+                .map(custom_type_param_to_str)
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{}({})", name, args)
+        }
+    }
+}
+
+#[inline]
 fn type_to_str(ty: &ast::Type) -> String {
     match ty {
-        Type::CustomType(cty) => {
-            cty.parts
-                .iter()
-                .map(|part| {
-                    // foo
-                    match part {
-                        CustomTypePart::Name(name) => symbol_primitive_to_label(name),
-                        CustomTypePart::Parameterized(name, args) => {
-                            let name = symbol_primitive_to_label(name);
-                            let args = args
-                                .iter()
-                                .map(|ctyp| match ctyp {
-                                    CustomTypeParam::Lit(lit) => lit_to_str(lit),
-                                    CustomTypeParam::Type(ty) => type_to_str(ty),
-                                })
-                                .collect::<Vec<_>>()
-                                .join(",");
-                            format!("{}({})", name, args)
-                        }
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(" ")
-        }
+        Type::CustomType(cty) => cty
+            .parts
+            .iter()
+            .map(custom_type_part_to_str)
+            .collect::<Vec<_>>()
+            .join(" "),
         _ => format!("{:?}", ty),
     }
 }

--- a/partiql-cli/src/visualize/render.rs
+++ b/partiql-cli/src/visualize/render.rs
@@ -80,6 +80,12 @@ fn render_to_string(format: GraphVizFormat, ast: &Box<ast::Expr>) -> String {
 
 /// Convert an AST into an attributed dot graph.
 #[inline]
+pub fn to_dot_raw(ast: &Box<ast::Expr>) -> String {
+    ast_to_dot(ast)
+}
+
+/// Convert an AST into an attributed dot graph.
+#[inline]
 pub fn to_dot(ast: &Box<ast::Expr>) -> String {
     render_to_string(GraphVizFormat::Dot, &ast)
 }
@@ -87,7 +93,7 @@ pub fn to_dot(ast: &Box<ast::Expr>) -> String {
 /// Convert an AST into a pretty-printed dot graph.
 #[inline]
 pub fn to_pretty_dot(ast: &Box<ast::Expr>) -> String {
-    render_to_string(GraphVizFormat::PrettyPrint, &ast)
+    render_to_string(GraphVizFormat::Canon, &ast)
 }
 
 /// Convert an AST into a graphviz svg.

--- a/partiql-conformance-tests/src/bin/generate_comparison_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_comparison_report.rs
@@ -11,7 +11,7 @@ struct CTSReport {
     commit_hash: String,
     passing: Vec<String>,
     failing: Vec<String>,
-    ignored: Vec<String>
+    ignored: Vec<String>,
 }
 
 /// Compares two conformance reports generated from [`generate_cts_report`], generating a comparison

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -632,6 +632,10 @@ pub enum Token<'input> {
     Where,
     #[regex("(?i:With)")]
     With,
+    #[regex("(?i:Without)")]
+    Without,
+    #[regex("(?i:Zone)")]
+    Zone,
 }
 
 impl<'input> Token<'input> {
@@ -804,7 +808,9 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Values
             | Token::When
             | Token::Where
-            | Token::With => {
+            | Token::With
+            | Token::Without
+            | Token::Zone => {
                 write!(f, "{}", format!("{:?}", self).to_uppercase())
             }
         }

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -135,9 +135,6 @@ mod tests {
         }};
     }
 
-    // TODO DATE <date string>
-    // TODO TIME <time string>
-    // TODO TIMESTAMP <timestamp string>
     mod literals {
         use super::*;
 
@@ -176,6 +173,18 @@ mod tests {
             parse!("17e2");
             parse!("1.317e-3");
             parse!("3141.59265e-03");
+        }
+
+        #[test]
+        fn time() {
+            parse!("time '22:12'");
+            parse!("time(10) '22:12'");
+            parse!("time WITH TIME ZONE '22:12'");
+            parse!("time WITHOUT TIME ZONE '22:12'");
+            parse!("time(10) WITH TIME ZONE '22:12'");
+            parse!("time(10) WITHOUT TIME ZONE '22:12'");
+            parse!("time (10) WITH TIME ZONE '22:12'");
+            parse!("time (10) WITHOUT TIME ZONE '22:12'");
         }
 
         #[test]
@@ -576,8 +585,11 @@ mod tests {
             parse!(r#"CAST(9 AS b)"#);
             parse!(r#"CAST(a AS VARCHAR)"#);
             parse!(r#"CAST(a AS VARCHAR(20))"#);
+            parse!(r#"CAST(a AS TIME)"#);
+            parse!(r#"CAST(a AS TIME(20))"#);
             parse!(r#"CAST( TRUE AS INTEGER)"#);
             parse!(r#"CAST( (4 in (1,2,3,4)) AS INTEGER)"#);
+            parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
         }
 
         #[test]

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -590,6 +590,8 @@ mod tests {
             parse!(r#"CAST( TRUE AS INTEGER)"#);
             parse!(r#"CAST( (4 in (1,2,3,4)) AS INTEGER)"#);
             parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
+            parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
+            parse!(r#"CAST(a AS TIME(20) WITH TIME ZONE)"#);
         }
 
         #[test]

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -916,12 +916,14 @@ FunctionCallArg: ast::CallArgAst = {
 #[inline]
 FunctionArgPositional: ast::CallArgAst = {
     <lo:@L> "*" <hi:@R> => ast::CallArg::Star().ast(lo..hi),
-    <lo:@L> <value:ExprQuery> <hi:@R> => ast::CallArg::Positional(value).ast(lo..hi)
+    <lo:@L> <value:ExprQuery> <hi:@R> => ast::CallArg::Positional(value).ast(lo..hi),
+    <lo:@L> <ty:TypeName> <hi:@R> => ast::CallArg::PositionalType(ty).ast(lo..hi),
 }
 
 #[inline]
 FunctionArgNamed: ast::CallArgAst = {
-    <lo:@L> <name:FunctionArgName> ":" <value:ExprQuery> <hi:@R> => ast::CallArg::Named{name, value: Some(value)}.ast(lo..hi)
+    <lo:@L> <name:FunctionArgName> ":" <value:ExprQuery> <hi:@R> => ast::CallArg::Named{name, value: value}.ast(lo..hi),
+    <lo:@L> <name:FunctionArgName> ":" <ty:TypeName> <hi:@R> => ast::CallArg::NamedType{name, ty: ty}.ast(lo..hi)
 }
 
 #[inline]
@@ -1050,7 +1052,7 @@ Literal: ast::Lit = {
     <LiteralAbsent>,
     <LiteralScalar>,
     <LiteralIon>,
-    <LiteralDateTime>,
+    <TypedLiteral>,
 };
 
 #[inline]
@@ -1106,11 +1108,43 @@ LiteralNumber: ast::Lit = {
 LiteralIon: ast::Lit = {
     <ion:"Ion"> => ast::Lit::IonStringLit(ion.to_owned()),
 }
+
 #[inline]
-LiteralDateTime: ast::Lit = {
-    "DATE" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::DateLit(s.to_owned())),
-    "TIME" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::TimeLit(s.to_owned())),
-    "TIMESTAMP" <s:"String"> => ast::Lit::DateTimeLit(ast::DateTimeLit::TimestampLit(s.to_owned())),
+TypeKeywordStr: &'static str = {
+    "DATE" => "DATE",
+    "TIME" => "TIME",
+    "TIMESTAMP" => "TIMESTAMP",
+    "WITH" => "WITH",
+    "WITHOUT" => "WITHOUT",
+    "ZONE" => "ZONE",
+}
+
+#[inline]
+TypeKeyword: ast::SymbolPrimitive = {
+    <s:TypeKeywordStr> => ast::SymbolPrimitive { value: s.to_string(), case: Some(ast::CaseSensitivity::CaseInsensitive), },
+}
+
+#[inline]
+TypeParam: ast::CustomTypeParam = {
+    <lo:@L> <ty:TypeName> <hi:@R> => ast::CustomTypeParam::Type(ty),
+    <lo:@L> <lit:LiteralScalar> <hi:@R> => ast::CustomTypeParam::Lit(lit),
+}
+
+TypeNamePart: ast::CustomTypePart = {
+    <id:TypeKeyword> => ast::CustomTypePart::Name( id ),
+    <id:TypeKeyword> "(" <args:CommaSepPlus<TypeParam>> ")" =>  ast::CustomTypePart::Parameterized( id, args ),
+}
+
+#[inline]
+TypeName: ast::Type = {
+    <parts:TypeNamePart+> => ast::Type::CustomType( ast::CustomType{ parts: parts } ),
+}
+
+#[inline]
+TypedLiteral: ast::Lit = {
+    <ty:TypeName> <s:"String"> => ast::Lit::TypedLit(s.to_owned(), ty),
+    // TODO we could support postgres-style literals with the following:
+    //<s:"String"> "::" <ty:TypeName> => ast::Lit::TypedLit(s.to_owned(), ty),
 }
 
 // ------------------------------------------------------------------------------ //
@@ -1309,5 +1343,7 @@ extern {
         "WHEN" => lexer::Token::When,
         "WHERE" => lexer::Token::Where,
         "WITH" => lexer::Token::With,
+        "WITHOUT" => lexer::Token::Without,
+        "ZONE" => lexer::Token::Zone,
     }
 }

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -23,6 +23,7 @@ pub(crate) enum FnExprArgMatch<'a> {
     /// 0 or more [`Token`]s that are not function punctuation (i.e., '(', ')', ',') and not a keyword
     ///
     /// Generally this will be preceded by a [`AnyOne`] match, in order to match 1 or more [`Token`]s
+    /// `bool` tuple value denotes if keyword is allowed to be considered as match.
     AnyZeroOrMore(bool),
     /// Explicitly match a single [`Token`]
     #[allow(dead_code)]

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -18,6 +18,7 @@ pub(crate) enum FnExprArgMatch<'a> {
     /// Any 1 [`Token`] that is not function punctuation (i.e., '(', ')', ',') and not a keyword.
     ///
     /// Generally this will be followed by a [`AnyZeroOrMore`] match, in order to match 1 or more [`Token`]s
+    /// `bool` tuple value denotes if keyword is allowed to be considered as match.
     AnyOne(bool),
     /// 0 or more [`Token`]s that are not function punctuation (i.e., '(', ')', ',') and not a keyword
     ///


### PR DESCRIPTION
Cf #156 

#108 #149 

Ensure the following statements parse:
- TIME WITH TIME ZONE <string-literal>
- TIME(10) WITH TIME ZONE <string-literal>
- TIME WITHOUT TIME ZONE <string-literal>
- TIME (20) WITHOUT TIME ZONE <string-literal>
- CAST(a AS TIME)
- CAST(b AS TIME(10))


`cargo run  --features visualize -- ast -Tdisplay  "select time (10) with time zone '22:12', time (10) without time zone '22:12'"`:

![iTerm2 xiILCm](https://user-images.githubusercontent.com/36067/181627658-a175029b-9abb-4a30-bce7-d0df58f6d9c3.png)

---

*Note* that this also allows statements like the following to parse (we'll need to reject at type check):
- TIME(3) WITH(2) TIME(5) ZONE(TIME(WITHOUT(5))) '22:22:10'

`cargo run  --features visualize -- ast -Tdisplay  "TIME(3) WITH(2) TIME(5) ZONE(TIME(WITHOUT(5))) '22:22:10'"`:

![iTerm2 yX4ixn](https://user-images.githubusercontent.com/36067/181627914-0635da59-70b7-4dd3-a0a7-23d22a7a996f.png)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
