### PR TITLE
Remove `petgraph` from logical plan dependency

### DIFF
--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -50,7 +50,6 @@ mod tests {
         };
 
         let plan = planner.compile_dag(logical);
-        // dbg!(&plan);
         let mut evaluator = DagEvaluator::new(bindings);
 
         if let Ok(out) = evaluator.execute_dag(plan) {

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -278,8 +278,8 @@ mod tests {
 
         let sink = lg.add_operator(BindingsExpr::Output);
 
-        lg.add_flow(&from, &project);
-        lg.add_flow(&project, &sink);
+        lg.add_flow(from, project);
+        lg.add_flow(project, sink);
 
         if let Value::Bag(b) = evaluate_dag(lg, data_3_tuple()) {
             assert_eq!(b.len(), 3);

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -21,7 +21,6 @@ edition.workspace = true
 
 [dependencies]
 partiql-value = { path = "../partiql-value" }
-petgraph = "0.6.*"
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -6,9 +6,57 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct LogicalPlan(pub StableGraph<BindingsExpr, (), Directed>);
 
+#[derive(Debug)]
+pub struct OpId(usize);
+
+impl OpId {
+    fn index(&self) -> usize {
+        self.0
+    }
+}
+
 impl LogicalPlan {
     pub fn new() -> Self {
         LogicalPlan(StableGraph::<BindingsExpr, (), Directed>::new())
+    }
+}
+
+#[derive(Debug)]
+pub struct LgPlan<'a, T> {
+    nodes: Vec<T>,
+    edges: Vec<Vec<&'a OpId>>,
+    node_count: usize,
+}
+
+impl<'b, T> LgPlan<'b, T> {
+    fn new() -> Self {
+        LgPlan {
+            nodes: vec![],
+            edges: vec![],
+            node_count: 0,
+        }
+    }
+
+    fn add_operator(&mut self, op: T) -> OpId {
+        self.nodes.push(op);
+        self.edges.push(vec![]);
+        self.node_count += 1;
+        OpId(self.node_count)
+    }
+    fn add_relation<'a: 'b>(&mut self, src: &'a OpId, dst: &'a OpId) {
+        let src_index = src.index() - 1;
+        let dst_index = dst.index() - 1;
+        self.nodes.get(src_index).expect("No such operator exists");
+        self.nodes.get(dst_index).expect("No such operator exists");
+
+        // let mut edge:&mut Vec<&OpId> = self.edges.get(src_index).expect("some").borrow_mut();
+        self.edges[src_index].extend(vec![dst]);
+    }
+    fn operators(&self) -> &Vec<T> {
+        &self.nodes
+    }
+    fn relations(&self) -> &Vec<Vec<&OpId>> {
+        &self.edges
     }
 }
 
@@ -132,4 +180,22 @@ pub struct SelectValue {
 #[derive(Debug)]
 pub struct Distinct {
     pub out: Box<BindingsExpr>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plan() {
+        let mut p:LgPlan<BindingsExpr> = LgPlan::new();
+        let a = p.add_operator(BindingsExpr::OrderBy);
+        let b = p.add_operator(BindingsExpr::Output);
+        let c = p.add_operator(BindingsExpr::Limit);
+        p.add_relation(&a, &b);
+        p.add_relation(&a, &c);
+        p.add_relation(&b, &c);
+        assert_eq!(3, p.operators().len());
+        assert_eq!(3, p.relations().len());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* 

Closes #206

*Description of changes:*
    
As a follow on action item from #202  this commit removes the `petgraph`
dependency from `LogicalPlan`.
    
The graph presented in this commit has just enough interfaces for doing
he work for now. We need to iterate on it later when vending as an API
to consumers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
