### PR TITLE
(cargo-release) start next development iteration 0.1.1-alpha.0

### DIFF
--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
   "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +21,7 @@ version = "0.1.0"
 path = "src/lib.rs"
 
 [dependencies]
-partiql-source-map = { path = "../partiql-source-map", version = "0.1.0" }
+partiql-source-map = { path = "../partiql-source-map", version = "0.1.1-alpha.0" }
 
 derive_builder = "~0.11.1"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }

--- a/partiql-cli/Cargo.toml
+++ b/partiql-cli/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 [workspace]
 

--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "**/.travis.yml",
     "**/.appveyor.yml",
 ]
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 edition = "2021"
 
 # TODO: fill in other details

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "**/.travis.yml",
     "**/.appveyor.yml",
 ]
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 edition = "2021"
 
 [[bin]]
@@ -31,10 +31,10 @@ required-features = ["report_tool"]
 walkdir = "2.3"
 ion-rs = "0.6.0"
 codegen = "0.1.3"
-partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.0" }
+partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.1-alpha.0" }
 
 [dependencies]
-partiql-parser = { path = "../partiql-parser", version = "0.1.0" }
+partiql-parser = { path = "../partiql-parser", version = "0.1.1-alpha.0" }
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 serde_json = { version = "1.*", optional = true }

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-irgen/Cargo.toml
+++ b/partiql-irgen/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -15,15 +15,15 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
 lalrpop = "~0.19.7"
 
 [dependencies]
-partiql-ast = { path = "../partiql-ast", version = "0.1.0" }
-partiql-source-map = { path = "../partiql-source-map", version = "0.1.0" }
+partiql-ast = { path = "../partiql-ast", version = "0.1.1-alpha.0" }
+partiql-source-map = { path = "../partiql-source-map", version = "0.1.1-alpha.0" }
 
 thiserror = "~1.0.24"
 

--- a/partiql-playground/Cargo.toml
+++ b/partiql-playground/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 [workspace]
 

--- a/partiql-rewriter/Cargo.toml
+++ b/partiql-rewriter/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
*Issue #, if available:* 

#166 

*Description of changes:*

Prepares the version as pre-release for the next version.

```bash
cargo release --dev-version --no-push --no-publish -x
...
```

Since `partiql-cli` and `partiql-playground` are [excluded](https://github.com/partiql/partiql-lang-rust/blob/f99ce48dc3bb64571d80452c705b662302e6dfce/Cargo.toml#L15) from workspace, had to create a change for them manually. For `partiql-playground` we don't intend to release as there is no entry-point to it at this stage. For `partiql-cli` we probably need to include it as workspace `members` so that it can get included in the release. For now I'm adding the change for both until we finalize the decision for the next release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
