### PR TITLE
[steel thread] Add query plan and eval using DAG model

### DIFF
--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -22,6 +22,7 @@ edition.workspace = true
 [dependencies]
 partiql-logical = { path = "../partiql-logical" }
 partiql-value = { path = "../partiql-value" }
+petgraph = "0.6.*"
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -1,3 +1,7 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use partiql_eval::env::basic::MapBindings;
@@ -8,9 +12,6 @@ use partiql_eval::eval::{
 use partiql_value::{
     partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
 };
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::time::Duration;
 
 fn data() -> MapBindings<Value> {
     let hr = partiql_tuple![(

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use partiql_value::{BindingsName, Tuple, Value};
 use unicase::UniCase;
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -5,7 +5,8 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 use petgraph::algo::toposort;
-use petgraph::{Graph, Incoming, Outgoing};
+use petgraph::{Directed, Incoming, Outgoing};
+use petgraph::prelude::StableGraph;
 
 use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{Bag, BindingsName, Tuple, Value};
@@ -60,7 +61,7 @@ pub struct Sink {
 }
 
 #[derive(Debug)]
-pub struct EvalPlan(pub Graph<EvalOp, ()>);
+pub struct EvalPlan(pub StableGraph::<EvalOp, (), Directed>);
 
 impl Default for EvalPlan {
     fn default() -> Self {
@@ -70,7 +71,7 @@ impl Default for EvalPlan {
 
 impl EvalPlan {
     fn new() -> Self {
-        EvalPlan(Graph::<EvalOp, ()>::new())
+        EvalPlan(StableGraph::<EvalOp, (), Directed>::new())
     }
 }
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use std::rc::Rc;
 
 use petgraph::algo::toposort;
-use petgraph::graph::NodeIndex;
 use petgraph::{Graph, Incoming, Outgoing};
 
 use partiql_value::Value::{Boolean, Missing, Null};
@@ -26,16 +25,14 @@ pub struct Scan {
     pub expr: Box<dyn EvalExpr>,
     pub as_key: String,
     pub output: Option<Value>,
-    pub consumers: Vec<NodeIndex>,
 }
 
 impl Scan {
-    pub fn new(expr: Box<dyn EvalExpr>, as_key: &str, consumers: Vec<NodeIndex>) -> Self {
+    pub fn new(expr: Box<dyn EvalExpr>, as_key: &str) -> Self {
         Scan {
             expr,
             as_key: as_key.to_string(),
             output: None,
-            consumers,
         }
     }
 }
@@ -45,16 +42,14 @@ pub struct Project {
     pub exprs: HashMap<String, Box<dyn EvalExpr>>,
     pub input: Vec<Tuple>,
     pub output: Vec<Tuple>,
-    pub consumers: Vec<NodeIndex>,
 }
 
 impl Project {
-    pub fn new(exprs: HashMap<String, Box<dyn EvalExpr>>, consumers: Vec<NodeIndex>) -> Self {
+    pub fn new(exprs: HashMap<String, Box<dyn EvalExpr>>) -> Self {
         Project {
             exprs,
             input: vec![],
             output: vec![],
-            consumers,
         }
     }
 }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -4,19 +4,22 @@ pub mod plan;
 
 #[cfg(test)]
 mod tests {
-    use crate::eval::{EvalFromAt, EvalOutputAccumulator, Evaluable, Evaluator, Output};
-    use partiql_logical as logical;
-    use partiql_value as value;
-
-    use crate::env::basic::MapBindings;
-    use crate::plan;
-    use partiql_logical::{BindingsExpr, PathComponent, ValueExpr};
-    use partiql_value::{
-        partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
-    };
     use std::cell::RefCell;
     use std::collections::HashMap;
     use std::rc::Rc;
+
+    use partiql_logical as logical;
+    use partiql_logical::{BindingsExpr, LogicalPlan, PathComponent, ValueExpr};
+    use partiql_value as value;
+    use partiql_value::{
+        partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
+    };
+
+    use crate::env::basic::MapBindings;
+    use crate::eval::{
+        DagEvaluator, EvalFromAt, EvalOutputAccumulator, Evaluable, Evaluator, Output,
+    };
+    use crate::plan;
 
     fn evaluate(logical: BindingsExpr, bindings: MapBindings<Value>) -> Bag {
         let output = Rc::new(RefCell::new(EvalOutputAccumulator::default()));
@@ -25,12 +28,27 @@ mod tests {
         };
 
         let evaluable = planner.compile(logical);
-
         let mut evaluator = Evaluator::new(bindings, evaluable);
+
         evaluator.execute();
 
         println!("{:?}", &output);
+        let result = &output.borrow_mut().output;
+        result.clone()
+    }
 
+    // TODO: rename once we move to DAG model completely
+    fn evaluate_dag(logical: LogicalPlan, bindings: MapBindings<Value>) -> Bag {
+        let output = Rc::new(RefCell::new(EvalOutputAccumulator::default()));
+        let planner = plan::EvaluatorPlanner {
+            output: output.clone(),
+        };
+        let plan = planner.compile_dag(logical);
+        let mut evaluator = DagEvaluator::new(bindings);
+
+        evaluator.execute_dag(plan);
+
+        println!("{:?}", &output);
         let result = &output.borrow_mut().output;
         result.clone()
     }
@@ -92,6 +110,38 @@ mod tests {
         });
 
         let result = evaluate(logical, data_3_tuple());
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn select_dag() {
+        // Plan for `select a as b from data`
+        let mut logical = LogicalPlan::new();
+        let from = logical.0.add_node(BindingsExpr::Scan(logical::Scan {
+            expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+            as_key: "data".to_string(),
+            at_key: None,
+        }));
+
+        let select = logical.0.add_node(BindingsExpr::Project(logical::Project {
+            exprs: HashMap::from([(
+                "b".to_string(),
+                ValueExpr::Path(
+                    Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                        "data".into(),
+                    ))),
+                    vec![PathComponent::Key("a".to_string())],
+                ),
+            )]),
+        }));
+
+        let output = logical.0.add_node(BindingsExpr::Output);
+
+        logical
+            .0
+            .extend_with_edges(&[(from, select), (select, output)]);
+
+        let result = evaluate_dag(logical, data_3_tuple());
         assert_eq!(result.len(), 3);
     }
 
@@ -161,9 +211,11 @@ mod tests {
     }
 
     mod clause_from {
-        use super::*;
-        use crate::eval::{BasicContext, EvalFrom, EvalPath, EvalVarRef, PathComponent};
         use partiql_value::{partiql_bag, partiql_list, BindingsName};
+
+        use crate::eval::{BasicContext, EvalFrom, EvalPath, EvalVarRef, PathComponent};
+
+        use super::*;
 
         fn some_ordered_table() -> List {
             partiql_list![
@@ -332,9 +384,11 @@ mod tests {
     }
 
     mod clause_unpivot {
-        use super::*;
-        use crate::eval::{BasicContext, EvalUnpivot, EvalVarRef, Output};
         use partiql_value::{partiql_bag, BindingsName, Tuple};
+
+        use crate::eval::{BasicContext, EvalUnpivot, EvalVarRef, Output};
+
+        use super::*;
 
         fn just_a_tuple() -> Tuple {
             partiql_tuple![("amzn", 840.05), ("tdc", 31.06)]

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -47,7 +47,7 @@ impl EvaluatorPlanner {
     #[inline]
     fn plan_eval_dag(&self, lg: LogicalPlan) -> EvalPlan {
         let plan = lg.0;
-        let mut eval_plan = EvalPlan::new();
+        let mut eval_plan = EvalPlan::default();
         eval_plan.0 = plan.map(
             |idx, n| {
                 let ne = plan.neighbors_directed(idx, Outgoing);

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -21,6 +21,7 @@ edition.workspace = true
 
 [dependencies]
 partiql-value = { path = "../partiql-value" }
+petgraph = "0.6.*"
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,10 +1,10 @@
 use partiql_value::{BindingsName, Value};
-use petgraph::{Directed};
-use std::collections::HashMap;
 use petgraph::prelude::StableGraph;
+use petgraph::Directed;
+use std::collections::HashMap;
 
 #[derive(Debug)]
-pub struct LogicalPlan(pub StableGraph::<BindingsExpr, (), Directed>);
+pub struct LogicalPlan(pub StableGraph<BindingsExpr, (), Directed>);
 
 impl LogicalPlan {
     pub fn new() -> Self {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,13 +1,23 @@
 use partiql_value::{BindingsName, Value};
+use petgraph::Graph;
 use std::collections::HashMap;
 
-// TODO we should replace this enum with some identifier that can be looked up in a symtab/funcregistry?
 #[derive(Debug)]
+pub struct LogicalPlan(pub Graph<BindingsExpr, ()>);
+
+impl LogicalPlan {
+    pub fn new() -> Self {
+        LogicalPlan(Graph::<BindingsExpr, ()>::new())
+    }
+}
+
+// TODO we should replace this enum with some identifier that can be looked up in a symtab/funcregistry?
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum UnaryOp {}
 
 // TODO we should replace this enum with some identifier that can be looked up in a symtab/funcregistry?
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum BinaryOp {
     And,
@@ -21,22 +31,13 @@ pub enum BinaryOp {
     Lteq,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum PathComponent {
     Key(String),
     Index(i64),
 }
 
-#[derive(Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
-pub enum Expr {
-    Value(ValueExpr),
-    Bindings(BindingsToValueExpr),
-    BindingsToValue(BindingsToValueExpr),
-    ValueToBindings(ValueToBindingsExpr),
-}
-
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum ValueExpr {
     // TODO other variants
@@ -51,10 +52,11 @@ pub enum ValueExpr {
 // Values   -> Bindings : From
 // Bindings -> Values   : Select Value
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum BindingsExpr {
     From(From),
+    Scan(Scan),
     Unpivot,
     Where(Where),
     OrderBy,
@@ -64,8 +66,10 @@ pub enum BindingsExpr {
     SetOp,
     SelectValue(SelectValue),
     Select(Select),
+    Project(Project),
     Distinct(Distinct),
     GroupBy,
+    #[default]
     Output,
 }
 
@@ -87,6 +91,13 @@ pub struct From {
 }
 
 #[derive(Debug)]
+pub struct Scan {
+    pub expr: ValueExpr,
+    pub as_key: String,
+    pub at_key: Option<String>,
+}
+
+#[derive(Debug)]
 pub struct Where {
     pub expr: ValueExpr,
     pub out: Box<BindingsExpr>,
@@ -96,6 +107,11 @@ pub struct Where {
 pub struct Select {
     pub exprs: HashMap<String, ValueExpr>,
     pub out: Box<BindingsExpr>,
+}
+
+#[derive(Debug)]
+pub struct Project {
+    pub exprs: HashMap<String, ValueExpr>,
 }
 
 #[derive(Debug)]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,13 +1,14 @@
 use partiql_value::{BindingsName, Value};
-use petgraph::Graph;
+use petgraph::{Directed};
 use std::collections::HashMap;
+use petgraph::prelude::StableGraph;
 
 #[derive(Debug)]
-pub struct LogicalPlan(pub Graph<BindingsExpr, ()>);
+pub struct LogicalPlan(pub StableGraph::<BindingsExpr, (), Directed>);
 
 impl LogicalPlan {
     pub fn new() -> Self {
-        LogicalPlan(Graph::<BindingsExpr, ()>::new())
+        LogicalPlan(StableGraph::<BindingsExpr, (), Directed>::new())
     }
 }
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::vec;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum BindingsName {
     CaseSensitive(String),
     CaseInsensitive(String),


### PR DESCRIPTION
*Issue #, if available:* 
Closes #21

#### Description of changes
Adds the required changes for enabling query evaluation using a DAG model.

What is our definition of DAG?
We are only interested in DAGs that can be used as execution plans, which leads to the following definition. A DAG is a directed, cycle-free graph G = (V, E) with a denoted root node v0 ∈ V such that all v ∈ V \{v0} are reachable from v0. Note that this is the definition of trees without the condition |E| = |V | − 1. Hence, all trees are DAGs. Reference: https://link.springer.com/article/10.1007/s00450-009-0061-0

#### In addition
- The steel thread includes only `Scan` and `Project` operators, and passes the test for planning and evaluation of the following query:
```SQL
SELECT a AS b FROM data
```
- The code is _not_ clean, maybe not idiomatic at some instances, and lacks documentation. I'll iterate through the code with a consequent PR when adding new operators.

#### Algorithm
We're loosely using a push model with DAG as called out in the following: https://link.springer.com/article/10.1007/s00450-009-0061-0 (Section 10.3.5. Pushing)

1. Create a DAG logical plan `LogicalPlan` with each node as a logical operator (for now manual until we integrate with AST -> PLAN).
1. Create an evaluation plan `EvalPlan` with the same structure as logical plan.
1. [Toposort](https://en.wikipedia.org/wiki/Topological_sorting) the `EvalPlan` to ensure all dependencies of a node get evaluated before the node itself.
1. For each operator in `EvalPlan`, eval the node.
1. Store the result in the node.
1. Push the output to each consumer—for now, for final result, we use a `Sink` node that is considered as the node that accumulates output; we need to see if there are better alternatives.

#### Yet to be implemented
- [ ] port all the other existing nodes and ensure the current tests pass against them
- [ ] add error handling and validation (incl. DAG cyclic validation).
- [ ] add documentation.

Finally, we're not performing any optimization at this stage (and we won't for extended amount of time).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
