### PR TITLE
Fix keywords and categories

### DIFF
--- a/partiql-cli/Cargo.toml
+++ b/partiql-cli/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 license = "Apache-2.0"
 readme = "../README.md"
-keywords = ["sql", "parser", "query", "compilers", "interpreters"]
+keywords = ["sql", "parser", "query", "compilers", "cli"]
 categories = ["database", "compilers", "parser-implementations"]
 exclude = [
   "**/.git/**",

--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -6,6 +6,8 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 license = "Apache-2.0"
 readme = "../README.md"
+keywords = ["sql", "parser", "conformance", "codegen", "tests"]
+categories = ["database", "compilers", "parser-implementations"]
 exclude = [
     "**/.git/**",
     "**/.github/**",

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -6,6 +6,8 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 license = "Apache-2.0"
 readme = "../README.md"
+keywords = ["sql", "parser", "conformance", "compilers", "tests"]
+categories = ["database", "compilers", "parser-implementations"]
 exclude = [
     "**/.git/**",
     "**/.github/**",

--- a/partiql-playground/Cargo.toml
+++ b/partiql-playground/Cargo.toml
@@ -6,8 +6,8 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 license = "Apache-2.0"
 readme = "../README.md"
-keywords = ["sql", "ast", "query", "compilers", "interpreters"]
-categories = ["database", "compilers", "wasm", "frontend"]
+keywords = ["sql", "ast", "query", "compilers", "playground"]
+categories = ["database", "compilers", "wasm", "web"]
 exclude = [
     "**/.git/**",
     "**/.github/**",

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 license = "Apache-2.0"
 readme = "../README.md"
-keywords = ["sql", "source", "sourcemap", "query", "compilers", "interpreters"]
+keywords = ["sql", "sourcemap", "query", "compilers", "interpreters"]
 categories = ["database", "compilers"]
 exclude = [
     "**/.git/**",


### PR DESCRIPTION
*Issue #, if available:*
#167 

*Description of changes:*

Fixes `keywords` and `categories` in `Cargo.toml`; specifically it ensures the number `keywords` is less than or equal to 5, because a value more than that causes an issue in `cargo publish`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
