### PR TITLE
Add arithmetic ops to evaluator; add Decimal partiql-value

### DIFF
--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -25,6 +25,7 @@ partiql-value = { path = "../partiql-value" }
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"
+rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -105,35 +105,56 @@ pub enum EvalBinop {
     Gteq,
     Lt,
     Lteq,
+
+    // Arithmetic ops
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Exp,
 }
 
 impl EvalExpr for EvalBinopExpr {
     fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
         let lhs = self.lhs.evaluate(bindings, ctx);
         let rhs = self.rhs.evaluate(bindings, ctx);
-        match self.op {
-            EvalBinop::And => todo!(),
-            EvalBinop::Or => todo!(),
-            EvalBinop::Concat => {
-                // TODO non-naive concat
-                let lhs = if let Value::String(s) = lhs {
-                    *s
-                } else {
-                    format!("{:?}", lhs)
-                };
-                let rhs = if let Value::String(s) = rhs {
-                    *s
-                } else {
-                    format!("{:?}", lhs)
-                };
-                Value::String(Box::new(format!("{}{}", lhs, rhs)))
+        // Missing and Null propagation. Missing has precedence over Null
+        if lhs == Value::Missing || rhs == Value::Missing {
+            Value::Missing
+        } else if lhs == Value::Null || rhs == Value::Null {
+            Value::Null
+        } else {
+            match self.op {
+                EvalBinop::And => todo!(),
+                EvalBinop::Or => todo!(),
+                EvalBinop::Concat => {
+                    // TODO non-naive concat
+                    let lhs = if let Value::String(s) = lhs {
+                        *s
+                    } else {
+                        format!("{:?}", lhs)
+                    };
+                    let rhs = if let Value::String(s) = rhs {
+                        *s
+                    } else {
+                        format!("{:?}", lhs)
+                    };
+                    Value::String(Box::new(format!("{}{}", lhs, rhs)))
+                }
+                EvalBinop::Eq => todo!(),
+                EvalBinop::Neq => todo!(),
+                EvalBinop::Gt => Boolean(lhs > rhs),
+                EvalBinop::Gteq => Boolean(lhs >= rhs),
+                EvalBinop::Lt => Boolean(lhs < rhs),
+                EvalBinop::Lteq => Boolean(lhs <= rhs),
+                EvalBinop::Add => lhs + rhs,
+                EvalBinop::Sub => lhs - rhs,
+                EvalBinop::Mul => lhs * rhs,
+                EvalBinop::Div => lhs / rhs,
+                EvalBinop::Mod => lhs % rhs,
+                EvalBinop::Exp => todo!("Exponentiation"),
             }
-            EvalBinop::Eq => todo!(),
-            EvalBinop::Neq => todo!(),
-            EvalBinop::Gt => Boolean(lhs > rhs),
-            EvalBinop::Gteq => Boolean(lhs >= rhs),
-            EvalBinop::Lt => Boolean(lhs < rhs),
-            EvalBinop::Lteq => Boolean(lhs <= rhs),
         }
     }
 }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -9,13 +9,12 @@ mod tests {
     use std::rc::Rc;
 
     use partiql_logical as logical;
-    use partiql_logical::{BindingsExpr, LogicalPlan, PathComponent, ValueExpr};
+    use partiql_logical::{BinaryOp, BindingsExpr, LogicalPlan, PathComponent, ValueExpr};
     use partiql_value as value;
 
     use crate::env::basic::MapBindings;
     use crate::plan;
     use ordered_float::OrderedFloat;
-    use partiql_logical::{BinaryOp, BindingsExpr, PathComponent, ValueExpr};
     use partiql_value::{
         partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
     };

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -90,6 +90,12 @@ impl EvaluatorPlanner {
                     BinaryOp::Gteq => EvalBinop::Gteq,
                     BinaryOp::Lt => EvalBinop::Lt,
                     BinaryOp::Lteq => EvalBinop::Gteq,
+                    BinaryOp::Add => EvalBinop::Add,
+                    BinaryOp::Sub => EvalBinop::Sub,
+                    BinaryOp::Mul => EvalBinop::Mul,
+                    BinaryOp::Div => EvalBinop::Div,
+                    BinaryOp::Mod => EvalBinop::Mod,
+                    BinaryOp::Exp => EvalBinop::Exp,
                 };
                 Box::new(EvalBinopExpr { op, lhs, rhs })
             }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -19,6 +19,14 @@ pub enum BinaryOp {
     Gteq,
     Lt,
     Lteq,
+
+    // Arithmetic ops
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Exp,
 }
 
 #[derive(Debug)]

--- a/partiql-value/Cargo.toml
+++ b/partiql-value/Cargo.toml
@@ -23,6 +23,8 @@ edition.workspace = true
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"
+rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
+rust_decimal_macros = "1.26"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -163,7 +163,7 @@ fn coerce_int_or_real_to_decimal(value: &Value) -> Value {
             } else {
                 match Decimal::from_f64(real_value.0) {
                     Some(d_from_r) => Value::Decimal(rust_decimal::Decimal::from(d_from_r)),
-                    None => Value::Missing,
+                    None => Value::Missing, // TODO: decide on behavior when float cannot be coerced to Decimal
                 }
             }
         }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -300,6 +300,12 @@ impl Ord for Value {
             (Value::Boolean(_), _) => Ordering::Less,
             (_, Value::Boolean(_)) => Ordering::Greater,
 
+            // TODO: `OrderedFloat`'s implementation of `Ord` slightly differs from what we want in
+            //  the PartiQL spec. See https://partiql.org/assets/PartiQL-Specification.pdf#subsection.12.2
+            //  point 3. In PartiQL, `nan`, comes before `-inf` which comes before all numeric
+            //  values, which are followed by `+inf`. `OrderedFloat` places `NaN` as greater than
+            //  all other `OrderedFloat` values. We could consider creating our own float type
+            //  to get around this annoyance.
             (Value::Real(l), Value::Real(r)) => {
                 if l.is_nan() {
                     if r.is_nan() {


### PR DESCRIPTION
Implements arithmetic ops (+, -, *, /, %; exponentiation is saved for a TODO) in the evaluator and adds a Decimal PartiQL `Value` using the [rust_decimal](https://crates.io/crates/rust_decimal) crate. Also included are some minor fixes to the following:
- Fix to `Ord` related to `OrderedFloat` behavior
- Add `missing`/`null` propagation in binary expressions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
