### PR TITLE
Add `SELECT VALUE` planning and evaluation

### DIFF
--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -29,6 +29,7 @@ unicase = "2.*"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.26"
 thiserror = "1.0.*"
+assert_matches = "1.5.*"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.10.*"
 unicase = "2.*"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.26"
+thiserror = "1.0.*"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -2,6 +2,8 @@ pub mod env;
 pub mod eval;
 pub mod plan;
 
+#[macro_use]
+extern crate assert_matches;
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -473,11 +475,16 @@ mod tests {
         lg.add_flow(from, project);
         lg.add_flow(project, sink);
 
-        if let Value::Bag(b) = evaluate(lg, data_3_tuple()) {
-            assert_eq!(b.len(), 3);
-        } else {
-            panic!("Wrong output")
-        }
+        let out = evaluate(lg, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
+            let expected = partiql_bag![
+                partiql_tuple![("b", 1)],
+                partiql_tuple![("b", 2)],
+                partiql_tuple![("b", 3)],
+            ];
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1:
@@ -505,13 +512,12 @@ mod tests {
         lg.add_flow(from, select_value);
         lg.add_flow(select_value, sink);
 
-        if let Value::Bag(out) = evaluate(lg, data_3_tuple()) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![2, 4, 6];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.1 — Tuple constructors
@@ -551,16 +557,15 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![
                 partiql_tuple![("a", 1), ("b", 1)],
                 partiql_tuple![("a", 2), ("b", 2)],
             ];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.1 — Tuple constructors
@@ -593,17 +598,16 @@ mod tests {
         lg.add_flow(from, project);
         lg.add_flow(project, sink);
 
-        if let Value::Bag(out) = evaluate(lg, data_3_tuple()) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![
                 partiql_tuple![("test", 2)],
                 partiql_tuple![("test", 4)],
                 partiql_tuple![("test", 6)],
             ];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.1 — Treatment of mistyped attribute names in permissive mode
@@ -641,13 +645,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_tuple![("legit", 1)], partiql_tuple![]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.1 — Treatment of duplicate attribute names
@@ -689,13 +692,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_tuple![("same", 1), ("same", 2)]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.2 — Array Constructors
@@ -732,13 +734,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_list![1, 1], partiql_list![2, 2]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.2 — Array Constructors
@@ -769,13 +770,12 @@ mod tests {
         lg.add_flow(from, select_value);
         lg.add_flow(select_value, sink);
 
-        if let Value::Bag(out) = evaluate(lg, data_3_tuple()) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_list![2], partiql_list![4], partiql_list![6]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.3 — Bag Constructors
@@ -813,13 +813,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_bag![1, 1], partiql_bag![2, 2]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.4 — Treatment of MISSING in SELECT VALUE
@@ -854,14 +853,13 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected =
                 partiql_bag![partiql_tuple![("a", 1), ("b", 1)], partiql_tuple![("a", 2)],];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.4 — Treatment of MISSING in SELECT VALUE
@@ -894,13 +892,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_list![1, 1], partiql_list![2, Value::Missing]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.4 — Treatment of MISSING in SELECT VALUE
@@ -926,13 +923,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![1, Value::Missing];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     // Spec 6.1.4 — Treatment of MISSING in SELECT VALUE
@@ -965,13 +961,12 @@ mod tests {
         let mut bindings: MapBindings<Value> = MapBindings::default();
         bindings.insert("data", data.into());
 
-        if let Value::Bag(out) = evaluate(lg, bindings) {
-            println!("{:?}", &out);
+        let out = evaluate(lg, bindings);
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![partiql_bag![1, 1], partiql_bag![2, Value::Missing]];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     #[test]
@@ -1036,15 +1031,15 @@ mod tests {
             (distinct, sink),
         ]);
 
-        if let Value::Bag(out) = evaluate(logical, data_customer()) {
+        let out = evaluate(logical, data_customer());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
             let expected = partiql_bag![
                 partiql_tuple![("firstName", "jason"), ("doubleName", "jasonjason")],
                 partiql_tuple![("firstName", "miriam"), ("doubleName", "miriammiriam")],
             ];
-            assert_eq!(expected, *out);
-        } else {
-            panic!("Wrong output")
-        }
+            assert_eq!(*bag, expected);
+        });
     }
 
     mod clause_from {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -105,6 +105,46 @@ pub enum ValueExpr {
     Lit(Box<Value>),
     Path(Box<ValueExpr>, Vec<PathComponent>),
     VarRef(BindingsName),
+    TupleExpr(TupleExpr),
+    ListExpr(ListExpr),
+    BagExpr(BagExpr),
+}
+
+#[derive(Clone, Debug)]
+pub struct TupleExpr {
+    pub attrs: Vec<ValueExpr>,
+    pub values: Vec<ValueExpr>,
+}
+
+impl TupleExpr {
+    pub fn new() -> Self {
+        TupleExpr {
+            attrs: vec![],
+            values: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ListExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+impl ListExpr {
+    pub fn new() -> Self {
+        ListExpr { elements: vec![] }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BagExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+impl BagExpr {
+    pub fn new() -> Self {
+        BagExpr { elements: vec![] }
+    }
 }
 
 // Bindings -> Bindings : Where, OrderBy, Offset, Limit, Join, SetOp, Select, Distinct, GroupBy, Unpivot, Let
@@ -122,8 +162,8 @@ pub enum BindingsExpr {
     Limit,
     Join,
     SetOp,
-    SelectValue(SelectValue),
     Project(Project),
+    ProjectValue(ProjectValue),
     Distinct,
     GroupBy,
     #[default]
@@ -165,9 +205,8 @@ pub struct Project {
 }
 
 #[derive(Debug)]
-pub struct SelectValue {
-    pub exprs: ValueExpr,
-    pub out: Box<ValueExpr>,
+pub struct ProjectValue {
+    pub expr: ValueExpr,
 }
 
 #[cfg(test)]

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -11,7 +11,7 @@ use std::{ops, vec};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::{Decimal as RustDecimal, Decimal};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Hash, Debug)]
 pub enum BindingsName {
     CaseSensitive(String),
     CaseInsensitive(String),
@@ -458,7 +458,7 @@ impl Debug for Value {
             Value::Blob(s) => write!(f, "'{:?}'", s),
             Value::List(l) => l.fmt(f),
             Value::Bag(b) => b.fmt(f),
-            Value::Tuple(t) => t.fmt(f),
+            Value::Tuple(t) => write!(f, "{:?}", t),
         }
     }
 }
@@ -886,7 +886,7 @@ impl Hash for Bag {
     }
 }
 
-#[derive(Default, Eq, Debug, Clone)]
+#[derive(Default, Eq, Clone)]
 pub struct Tuple {
     attrs: Vec<String>,
     vals: Vec<Value>,
@@ -978,6 +978,18 @@ impl Hash for Tuple {
             k.hash(state);
             v.hash(state);
         }
+    }
+}
+
+impl Debug for Tuple {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let pairs = self.pairs();
+        let mut fmt = f.debug_struct("Tuple");
+        pairs.into_iter().for_each(|(k, v)| {
+            fmt.field(k, v);
+        });
+
+        fmt.finish()
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Closes #216 

*Description of changes:*

This commit adds the planning and evaluation of `SELECT VALUE` statements. It also:
- Addresses a previous comment with regards to adding `thiserror` to `EvaluationErr`.
- Adds `Debug` to `Tuple` type.

The following cases are covered in tests:
#### Section 6.1 (basic `SELECT VALUE`)
```SQL
-- Expected: <<2, 4, 6>>
SELECT VALUE 2*v.a
FROM [{'a': 1}, {'a': 2}, {'a': 3}] AS v;
```

#### Section 6.1.1 _Tuple constructors_
```SQL
-- Expected: <<{'a': 1, 'b': 1}, {'a': 2, 'b': 2}>>
SELECT VALUE {'a':v.a, 'b':v.b}
FROM [{'a': 1, 'b': 1}, {'a': 2, 'b': 2}] AS v;

-- Treatment of mistyped attribute names
-- Expected: <<{'legit': 1}, {}>>
SELECT VALUE {v.a: v.b}
FROM [{'a': 'legit', 'b': 1}, {'a': 400, 'b': 2}] AS v;

-- Treatment of duplicate attribute names
-- Expected: <<{'same': 1, 'same': 2}>>
SELECT VALUE {v.a: v.b, v.c: v.d}
FROM [{'a': 'same', 'b': 1, 'c': 'same', 'd': 2}] AS v;
```

#### Section 6.1.2 _Array Constructors_

```SQL
-- Expected: <<[1, 1], [2, 2]>>
SELECT VALUE [v.a, v.b]
FROM [{'a':  1, 'b':  1}, {'a': 2, 'b': 2}] AS v;
```

#### Section 6.1.3 _Bag Constructors_

```SQL
-- Expected: << <<1, 1>>, <<2, 2>> >>
SELECT VALUE <<v.a, v.b>>
FROM [{'a': 1, 'b': 1}, {'a': 2, 'b': 2}] AS v;
```

#### Section 6.1.4 _Treatment of MISSING in SELECT VALUE_

```SQL
-- Expected: <<{'a': 1, 'b': 1}, {'a': 2}>>
SELECT VALUE {'a': v.a, 'b': v.b}
FROM [{'a': 1, 'b': 1}, {'a': 2}] AS v;

-- Expected: <<[1, 1], [2, MISSING]>>
SELECT VALUE [v.a, v.b]
FROM [{'a': 1, 'b': 1}, {'a': 2}] AS v;

-- Expected: <<1, MISSING>>
SELECT VALUE v.b
FROM [{'a': 1, 'b': 1}, {'a': 2}] AS v;
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
