### PR TITLE
Fix pre-release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,6 @@
 members = [
   "partiql",
   "partiql-ast",
-  "partiql-conformance-test-generator",
-  "partiql-conformance-tests",
   "partiql-source-map",
   "partiql-eval",
   "partiql-ir",
@@ -14,7 +12,9 @@ members = [
 ]
 
 exclude = [
+  "partiql-conformance-test-generator",
+  "partiql-conformance-tests",
+  "partiql-cli",
   "partiql-playground",
-  "partiql-cli"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@
 members = [
   "partiql",
   "partiql-ast",
+  "partiql-conformance-tests",
+  "partiql-conformance-test-generator",
   "partiql-source-map",
   "partiql-eval",
   "partiql-ir",
@@ -12,8 +14,6 @@ members = [
 ]
 
 exclude = [
-  "partiql-conformance-test-generator",
-  "partiql-conformance-tests",
   "partiql-cli",
   "partiql-playground",
 ]

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
   "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,7 +21,7 @@ version = "0.1.1-alpha.0"
 path = "src/lib.rs"
 
 [dependencies]
-partiql-source-map = { path = "../partiql-source-map", version = "0.1.1-alpha.0" }
+partiql-source-map = { path = "../partiql-source-map", version = "0.1.0" }
 
 derive_builder = "~0.11.1"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }

--- a/partiql-cli/Cargo.toml
+++ b/partiql-cli/Cargo.toml
@@ -15,9 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
-
-[workspace]
+version = "0.1.0"
 
 # Example of customizing binaries in Cargo.toml.
 [[bin]]

--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "**/.travis.yml",
     "**/.appveyor.yml",
 ]
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 edition = "2021"
 
 # TODO: fill in other details

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
     "**/.travis.yml",
     "**/.appveyor.yml",
 ]
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 edition = "2021"
 
 [[bin]]
@@ -31,10 +31,10 @@ required-features = ["report_tool"]
 walkdir = "2.3"
 ion-rs = "0.6.0"
 codegen = "0.1.3"
-partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.1-alpha.0" }
+partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.0" }
 
 [dependencies]
-partiql-parser = { path = "../partiql-parser", version = "0.1.1-alpha.0" }
+partiql-parser = { path = "../partiql-parser", version = "0.1.0" }
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 serde_json = { version = "1.*", optional = true }

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-irgen/Cargo.toml
+++ b/partiql-irgen/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -15,15 +15,15 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
 lalrpop = "~0.19.7"
 
 [dependencies]
-partiql-ast = { path = "../partiql-ast", version = "0.1.1-alpha.0" }
-partiql-source-map = { path = "../partiql-source-map", version = "0.1.1-alpha.0" }
+partiql-ast = { path = "../partiql-ast", version = "0.1.0" }
+partiql-source-map = { path = "../partiql-source-map", version = "0.1.0" }
 
 thiserror = "~1.0.24"
 

--- a/partiql-playground/Cargo.toml
+++ b/partiql-playground/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 [workspace]
 

--- a/partiql-rewriter/Cargo.toml
+++ b/partiql-rewriter/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
     "**/.github/**",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
   "**/.appveyor.yml",
 ]
 edition = "2021"
-version = "0.1.1-alpha.0"
+version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
*Issue #, if available:*
#166 

*Description of changes:*

- Moves the following pacakges to workspace excluded:
   - "partiql-conformance-test-generator"
   - "partiql-conformance-tests"

  For both, users can play around with conformance tests using GitHub code.

- Removes [workspace] attribute from `partiql-cli` `Cargo.toml`. This is
  does not seems to be affect partiql-cli build.

- Changes the version back to "0.1.0". This seems to be more aligned with
  other projects as noted by @alancai98 before.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
