### PR TITLE
Allow `unused variables` in "Not Yet Implemented" tests

### DIFF
--- a/partiql-conformance-test-generator/src/generator.rs
+++ b/partiql-conformance-test-generator/src/generator.rs
@@ -55,6 +55,7 @@ fn test_case_to_function(test_case: &TestCase) -> Function {
             Assertion::NotYetImplemented => {
                 // for `NotYetImplemented` assertions, add the 'ignore' annotation to the test case
                 test_fn.attr("ignore = \"not yet implemented\"");
+                test_fn.attr("allow(unused_variables)");
             }
         }
     }


### PR DESCRIPTION
Cleans up ~97 warnings in the conformance tests similar to

```
warning: unused variable: `statement`
   --> partiql-conformance-tests/tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/time_constructor.rs:166:9
    |
166 |     let statement = r#"TIME WITH TIME ZONE (4) '23:59:59.99999'"#;
    |         ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_statement
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
