### PR TITLE
Use workspace inheritance for common keys in Cargo.toml for each crate in workspace

### DIFF
--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-ast"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL AST"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "ast", "query", "compilers", "interpreters"]
@@ -12,8 +12,8 @@ exclude = [
   "**/.git/**",
   "**/.github/**",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-conformance-tests"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL conformance test runner"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "conformance", "compilers", "tests"]
@@ -14,8 +14,8 @@ exclude = [
     "**/.travis.yml",
     "**/.appveyor.yml",
 ]
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "generate_comparison_report"

--- a/partiql-ir/Cargo.toml
+++ b/partiql-ir/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-ir"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL Intermediate Representation"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
@@ -14,8 +14,8 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.0.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-irgen/Cargo.toml
+++ b/partiql-irgen/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-irgen"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL IR Generator"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
@@ -14,8 +14,8 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-parser"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL Parser"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
@@ -14,8 +14,8 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -44,7 +44,7 @@ lazy_static = "~1.4.0"
 serde = { version = "1.*", features = ["derive"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [features]
 default = []

--- a/partiql-rewriter/Cargo.toml
+++ b/partiql-rewriter/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-rewriter"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL Rewriter Framework"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
@@ -14,8 +14,8 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql-source-map"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL Source Map"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "sourcemap", "query", "compilers", "interpreters"]
@@ -12,8 +12,8 @@ exclude = [
     "**/.git/**",
     "**/.github/**",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql-types/Cargo.toml
+++ b/partiql-types/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "partiql-types"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL Type Definitions"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
-categories = ["database", "compilers", "parser-implementations"]
+categories = ["database", "compilers"]
 exclude = [
   "**/.git/**",
   "**/.github/**",
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.0.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "partiql"
-authors = ["PartiQL Team <partiql-team@amazon.com>"]
 description = "PartiQL in Rust"
-homepage = "https://github.com/partiql/partiql-lang-rust"
-repository = "https://github.com/partiql/partiql-lang-rust"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 license = "Apache-2.0"
 readme = "../README.md"
 keywords = ["sql", "parser", "query", "compilers", "interpreters"]
@@ -14,8 +14,8 @@ exclude = [
   "**/.travis.yml",
   "**/.appveyor.yml",
 ]
-edition = "2021"
-version = "0.1.0"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Common Keys:
 - authors
 - homepage
 - repository
 - crate version
 - rust edition

See
https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
