### PR TITLE
Add `INNER` and `CROSS JOIN`s to planner and evaluator

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use petgraph::algo::toposort;
 use petgraph::prelude::StableGraph;
-use petgraph::{Directed, Incoming, Outgoing};
+use petgraph::{Directed, Outgoing};
 
 use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{
@@ -18,7 +18,7 @@ use crate::env::basic::MapBindings;
 use crate::env::Bindings;
 
 #[derive(Debug)]
-pub struct EvalPlan(pub StableGraph<Box<dyn Evaluable>, (), Directed>);
+pub struct EvalPlan(pub StableGraph<Box<dyn Evaluable>, u8, Directed>);
 
 impl Default for EvalPlan {
     fn default() -> Self {
@@ -28,7 +28,7 @@ impl Default for EvalPlan {
 
 impl EvalPlan {
     fn new() -> Self {
-        EvalPlan(StableGraph::<Box<dyn Evaluable>, (), Directed>::new())
+        EvalPlan(StableGraph::<Box<dyn Evaluable>, u8, Directed>::new())
     }
 }
 
@@ -50,7 +50,7 @@ pub enum EvaluationError {
 
 pub trait Evaluable: Debug {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value>;
-    fn update_input(&mut self, input: &Value);
+    fn update_input(&mut self, input: &Value, branch_num: u8);
 }
 
 #[derive(Debug)]
@@ -108,8 +108,97 @@ impl Evaluable for EvalScan {
         self.output.clone()
     }
 
-    fn update_input(&mut self, _input: &Value) {
+    fn update_input(&mut self, _input: &Value, _branch_num: u8) {
         todo!("update_input for Scan")
+    }
+}
+
+#[derive(Debug)]
+pub enum EvalJoinKind {
+    Inner,
+    Left,
+    Right,
+    Full,
+    Cross,
+}
+
+#[derive(Debug)]
+pub struct EvalJoin {
+    pub kind: EvalJoinKind,
+    pub on: Option<Box<dyn EvalExpr>>,
+    pub input_l: Option<Value>,
+    pub input_r: Option<Value>,
+    pub output: Option<Value>,
+}
+
+impl EvalJoin {
+    pub fn new(kind: EvalJoinKind, on: Option<Box<dyn EvalExpr>>) -> Self {
+        EvalJoin {
+            kind,
+            on,
+            input_l: None,
+            input_r: None,
+            output: None,
+        }
+    }
+}
+
+impl Evaluable for EvalJoin {
+    fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value> {
+        let output = match self.kind {
+            EvalJoinKind::Inner => {
+                let mut result = partiql_bag!();
+                for binding_tuple_l in self.input_l.clone().unwrap() {
+                    let binding_tuple_l = binding_tuple_l.coerce_to_tuple();
+                    for binding_tuple_r in self.input_r.clone().unwrap() {
+                        let binding_tuple_r = binding_tuple_r.coerce_to_tuple();
+                        let mut new_result = binding_tuple_l.clone();
+                        for pairs in binding_tuple_r.pairs() {
+                            new_result.insert(pairs.0, pairs.1.clone());
+                        }
+                        if let Some(on_condition) = &self.on {
+                            if on_condition.evaluate(&new_result, ctx) == Boolean(true) {
+                                result.push(new_result.into());
+                            }
+                        } else {
+                            result.push(new_result.into());
+                        }
+                    }
+                }
+                Some(result.into())
+            }
+            EvalJoinKind::Left => {
+                todo!("Left JOINs")
+            }
+            EvalJoinKind::Cross => {
+                let mut result = partiql_bag!();
+                for binding_tuple_l in self.input_l.clone().unwrap() {
+                    let binding_tuple_l = binding_tuple_l.coerce_to_tuple();
+                    for binding_tuple_r in self.input_r.clone().unwrap() {
+                        let binding_tuple_r = binding_tuple_r.coerce_to_tuple();
+                        let mut new_result = binding_tuple_l.clone();
+                        for pairs in binding_tuple_r.pairs() {
+                            new_result.insert(pairs.0, pairs.1.clone());
+                        }
+                        result.push(new_result.into());
+                    }
+                }
+                Some(result.into())
+            }
+            EvalJoinKind::Full | EvalJoinKind::Right => {
+                todo!("Full and Right Joins are not yet implemented for `partiql-lang-rust`")
+            }
+        };
+        self.output = output;
+        self.output.clone()
+    }
+
+    fn update_input(&mut self, input: &Value, branch_num: u8) {
+        match branch_num {
+            0 => self.input_l = Some(input.clone()),
+            1 => self.input_r = Some(input.clone()),
+            _ => panic!("EvalJoin nodes only support `0` and `1` for the `branch_num`"),
+        };
     }
 }
 
@@ -154,7 +243,7 @@ impl Evaluable for EvalUnpivot {
         self.output.clone()
     }
 
-    fn update_input(&mut self, _input: &Value) {
+    fn update_input(&mut self, _input: &Value, _branch_num: u8) {
         todo!()
     }
 }
@@ -206,7 +295,7 @@ impl Evaluable for EvalFilter {
         self.output = Some(Value::Bag(Box::new(out)));
         self.output.clone()
     }
-    fn update_input(&mut self, input: &Value) {
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
         self.input = Some(input.clone())
     }
 }
@@ -257,7 +346,7 @@ impl Evaluable for EvalProject {
         self.output.clone()
     }
 
-    fn update_input(&mut self, input: &Value) {
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
         self.input = Some(input.clone());
     }
 }
@@ -304,7 +393,7 @@ impl Evaluable for EvalProjectValue {
         self.output.clone()
     }
 
-    fn update_input(&mut self, input: &Value) {
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
         self.input = Some(input.clone());
     }
 }
@@ -436,7 +525,7 @@ impl Evaluable for EvalDistinct {
         self.output.clone()
     }
 
-    fn update_input(&mut self, input: &Value) {
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
         self.input = Some(input.clone());
     }
 }
@@ -451,7 +540,7 @@ impl Evaluable for EvalSink {
     fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
         self.input.clone()
     }
-    fn update_input(&mut self, input: &Value) {
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
         self.input = Some(input.clone());
     }
 }
