### PR TITLE
Refactor conformance test generator to encapsulate logic

### DIFF
--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -23,6 +23,8 @@ edition = "2021"
 
 [dependencies]
 walkdir = "2.3"
-ion-rs = "0.6.0"
-codegen = "0.1.3"
+ion-rs = "0.14.*"
+codegen = "0.2.*"
 Inflector = "0.11.4"
+miette = "5.*"
+thiserror = "1.*"

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -1,174 +1,57 @@
-pub mod generator;
+mod generator;
+mod reader;
 mod schema;
-pub mod util;
+mod util;
+mod writer;
 
-use crate::schema::{
+use crate::generator::Generator;
+use crate::schema::spec::{
     Assertion, Assertions, Namespace, Namespaces, TestCase, TestCases, TestDocument,
 };
 use crate::util::StringExt;
-use ion_rs::value::owned::OwnedElement;
-use ion_rs::value::{Element, Sequence, Struct, SymbolToken};
-use ion_rs::IonType;
-use std::collections::HashSet;
-use std::ops::Add;
 
-// TODO: move these test data parsing functions to own file
-/// Converts a vector of Ion data into a `TestDocument`, which can be composed of `Namespace`s
-/// and `TestCase`s. `Namespace`s must be provided as IonLists while `TestCase`s must be provided
-/// as IonStructs. Other Ion types will result in a panic.
-///
-/// When encountering a duplicate namespace/test case, a namespace/test case will be added with
-/// '_0' suffixed to the end of the name.
-pub fn ion_data_to_test_document(all_ion_data: Vec<OwnedElement>) -> TestDocument {
-    let mut namespaces = Vec::new();
-    let mut test_cases = Vec::new();
+use std::path::Path;
 
-    let mut encountered_ns_names: HashSet<String> = HashSet::new();
-    let mut encountered_tc_names: HashSet<String> = HashSet::new();
+use crate::reader::read_schema;
 
-    for elem in all_ion_data {
-        match elem.ion_type() {
-            IonType::List => {
-                // namespace in document
-                let mut ns = test_namespace(&elem);
-                if encountered_ns_names.contains(&ns.name) {
-                    ns.name.push_str("_0")
-                }
-                encountered_ns_names.insert(ns.name.clone());
-                namespaces.push(ns)
-            }
-            IonType::Struct => {
-                // test case in document
-                let mut tc = test_case(&elem);
-                if encountered_tc_names.contains(&tc.test_name) {
-                    tc.test_name.push_str("_0")
-                }
-                encountered_tc_names.insert(tc.test_name.clone());
-                test_cases.push(tc)
-            }
-            _ => panic!("Document parsing requires an IonList or IonStruct"),
+// TODO docs
+#[derive(Debug, Copy, Clone)]
+pub enum OverwriteStrategy {
+    Overwrite,
+    Backup,
+}
+
+/// Configuration for the generation of conformance tests.
+#[derive(Debug, Copy, Clone)]
+pub struct Config {
+    pub overwrite: OverwriteStrategy,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            overwrite: OverwriteStrategy::Overwrite,
         }
-    }
-    TestDocument {
-        namespaces,
-        test_cases,
     }
 }
 
-/// Parses the given `OwnedElement` to a `Namespace`. Requires an annotation to provided that will
-/// be used to create the name. '_namespace' will be suffixed to the first annotation provided.
-/// The namespace can contain sub-namespaces and test cases represented by IonLists and IonStructs
-/// respectively. When provided with something other than an IonList or IonStruct, this function
-/// will panic.
-pub fn test_namespace(element: &OwnedElement) -> Namespace {
-    let annot: Vec<_> = element
-        .annotations()
-        .map(|a| a.text().expect("annotation text"))
-        .collect();
-    let name = annot
-        .first()
-        .expect("expected an annotation for the namespace")
-        .escaped_snake_case()
-        .add("_namespace");
-
-    let mut namespaces: Namespaces = Vec::new();
-    let mut test_cases: TestCases = Vec::new();
-
-    let mut encountered_ns_names: HashSet<String> = HashSet::new();
-    let mut encountered_tc_names: HashSet<String> = HashSet::new();
-
-    for ns_or_test in element.as_sequence().expect("namespace is list").iter() {
-        match ns_or_test.ion_type() {
-            // namespace within the namespace
-            IonType::List => {
-                let mut ns = test_namespace(ns_or_test);
-                if encountered_ns_names.contains(&ns.name) {
-                    ns.name.push_str("_0")
-                }
-                encountered_ns_names.insert(ns.name.clone());
-                namespaces.push(ns)
-            }
-            // test case within the namespace
-            IonType::Struct => {
-                let mut tc = test_case(ns_or_test);
-                if encountered_tc_names.contains(&tc.test_name) {
-                    tc.test_name.push_str("_0")
-                }
-                encountered_tc_names.insert(tc.test_name.clone());
-                test_cases.push(tc)
-            }
-            _ => panic!("Namespace parsing requires an IonList or IonStruct"),
-        }
+impl Config {
+    pub fn new() -> Config {
+        Config::default()
     }
-    Namespace {
-        name,
-        namespaces,
-        test_cases,
-    }
-}
 
-/// Parses the given IonStruct to a `TestCase`. The IonStruct requires two string fields with the
-/// 'name' and 'statement' in addition to an 'assert' field containing one or more `Assertions`.
-///
-/// For test assertions that are not supported (e.g. StaticAnalysisFail), the assertion of
-/// `NotYetImplemented` will be used.
-fn test_case(element: &OwnedElement) -> TestCase {
-    let test_struct = element.as_struct().expect("struct");
-    let test_name = test_struct
-        .get("name")
-        .expect("name")
-        .as_str()
-        .expect("as_str()")
-        .escaped_snake_case()
-        .add("_test");
-    let statement = test_struct
-        .get("statement")
-        .expect("statement")
-        .as_str()
-        .expect("as_str()")
-        .to_string();
+    pub fn process_dir(
+        &self,
+        test_data: impl AsRef<Path>,
+        out_path: impl AsRef<Path>,
+    ) -> miette::Result<()> {
+        let schema = read_schema(test_data)?;
+        let scopes = Generator::new().generate(schema)?;
 
-    let assert_field = test_struct.get("assert").expect("assert field missing");
-    let assertions_vec: Vec<_> = match assert_field.ion_type() {
-        IonType::Struct => vec![assert_field],
-        IonType::List => assert_field
-            .as_sequence()
-            .expect("as_sequence")
-            .iter()
-            .collect(),
-        _ => panic!("Invalid IonType for the test case assertions"),
-    };
-    let assertions = assertions(&assertions_vec);
-    TestCase {
-        test_name,
-        statement,
-        assertions,
+        // TODO implement OverwriteStrategy
+        writer::write_scopes(out_path, scopes)?;
+        Ok(())
     }
-}
-
-/// Converts the vector of Ion values into `Assertions`. Checks that a result field is provided
-/// in the vector and has the symbol 'SyntaxSuccess' or 'SyntaxFail', which correspond to
-/// `Assertion::SyntaxSuccess` and `Assertion::SyntaxFail` respectively. Other assertion symbols
-/// will default to `Assertion::NotYetImplemented`
-fn assertions(assertions: &Vec<&OwnedElement>) -> Assertions {
-    let mut test_case_assertions: Assertions = Vec::new();
-    for assertion in assertions {
-        let assertion_struct = assertion.as_struct().expect("as_struct()");
-        let parse_result = assertion_struct.get("result");
-        match parse_result {
-            Some(r) => {
-                let r_as_str = r.as_str().expect("as_str()");
-                let assertion = match r_as_str {
-                    "SyntaxSuccess" => Assertion::SyntaxSuccess,
-                    "SyntaxFail" => Assertion::SyntaxFail,
-                    _ => Assertion::NotYetImplemented,
-                };
-                test_case_assertions.push(assertion);
-            }
-            None => (),
-        }
-    }
-    test_case_assertions
 }
 
 #[cfg(test)]

--- a/partiql-conformance-test-generator/src/reader.rs
+++ b/partiql-conformance-test-generator/src/reader.rs
@@ -1,0 +1,229 @@
+use crate::schema::structure::{TestDir, TestEntry, TestFile, TestRoot};
+use crate::{
+    Assertion, Assertions, Namespace, Namespaces, StringExt, TestCase, TestCases, TestDocument,
+};
+
+use ion_rs::value::owned::Element;
+use ion_rs::value::reader::{element_reader, ElementReader};
+use ion_rs::value::{IonElement, IonSequence, IonStruct};
+use ion_rs::IonType;
+use miette::IntoDiagnostic;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::fs;
+use std::fs::DirEntry;
+
+use std::ops::Add;
+use std::path::{Path, PathBuf};
+
+pub fn read_schema(root: impl AsRef<Path>) -> miette::Result<TestRoot> {
+    let fail = read_root(&root, "fail")?;
+    let success = read_root(&root, "success")?;
+    Ok(TestRoot { fail, success })
+}
+
+fn read_root(root: impl AsRef<Path>, root_type: &str) -> miette::Result<Vec<TestEntry>> {
+    let mut dir: PathBuf = PathBuf::from(root.as_ref());
+    dir.push(root_type);
+
+    let root = fs::read_dir(root)
+        .into_diagnostic()?
+        .filter_map(|entry| read_entry(entry.expect("entry")))
+        .collect();
+    Ok(root)
+}
+
+fn read_entry(entry: DirEntry) -> Option<TestEntry> {
+    let file_type = entry.file_type().expect("file_type");
+    let name = entry.file_name().into_string().expect("file name");
+
+    let ion_file_extension = OsStr::new("ion");
+    if file_type.is_file() {
+        if entry.path().extension() == Some(ion_file_extension) {
+            let contents = read_test_doc(entry);
+            Some(TestEntry::Doc(TestFile {
+                file_name: name,
+                contents,
+            }))
+        } else {
+            None
+        }
+    } else if file_type.is_dir() {
+        let contents = fs::read_dir(entry.path())
+            .expect("read_dir")
+            .into_iter()
+            .filter_map(|x| read_entry(x.expect("entry")))
+            .collect();
+        Some(TestEntry::Dir(TestDir {
+            dir_name: name,
+            contents,
+        }))
+    } else {
+        unreachable!()
+    }
+}
+
+fn read_test_doc(entry: DirEntry) -> TestDocument {
+    let buf = fs::read(entry.path()).unwrap();
+    let elements = element_reader().read_all(&buf).unwrap();
+    ion_data_to_test_document(elements)
+}
+
+/// Converts a vector of Ion data into a `TestDocument`, which can be composed of `Namespace`s
+/// and `TestCase`s. `Namespace`s must be provided as IonLists while `TestCase`s must be provided
+/// as IonStructs. Other Ion types will result in a panic.
+///
+/// When encountering a duplicate namespace/test case, a namespace/test case will be added with
+/// '_0' suffixed to the end of the name.
+fn ion_data_to_test_document(all_ion_data: Vec<Element>) -> TestDocument {
+    let mut namespaces = Vec::new();
+    let mut test_cases = Vec::new();
+
+    let mut encountered_ns_names: HashSet<String> = HashSet::new();
+    let mut encountered_tc_names: HashSet<String> = HashSet::new();
+
+    for elem in all_ion_data {
+        match elem.ion_type() {
+            IonType::List => {
+                // namespace in document
+                let mut ns = test_namespace(&elem);
+                if encountered_ns_names.contains(&ns.name) {
+                    ns.name.push_str("_0")
+                }
+                encountered_ns_names.insert(ns.name.clone());
+                namespaces.push(ns)
+            }
+            IonType::Struct => {
+                // test case in document
+                let mut tc = test_case(&elem);
+                if encountered_tc_names.contains(&tc.test_name) {
+                    tc.test_name.push_str("_0")
+                }
+                encountered_tc_names.insert(tc.test_name.clone());
+                test_cases.push(tc)
+            }
+            _ => panic!("Document parsing requires an IonList or IonStruct"),
+        }
+    }
+    TestDocument {
+        namespaces,
+        test_cases,
+    }
+}
+
+/// Parses the given `OwnedElement` to a `Namespace`. Requires an annotation to provided that will
+/// be used to create the name. '_namespace' will be suffixed to the first annotation provided.
+/// The namespace can contain sub-namespaces and test cases represented by IonLists and IonStructs
+/// respectively. When provided with something other than an IonList or IonStruct, this function
+/// will panic.
+fn test_namespace(element: &Element) -> Namespace {
+    let annot: Vec<_> = element
+        .annotations()
+        .map(|a| a.text().expect("annotation text"))
+        .collect();
+    let name = annot
+        .first()
+        .expect("expected an annotation for the namespace")
+        .escaped_snake_case()
+        .add("_namespace");
+
+    let mut namespaces: Namespaces = Vec::new();
+    let mut test_cases: TestCases = Vec::new();
+
+    let mut encountered_ns_names: HashSet<String> = HashSet::new();
+    let mut encountered_tc_names: HashSet<String> = HashSet::new();
+
+    for ns_or_test in element.as_sequence().expect("namespace is list").iter() {
+        match ns_or_test.ion_type() {
+            // namespace within the namespace
+            IonType::List => {
+                let mut ns = test_namespace(ns_or_test);
+                if encountered_ns_names.contains(&ns.name) {
+                    ns.name.push_str("_0")
+                }
+                encountered_ns_names.insert(ns.name.clone());
+                namespaces.push(ns)
+            }
+            // test case within the namespace
+            IonType::Struct => {
+                let mut tc = test_case(ns_or_test);
+                if encountered_tc_names.contains(&tc.test_name) {
+                    tc.test_name.push_str("_0")
+                }
+                encountered_tc_names.insert(tc.test_name.clone());
+                test_cases.push(tc)
+            }
+            _ => panic!("Namespace parsing requires an IonList or IonStruct"),
+        }
+    }
+    Namespace {
+        name,
+        namespaces,
+        test_cases,
+    }
+}
+
+/// Parses the given IonStruct to a `TestCase`. The IonStruct requires two string fields with the
+/// 'name' and 'statement' in addition to an 'assert' field containing one or more `Assertions`.
+///
+/// For test assertions that are not supported (e.g. StaticAnalysisFail), the assertion of
+/// `NotYetImplemented` will be used.
+fn test_case(element: &Element) -> TestCase {
+    let test_struct = element.as_struct().expect("struct");
+    let test_name = test_struct
+        .get("name")
+        .expect("name")
+        .as_str()
+        .expect("as_str()")
+        .escaped_snake_case()
+        .add("_test");
+    let statement = test_struct
+        .get("statement")
+        .expect("statement")
+        .as_str()
+        .expect("as_str()")
+        .to_string();
+
+    let assert_field = test_struct.get("assert").expect("assert field missing");
+    let assertions_vec: Vec<_> = match assert_field.ion_type() {
+        IonType::Struct => vec![assert_field],
+        IonType::List => assert_field
+            .as_sequence()
+            .expect("as_sequence")
+            .iter()
+            .collect(),
+        _ => panic!("Invalid IonType for the test case assertions"),
+    };
+    let assertions = assertions(&assertions_vec);
+    TestCase {
+        test_name,
+        statement,
+        assertions,
+    }
+}
+
+/// Converts the vector of Ion values into `Assertions`. Checks that a result field is provided
+/// in the vector and has the symbol 'SyntaxSuccess' or 'SyntaxFail', which correspond to
+/// `Assertion::SyntaxSuccess` and `Assertion::SyntaxFail` respectively. Other assertion symbols
+/// will default to `Assertion::NotYetImplemented`
+fn assertions(assertions: &Vec<&Element>) -> Assertions {
+    let mut test_case_assertions: Assertions = Vec::new();
+    for assertion in assertions {
+        let assertion_struct = assertion.as_struct().expect("as_struct()");
+        let parse_result = assertion_struct.get("result");
+
+        if let Some(r) = parse_result {
+            let r_as_str = r.as_str().expect("as_str()");
+            let assertion = match r_as_str {
+                "SyntaxSuccess" => Assertion::SyntaxSuccess,
+                "SyntaxFail" => Assertion::SyntaxFail,
+                _ => Assertion::NotYetImplemented,
+            };
+            test_case_assertions.push(assertion);
+        }
+    }
+    test_case_assertions
+}
+
+#[cfg(test)]
+mod test {}

--- a/partiql-conformance-test-generator/src/schema.rs
+++ b/partiql-conformance-test-generator/src/schema.rs
@@ -1,43 +1,72 @@
-/// Conformance test document containing namespaces and/or tests
-///
-/// Follows the `partiql-tests-data` specified in https://github.com/partiql/partiql-tests/blob/main/partiql-tests-data/partiql-tests-schema.isl.
-///
-/// TODO: when `ion-schema-rust` supports schema code generation based on .isl, replace these
-///  objects.
-pub struct TestDocument {
-    pub(crate) namespaces: Namespaces,
-    pub(crate) test_cases: TestCases,
-}
-pub type Namespaces = Vec<Namespace>;
+pub mod structure {
+    use crate::schema::spec::TestDocument;
 
-/// Namespace can contain other namespaces and/or tests
-pub struct Namespace {
-    pub(crate) name: String,
-    pub(crate) namespaces: Namespaces,
-    pub(crate) test_cases: TestCases,
-}
-pub type TestCases = Vec<TestCase>;
+    pub struct TestRoot {
+        pub fail: Vec<TestEntry>,
+        pub success: Vec<TestEntry>,
+    }
 
-/// Test cases have a `test_name` and a PartiQL `statement` along with the `assertions` to check for
-/// expected behavior(s). In the future, additional fields will be added the `TestCase` struct for
-/// additional testing configurations.
-pub struct TestCase {
-    pub(crate) test_name: String,
-    pub(crate) statement: String,
-    pub(crate) assertions: Assertions,
-}
-pub type Assertions = Vec<Assertion>;
+    pub enum TestEntry {
+        Dir(TestDir),
+        Doc(TestFile),
+    }
 
-/// Assertion specifies expected behaviors to be checked in the given test case.
-///
-/// Currently just supports 'Syntax'-related assertions. In the future, other assertion variants
-/// will be added (e.g. static analysis, evaluation). For now, the other assertions will be
-/// `NotYetImplemented`.
-pub enum Assertion {
-    /// Asserts statement is syntactically correct
-    SyntaxSuccess,
-    /// Asserts statement has at least one syntax error
-    SyntaxFail,
-    /// Assertion that has yet to be implemented
-    NotYetImplemented,
+    pub struct TestDir {
+        pub dir_name: String,
+        pub contents: Vec<TestEntry>,
+    }
+
+    pub struct TestFile {
+        pub file_name: String,
+        pub contents: TestDocument,
+    }
+}
+
+pub mod spec {
+    /// Conformance test document containing namespaces and/or tests
+    ///
+    /// Follows the `partiql-tests-data` specified in https://github.com/partiql/partiql-tests/blob/main/partiql-tests-data/partiql-tests-schema.isl.
+    ///
+    /// TODO: when `ion-schema-rust` supports schema code generation based on .isl, replace these
+    ///  objects.
+    pub struct TestDocument {
+        pub namespaces: Namespaces,
+        pub test_cases: TestCases,
+    }
+
+    pub type Namespaces = Vec<Namespace>;
+
+    /// Namespace can contain other namespaces and/or tests
+    pub struct Namespace {
+        pub name: String,
+        pub namespaces: Namespaces,
+        pub test_cases: TestCases,
+    }
+
+    pub type TestCases = Vec<TestCase>;
+
+    /// Test cases have a `test_name` and a PartiQL `statement` along with the `assertions` to check for
+    /// expected behavior(s). In the future, additional fields will be added the `TestCase` struct for
+    /// additional testing configurations.
+    pub struct TestCase {
+        pub test_name: String,
+        pub statement: String,
+        pub assertions: Assertions,
+    }
+
+    pub type Assertions = Vec<Assertion>;
+
+    /// Assertion specifies expected behaviors to be checked in the given test case.
+    ///
+    /// Currently just supports 'Syntax'-related assertions. In the future, other assertion variants
+    /// will be added (e.g. static analysis, evaluation). For now, the other assertions will be
+    /// `NotYetImplemented`.
+    pub enum Assertion {
+        /// Asserts statement is syntactically correct
+        SyntaxSuccess,
+        /// Asserts statement has at least one syntax error
+        SyntaxFail,
+        /// Assertion that has yet to be implemented
+        NotYetImplemented,
+    }
 }

--- a/partiql-conformance-test-generator/src/util.rs
+++ b/partiql-conformance-test-generator/src/util.rs
@@ -1,11 +1,4 @@
 use inflector::Inflector;
-use std::ffi::{OsStr, OsString};
-use std::fs;
-use std::fs::File;
-use std::io::Write;
-use std::ops::Add;
-use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 pub trait StringExt {
     /// Converts a string slice into an escaped `String`
@@ -21,65 +14,9 @@ impl StringExt for &str {
     }
 }
 
-/// Returns a file name with prefix prepended and 'rs' as the extension
-pub fn to_full_file_name(prefix: &str, ion_file: &Path) -> String {
-    let ion_file = ion_file
-        .file_stem()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .escaped_snake_case()
-        .add(".rs");
-    format!("{}_{}", prefix, ion_file)
-}
-
-/// Returns a vector of all .ion files in the directory `dir`
-pub fn all_ion_files_in(dir: &str) -> walkdir::Result<Vec<PathBuf>> {
-    let ion_file_extension = OsStr::new("ion");
-    WalkDir::new(dir)
-        .into_iter()
-        .filter_map(|result| match result {
-            Ok(entry) => {
-                if entry.path().extension() == Some(ion_file_extension) {
-                    Some(Ok(entry.into_path()))
-                } else {
-                    None
-                }
-            }
-            Err(e) => Some(Err(e)),
-        })
-        .collect()
-}
-
-/// Creates a `mod.rs` file for the given `dir` with all the subdirectories and file names in the
-/// directory. Also recursively generates `mod.rs` files for all of `dir`'s subdirectories. Requires
-/// `dir` to be a directory.
-pub fn dir_to_mods(dir: &Path) {
-    assert!(dir.is_dir());
-    let mut modules_in_dir: Vec<OsString> = Vec::new();
-    for entry in fs::read_dir(dir).expect("read dir") {
-        let entry = entry.expect("dir entry");
-        let entry_file_type = entry.file_type().expect("file type");
-
-        if entry_file_type.is_file() {
-            let file_name = entry.file_name();
-            if file_name == "mod.rs" {
-                continue;
-            }
-        }
-
-        modules_in_dir.push(entry.path().file_stem().expect("file stem").to_os_string());
-
-        if entry_file_type.is_dir() {
-            dir_to_mods(&entry.path())
-        }
-    }
-    let mod_rs_path = dir.join(Path::new("mod.rs"));
-    let mut mod_rs_file = File::create(mod_rs_path).expect("mod.rs create failed");
-    for module in modules_in_dir {
-        mod_rs_file
-            .write_all(format!("mod {};\n", module.to_str().expect("to str")).as_bytes())
-            .expect("Failure when writing to file");
+impl StringExt for String {
+    fn escaped_snake_case(&self) -> String {
+        self.as_str().escaped_snake_case()
     }
 }
 

--- a/partiql-conformance-test-generator/src/writer.rs
+++ b/partiql-conformance-test-generator/src/writer.rs
@@ -1,0 +1,89 @@
+use crate::generator::{TestComponent, TestModule};
+use crate::StringExt;
+use codegen::Scope;
+use miette::IntoDiagnostic;
+
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn write_scopes(path: impl AsRef<Path>, root: TestModule) -> miette::Result<()> {
+    let path: &Path = path.as_ref();
+    std::fs::create_dir_all(&path).into_diagnostic()?;
+
+    write_top_level(path, "partiql_tests")?;
+
+    let mut path: PathBuf = (&path).into();
+
+    path.push("partiql_tests");
+
+    write_module(path, root)?;
+
+    Ok(())
+}
+
+fn write_module(path: impl AsRef<Path>, module: TestModule) -> miette::Result<()> {
+    write_dir_mod(&path, module.children.keys())?;
+
+    for (name, child) in module.children {
+        let mut child_path: PathBuf = path.as_ref().into();
+        match child {
+            TestComponent::Scope(mut scope) => {
+                child_path.push(&name);
+                write_scope(child_path, scope.module.scope())?
+            }
+            TestComponent::Module(module) => {
+                child_path.push(&name.escaped_snake_case());
+
+                write_module(child_path, module)?
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_top_level(path: impl AsRef<Path>, sub_tests_dir: &str) -> miette::Result<()> {
+    std::fs::create_dir_all(&path).into_diagnostic()?;
+
+    // Creates the top-level mod.rs file in the tests/ directory and adds the "conformance_test"
+    // flag to this mod
+    let file_path = path.as_ref().join("mod.rs");
+    File::create(file_path)
+        .into_diagnostic()?
+        .write_all(
+            format!(
+                "#[cfg(feature = \"conformance_test\")]\nmod {};\n",
+                sub_tests_dir
+            )
+            .as_bytes(),
+        )
+        .into_diagnostic()
+}
+
+fn write_dir_mod<'a>(
+    path: impl AsRef<Path>,
+    sub_mods: impl Iterator<Item = &'a String>,
+) -> miette::Result<()> {
+    std::fs::create_dir_all(&path).into_diagnostic()?;
+
+    let contents = sub_mods
+        .map(|m| format!("mod {};", m.replace(".rs", "").escaped_snake_case()))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let file_path = path.as_ref().join("mod.rs");
+    File::create(file_path)
+        .into_diagnostic()?
+        .write_all(contents.as_bytes())
+        .into_diagnostic()
+}
+
+fn write_scope(path: impl AsRef<Path>, scope: &Scope) -> miette::Result<()> {
+    let contents = scope.to_string();
+
+    File::create(path)
+        .into_diagnostic()?
+        .write_all(contents.as_bytes())
+        .into_diagnostic()
+}

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -28,9 +28,10 @@ required-features = ["report_tool"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-walkdir = "2.3"
-ion-rs = "0.6.0"
-codegen = "0.1.3"
+#walkdir = "2.3"
+#ion-rs = "0.6.0"
+#codegen = "0.1.3"
+miette = { version ="5.*", features = ["fancy"] }
 partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.0" }
 
 [dependencies]

--- a/partiql-conformance-tests/build.rs
+++ b/partiql-conformance-tests/build.rs
@@ -1,66 +1,12 @@
-use ion_rs::value::reader::{element_reader, ElementReader};
-use partiql_conformance_test_generator::generator::Generator;
-use partiql_conformance_test_generator::ion_data_to_test_document;
-use partiql_conformance_test_generator::util::{all_ion_files_in, dir_to_mods, StringExt};
-use std::fs::File;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use partiql_conformance_test_generator::Config;
+
 use std::process::Command;
-use std::{fs, io};
 
-/// TODO: once APIs are more stable, include documentation on what this build script is doing
-fn main() -> io::Result<()> {
+fn main() -> miette::Result<()> {
     println!("cargo:rerun-if-changed=partiql-tests");
+    println!("cargo:rerun-if-changed=tests/partiql_tests");
 
-    let tests_dir = "tests/";
-    let tests_path = Path::new(tests_dir);
-
-    // TODO: consider first moving directory and deleting once test generation is successful
-    if tests_path.exists() {
-        fs::remove_dir_all(tests_dir).expect("removal of tests/ before test generation");
-    }
-
-    let file_dir = "partiql-tests";
-    let all_files = all_ion_files_in(file_dir).expect("test files");
-
-    for file in &all_files {
-        let all_data = fs::read(file).unwrap();
-        let all_ion_data = element_reader().read_all(&all_data).unwrap();
-
-        let test_document = ion_data_to_test_document(all_ion_data);
-        let test_generator = Generator { test_document };
-        let scope = test_generator.generate_scope().to_string();
-
-        let dest_path_non_escaped = Path::new("tests").join(file.with_extension(""));
-        let dest_path_escaped: PathBuf = dest_path_non_escaped
-            .iter()
-            .map(|path_part| path_part.to_str().expect("to_str").escaped_snake_case())
-            .collect();
-        let dest_path = dest_path_escaped.with_extension("rs");
-
-        let dest_dir = dest_path.parent().expect("parent of dest_path");
-        std::fs::create_dir_all(dest_dir).expect("recursively created directory");
-        File::create(dest_path)
-            .expect("File creation failed")
-            .write_all(scope.as_bytes())
-            .expect("Failure when writing to file");
-    }
-
-    let sub_tests_dir = "partiql_tests";
-    let sub_tests_path = Path::new(sub_tests_dir);
-    dir_to_mods(&tests_path.join(sub_tests_path));
-    // Creates the top-level mod.rs file in the tests/ directory and adds the "conformance_test"
-    // flag to this mod
-    File::create(&tests_path.join("mod.rs"))
-        .expect("mod.rs created in root test folder")
-        .write_all(
-            format!(
-                "#[cfg(feature = \"conformance_test\")]\nmod {};\n",
-                sub_tests_dir
-            )
-            .as_bytes(),
-        )
-        .expect("Failure when writing to file");
+    Config::new().process_dir("partiql-tests", "tests/")?;
 
     Command::new("cargo")
         .arg("fmt")
@@ -68,5 +14,6 @@ fn main() -> io::Result<()> {
         .arg("--")
         .spawn()
         .expect("cargo fmt of tests/ failed");
+
     Ok(())
 }

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -18,7 +18,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smallvec = { version = "~1.8.0" }
+smallvec = { version = "1.*" }
 serde = { version = "1.*", features = ["derive"], optional = true }
 
 anymap = "1.0.0-beta.2"


### PR DESCRIPTION
This is a behavior-preserving refactor of conformance test generator library to encapsulate all generation logic. 

Logic is split into 3 phases:
 - the reader reads the filesystem & ion test files into a set of schema structs
 - the generator transforms the schema & structure into a tree of 'codegen' objects
 - the writer creates directories, writes out the codegen objects, and generates rust module trees

---

Diff against previous version's generated output, showing identical generation:

```shell
❯ diff -C 1 -r tests tests_v0 -s
Files tests/mod.rs and tests_v0/mod.rs are identical
Files tests/partiql_tests/mod.rs and tests_v0/partiql_tests/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/aggregate_function_call.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/aggregate_function_call.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/call.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/call.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/cast.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/cast.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/date_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/date_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/operator/is_operator.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/operator/is_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/operator/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/operator/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/time_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/fail/static_analysis/primitives/time_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/call.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/call.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/case.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/case.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/cast.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/cast.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/container_constructors.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/container_constructors.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/date_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/date_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/expressions.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/expressions.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/at_operator.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/at_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/between_operator.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/between_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/like_operator.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/like_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/operators/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/path_expression.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/path_expression.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/primitives/time_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/primitives/time_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/pivot.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/pivot.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/select/joins.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/select/joins.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/select/limit_offset.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/select/limit_offset.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/select/mod.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/select/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/select/order_by.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/select/order_by.rs are identical
Files tests/partiql_tests/partiql_tests_data/fail/syntax/query/select/select.rs and tests_v0/partiql_tests/partiql_tests_data/fail/syntax/query/select/select.rs are identical
Files tests/partiql_tests/partiql_tests_data/mod.rs and tests_v0/partiql_tests/partiql_tests_data/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/aggregate_function_call.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/aggregate_function_call.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/call.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/call.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/case.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/case.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/cast.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/cast.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/container_constructors.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/container_constructors.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/date_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/date_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/extract.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/extract.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/identifiers.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/identifiers.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/literal.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/literal.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/arithmetic_operators.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/arithmetic_operators.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/at_operator.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/at_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/between_operator.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/between_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/comparison_operators.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/comparison_operators.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/in_operator.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/in_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/is_operator.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/is_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/like_operator.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/like_operator.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/logical_operators.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/logical_operators.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/string_operators.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/string_operators.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/unary_operators.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/operators/unary_operators.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/parameter.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/parameter.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/path_expression.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/path_expression.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/time_constructor.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/time_constructor.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/primitives/union_except_intersect.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/primitives/union_except_intersect.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/pivot.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/pivot.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/group_by.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/group_by.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/having.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/having.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/joins.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/joins.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/limit_offset.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/limit_offset.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/mod.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/mod.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/order_by.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/order_by.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/select.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/select.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/select_value.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/select_value.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/set_quantifier.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/set_quantifier.rs are identical
Files tests/partiql_tests/partiql_tests_data/success/syntax/query/select/unpivot.rs and tests_v0/partiql_tests/partiql_tests_data/success/syntax/query/select/unpivot.rs are identical
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
