### PR TITLE
Add `partiql_tuple!` macro

### DIFF
--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -5,47 +5,44 @@ use partiql_eval::eval::{
     BasicContext, EvalFrom, EvalOutputAccumulator, EvalPath, EvalVarRef, Evaluable, Output,
     PathComponent,
 };
-use partiql_value::{partiql_bag, partiql_list, Bag, BindingsName, List, Tuple, Value};
+use partiql_value::{
+    partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
+};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
 fn data() -> MapBindings<Value> {
-    let employees = partiql_bag![
-        Tuple::from([
-            ("id", 3.into()),
-            ("name", "Bob Smith".into()),
-            ("title", Value::Null),
-            (
-                "projects",
-                partiql_list![
-                    "AWS Redshift Spectrum querying".into(),
-                    "AWS Redshift security".into(),
-                    "AWS Aurora security".into()
-                ]
-                .into()
-            ),
-        ])
-        .into(),
-        Tuple::from([
-            ("id", 4.into()),
-            ("name", "Susan Smith".into()),
-            ("title", "Dev Mgr".into()),
-            ("projects", partiql_list![].into()),
-        ])
-        .into(),
-        Tuple::from([
-            ("id", 6.into()),
-            ("name", "Jane Smith".into()),
-            ("title", "Software Eng 2".into()),
-            (
-                "projects",
-                partiql_list!["AWS Redshift security".into()].into()
-            ),
-        ])
-        .into(),
-    ];
-    let hr = Tuple::from([("employeesNestScalars", Value::from(employees))]);
+    let hr = partiql_tuple![(
+        "employeesNestScalars",
+        partiql_bag![
+            partiql_tuple![
+                ("id", 3),
+                ("name", "Bob Smith"),
+                ("title", Value::Null),
+                (
+                    "projects",
+                    partiql_list![
+                        "AWS Redshift Spectrum querying",
+                        "AWS Redshift security",
+                        "AWS Aurora security",
+                    ]
+                ),
+            ],
+            partiql_tuple![
+                ("id", 4),
+                ("name", "Susan Smith"),
+                ("title", "Dev Mgr"),
+                ("projects", partiql_list![]),
+            ],
+            partiql_tuple![
+                ("id", 6),
+                ("name", "Jane Smith"),
+                ("title", "Software Eng 2"),
+                ("projects", partiql_list!["AWS Redshift security"]),
+            ],
+        ]
+    )];
 
     let mut p0: MapBindings<Value> = MapBindings::default();
     p0.insert("hr", hr.into());

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -11,7 +11,9 @@ mod tests {
     use crate::env::basic::MapBindings;
     use crate::plan;
     use partiql_logical::{BindingsExpr, PathComponent, ValueExpr};
-    use partiql_value::{partiql_bag, partiql_list, Bag, BindingsName, List, Tuple, Value};
+    use partiql_value::{
+        partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
+    };
     use std::cell::RefCell;
     use std::collections::HashMap;
     use std::rc::Rc;
@@ -165,8 +167,8 @@ mod tests {
 
         fn some_ordered_table() -> List {
             partiql_list![
-                Tuple::from([("a", Value::from(0)), ("b", Value::from(0))]).into(),
-                Tuple::from([("a", 1.into()), ("b", 1.into())]).into(),
+                partiql_tuple![("a", 0), ("b", 0)],
+                partiql_tuple![("a", 1), ("b", 1)],
             ]
         }
 
@@ -198,16 +200,8 @@ mod tests {
             println!("{:?}", &output.borrow().output);
             // <<{ x:  { b: 0, a: 0 } },  { x:  { b: 1, a: 1 } }>>
             let expected = partiql_bag![
-                Tuple::from([(
-                    "x",
-                    Tuple::from([("a", Value::Integer(0)), ("b", 0.into())]).into()
-                ),])
-                .into(),
-                Tuple::from([(
-                    "x",
-                    Tuple::from([("a", Value::Integer(1)), ("b", 1.into())]).into()
-                ),])
-                .into()
+                partiql_tuple![("x", partiql_tuple![("a", 0), ("b", 0)]),],
+                partiql_tuple![("x", partiql_tuple![("a", 1), ("b", 1)]),],
             ];
             assert_eq!(&expected, &output.borrow().output);
         }
@@ -237,22 +231,8 @@ mod tests {
             println!("{:?}", &output.borrow().output);
             // <<{ y: 0, x:  { b: 0, a: 0 } },  { x:  { b: 1, a: 1 }, y: 1 }>>
             let expected = partiql_bag![
-                Tuple::from([
-                    (
-                        "x",
-                        Tuple::from([("a", Value::Integer(0)), ("b", 0.into())]).into()
-                    ),
-                    ("y", Value::Integer(0))
-                ])
-                .into(),
-                Tuple::from([
-                    (
-                        "x",
-                        Tuple::from([("a", Value::Integer(1)), ("b", 1.into())]).into()
-                    ),
-                    ("y", value::Value::Integer(1))
-                ])
-                .into()
+                partiql_tuple![("x", partiql_tuple![("a", 0), ("b", 0)]), ("y", 0)],
+                partiql_tuple![("x", partiql_tuple![("a", 1), ("b", 1)]), ("y", 1)],
             ];
             assert_eq!(&expected, &output.borrow().output);
         }
@@ -282,22 +262,14 @@ mod tests {
             println!("{:?}", &output.borrow().output);
             // <<{ y: MISSING, x:  { b: 0, a: 0 } },  { x:  { b: 1, a: 1 }, y: MISSING }>>
             let expected = partiql_bag![
-                Tuple::from([
-                    (
-                        "x",
-                        Tuple::from([("a", Value::Integer(0)), ("b", 0.into())]).into()
-                    ),
+                partiql_tuple![
+                    ("x", partiql_tuple![("a", 0), ("b", 0)]),
                     ("y", value::Value::Missing)
-                ])
-                .into(),
-                Tuple::from([
-                    (
-                        "x",
-                        Tuple::from([("a", Value::Integer(1)), ("b", 1.into())]).into()
-                    ),
+                ],
+                partiql_tuple![
+                    ("x", partiql_tuple![("a", 1), ("b", 1)]),
                     ("y", value::Value::Missing)
-                ])
-                .into()
+                ],
             ];
             assert_eq!(&expected, &output.borrow().output);
         }
@@ -326,7 +298,7 @@ mod tests {
             from.evaluate(&ctx);
 
             println!("{:?}", &output.borrow().output);
-            let expected = partiql_bag![Tuple::from([("x", 0.into())]).into()];
+            let expected = partiql_bag![partiql_tuple![("x", 0)]];
             assert_eq!(&expected, &output.borrow().output);
         }
 
@@ -354,7 +326,7 @@ mod tests {
             from.evaluate(&ctx);
 
             println!("{:?}", &output.borrow().output);
-            let expected = partiql_bag![Tuple::from([("x", value::Value::Missing)]).into()];
+            let expected = partiql_bag![partiql_tuple![("x", value::Value::Missing)]];
             assert_eq!(&expected, &output.borrow().output);
         }
     }
@@ -365,7 +337,7 @@ mod tests {
         use partiql_value::{partiql_bag, BindingsName, Tuple};
 
         fn just_a_tuple() -> Tuple {
-            Tuple::from([("amzn", Value::from(840.05)), ("tdc", Value::from(31.06))])
+            partiql_tuple![("amzn", 840.05), ("tdc", 31.06)]
         }
 
         // Spec 5.2
@@ -392,16 +364,8 @@ mod tests {
 
             println!("{:?}", &output.borrow().output);
             let expected = partiql_bag![
-                Tuple::from([
-                    ("symbol", "tdc".into()),
-                    ("price", Value::Real(31.06.into()))
-                ])
-                .into(),
-                Tuple::from([
-                    ("symbol", "amzn".into()),
-                    ("price", Value::Real(840.05.into()))
-                ])
-                .into(),
+                partiql_tuple![("symbol", "tdc"), ("price", 31.06)],
+                partiql_tuple![("symbol", "amzn"), ("price", 840.05)],
             ];
             assert_eq!(&expected, &output.borrow().output);
         }
@@ -429,8 +393,7 @@ mod tests {
             unpivot.evaluate(&ctx);
 
             println!("{:?}", &output.borrow().output);
-            let expected =
-                partiql_bag![Tuple::from([("x", Value::Integer(1)), ("y", "_1".into())]).into()];
+            let expected = partiql_bag![partiql_tuple![("x", 1), ("y", "_1")]];
             assert_eq!(&expected, &output.borrow().output);
         }
     }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -222,16 +222,16 @@ impl From<Bag> for List {
 
 #[macro_export]
 macro_rules! partiql_list {
-        () => (
-             List::from(vec![])
-        );
-        ($elem:expr; $n:expr) => (
-            List::from(vec![$elem, $n])
-        );
-        ($($x:expr),+ $(,)?) => (
-            List::from(vec![$($x),+])
-        );
-    }
+    () => (
+         List::from(vec![])
+    );
+    ($elem:expr; $n:expr) => (
+        List::from(vec![Value::from($elem), $n])
+    );
+    ($($x:expr),+ $(,)?) => (
+        List::from(vec![$(Value::from($x)),+])
+    );
+}
 
 impl IntoIterator for List {
     type Item = Value;
@@ -342,16 +342,16 @@ impl From<List> for Bag {
 
 #[macro_export]
 macro_rules! partiql_bag {
-        () => (
-             Bag::from(vec![])
-        );
-        ($elem:expr; $n:expr) => (
-            Bag::from(vec![$elem, $n])
-        );
-        ($($x:expr),+ $(,)?) => (
-            Bag::from(vec![$($x),+])
-        );
-    }
+    () => (
+         Bag::from(vec![])
+    );
+    ($elem:expr; $n:expr) => (
+        Bag::from(vec![Value::from($elem), $n])
+    );
+    ($($x:expr),+ $(,)?) => (
+        Bag::from(vec![$(Value::from($x)),+])
+    );
+}
 
 impl IntoIterator for Bag {
     type Item = Value;
@@ -432,11 +432,14 @@ impl Hash for Bag {
 #[derive(Default, Eq, Clone)]
 pub struct Tuple(pub HashMap<String, Value>);
 
-impl<const N: usize> From<[(&str, Value); N]> for Tuple {
+impl<const N: usize, T> From<[(&str, T); N]> for Tuple
+where
+    T: Into<Value>,
+{
     #[inline]
-    fn from(arr: [(&str, Value); N]) -> Self {
+    fn from(arr: [(&str, T); N]) -> Self {
         Tuple(HashMap::from_iter(
-            arr.into_iter().map(|(k, v)| (k.to_string(), v)),
+            arr.into_iter().map(|(k, v)| (k.to_string(), v.into())),
         ))
     }
 }
@@ -446,6 +449,16 @@ impl From<Tuple> for Value {
     fn from(v: Tuple) -> Self {
         Value::Tuple(Box::new(v))
     }
+}
+
+#[macro_export]
+macro_rules! partiql_tuple {
+    () => (
+         Tuple::from(vec![])
+    );
+    ($(($x:expr, $y:expr)),+ $(,)?) => (
+        Tuple::from([$(($x, Value::from($y))),+])
+    );
 }
 
 impl Debug for Tuple {


### PR DESCRIPTION
Clean up test & static data creation via creation and use of `partiql_tuple!` macro.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