@@ -627,39 +716,33 @@ impl Evaluator {
         // that all v ∈ V \{v0} are reachable from v0. Note that this is the definition of trees
         // without the condition |E| = |V | − 1. Hence, all trees are DAGs.
         // Reference: https://link.springer.com/article/10.1007/s00450-009-0061-0
-        match graph.externals(Incoming).exactly_one() {
-            Ok(_) => {
-                let sorted_ops = toposort(&graph, None);
-                match sorted_ops {
-                    Ok(ops) => {
-                        let mut result = None;
-                        for idx in ops.into_iter() {
-                            let src = graph
-                                .node_weight_mut(idx)
-                                .expect("Error in retrieving node");
-                            result = src.evaluate(&*self.ctx);
+        let sorted_ops = toposort(&graph, None);
+        match sorted_ops {
+            Ok(ops) => {
+                let mut result = None;
+                for idx in ops.into_iter() {
+                    let src = graph
+                        .node_weight_mut(idx)
+                        .expect("Error in retrieving node");
+                    result = src.evaluate(&*self.ctx);
 
-                            let mut ne = graph.neighbors_directed(idx, Outgoing).detach();
-                            while let Some(n) = ne.next_node(&graph) {
-                                let dst =
-                                    graph.node_weight_mut(n).expect("Error in retrieving node");
-                                dst.update_input(
-                                    &result.clone().expect("Error in retrieving source value"),
-                                );
-                            }
-                        }
-                        let evaluated = Evaluated {
-                            result: result.expect("Error in retrieving eval output"),
-                        };
-                        Ok(evaluated)
+                    let mut ne = graph.neighbors_directed(idx, Outgoing).detach();
+                    while let Some((e, n)) = ne.next(&graph) {
+                        // use the edge weight to store the `branch_num`
+                        let branch_num = *graph
+                            .edge_weight(e)
+                            .expect("Error in retrieving weight for edge");
+                        let dst = graph.node_weight_mut(n).expect("Error in retrieving node");
+                        dst.update_input(
+                            &result.clone().expect("Error in retrieving source value"),
+                            branch_num,
+                        );
                     }
-                    Err(e) => Err(EvalErr {
-                        errors: vec![EvaluationError::InvalidEvaluationPlan(format!(
-                            "Malformed evaluation plan detected: {:?}",
-                            e
-                        ))],
-                    }),
                 }
+                let evaluated = Evaluated {
+                    result: result.expect("Error in retrieving eval output"),
+                };
+                Ok(evaluated)
             }
             Err(e) => Err(EvalErr {
                 errors: vec![EvaluationError::InvalidEvaluationPlan(format!(

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -145,6 +145,9 @@ impl EvalJoin {
 
 impl Evaluable for EvalJoin {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value> {
+        // TODO: PartiQL defaults to lateral JOINs (RHS can reference binding tuples defined from the LHS)
+        //  https://partiql.org/assets/PartiQL-Specification.pdf#subsection.5.3. Adding this behavior
+        //  to be spec-compliant may result in changes to the DAG flows.
         let output = match self.kind {
             EvalJoinKind::Inner => {
                 let mut result = partiql_bag!();

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
 use partiql_logical as logical;
-use partiql_logical::{BinaryOp, BindingsExpr, LogicalPlan, PathComponent, UnaryOp, ValueExpr};
+use partiql_logical::{
+    BinaryOp, BindingsExpr, JoinKind, LogicalPlan, PathComponent, UnaryOp, ValueExpr,
+};
 
 use crate::eval;
 use crate::eval::{
-    EvalBagExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalListExpr, EvalLitExpr, EvalPath, EvalPlan,
-    EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
+    EvalBagExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalJoinKind, EvalListExpr, EvalLitExpr,
+    EvalPath, EvalPlan, EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
 };
 
 pub struct EvaluatorPlanner;
@@ -25,7 +27,7 @@ impl EvaluatorPlanner {
         let mut seen = HashMap::new();
 
         flows.into_iter().for_each(|r| {
-            let (s, d) = r;
+            let (s, d, w) = r;
 
             let mut nodes = vec![];
             for op_id in vec![s, d] {
@@ -40,7 +42,7 @@ impl EvaluatorPlanner {
                 nodes.push(eval_op)
             }
 
-            eval_plan.0.add_edge(nodes[0], nodes[1], ());
+            eval_plan.0.add_edge(nodes[0], nodes[1], *w);
         });
 
         eval_plan
@@ -93,6 +95,20 @@ impl EvaluatorPlanner {
                 as_key,
                 at_key.as_ref().unwrap(),
             )),
+            BindingsExpr::Join(logical::Join { kind, on }) => {
+                let kind = match kind {
+                    JoinKind::Inner => EvalJoinKind::Inner,
+                    JoinKind::Left => EvalJoinKind::Left,
+                    JoinKind::Right => EvalJoinKind::Right,
+                    JoinKind::Full => EvalJoinKind::Full,
+                    JoinKind::Cross => EvalJoinKind::Cross,
+                };
+                let on = match on {
+                    None => None,
+                    Some(on_condition) => Some(self.plan_values(on_condition.clone())),
+                };
+                Box::new(eval::EvalJoin::new(kind, on))
+            }
             _ => panic!("Unevaluable bexpr"),
         }
     }


### PR DESCRIPTION
Adds `INNER` and `CROSS JOIN`s to planner and evaluator, which required adding a branch side tracking to the DAG.

Still have some TODOs to address but wanted to cut this PR before working on those.
- `LATERAL` `JOIN`s
- Cleanup of `.clone()`ing
- `LEFT JOIN`s

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
