### PR TITLE
Fix v0.1.0

### DIFF
--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -31,10 +31,10 @@ required-features = ["report_tool"]
 walkdir = "2.3"
 ion-rs = "0.6.0"
 codegen = "0.1.3"
-partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator" }
+partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.0" }
 
 [dependencies]
-partiql-parser = { path = "../partiql-parser" }
+partiql-parser = { path = "../partiql-parser", version = "0.1.0" }
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 serde_json = { version = "1.*", optional = true }


### PR DESCRIPTION
*Issue #, if available:*
#166 

*Description of changes:*

1. Remove PartiQL Playground `demo.gif`
```bash
cargo publish --dry-run && echo $?
warning: aborting upload due to dry run

0

cargo publish
...
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: max upload size is: 10485760

# new size after gif removal
➜  partiql-playground git:(playgrond-size-reduce) ls -l target/package/partiql-playground-0.1.0.crate
-rw-r--r--  1 maymandi  staff  10273106 Aug  5 15:59 target/package/partiql-playground-0.1.0.crate
```

We could use `exclude` in `Cargo.toml` but I as what the file represents can get obsolete perhaps it's worthwhile to just remove it.

2. Fix version numbers in conformance tests packages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

