### PR TITLE
For Conformance Test Generator: large epectations to file rather than inline string.

### DIFF
--- a/partiql-conformance-test-generator/src/reader.rs
+++ b/partiql-conformance-test-generator/src/reader.rs
@@ -199,7 +199,6 @@ impl TryFrom<&Struct> for TestCase {
             }
         };
 
-        //let statement = expect_str!(value.get("statement"), "TestCase statement").into();
         let env = if let Some(v) = value.get("env") {
             Some(expect_struct!(Some(v), "TestCase envs").clone())
         } else {


### PR DESCRIPTION
Move large "expected" values to external files similar to "environment" files.
Move all such test data files into `_test_data` directory.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
