### PR TITLE
Implement `IN` expr

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -535,6 +535,7 @@ pub enum EvalBinOp {
     Div,
     Mod,
     Exp,
+    In,
 }
 
 impl EvalExpr for EvalBinOpExpr {
@@ -583,6 +584,15 @@ impl EvalExpr for EvalBinOpExpr {
             EvalBinOp::Mul => lhs * rhs,
             EvalBinOp::Div => lhs / rhs,
             EvalBinOp::Mod => lhs % rhs,
+            // TODO apply the changes once we clarify the rules of coercion for `IN` RHS.
+            // See also:
+            // - https://github.com/partiql/partiql-docs/pull/13
+            // - https://github.com/partiql/partiql-lang-kotlin/issues/524
+            // - https://github.com/partiql/partiql-lang-kotlin/pull/621#issuecomment-1147754213
+            EvalBinOp::In => match rhs.is_bag() | rhs.is_list() {
+                true => Boolean(rhs.into_iter().contains(&lhs)),
+                false => Boolean(false),
+            },
             EvalBinOp::Exp => todo!("Exponentiation"),
         }
     }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -453,6 +453,43 @@ mod tests {
     }
 
     #[test]
+    fn in_expr() {
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(1),
+            Value::from(partiql_list![1, 2, 3]),
+            Value::from(true),
+        );
+        // We still need to define the rules of coercion for `IN` RHS.
+        // See also:
+        // - https://github.com/partiql/partiql-docs/pull/13
+        // - https://github.com/partiql/partiql-lang-kotlin/issues/524
+        // - https://github.com/partiql/partiql-lang-kotlin/pull/621#issuecomment-1147754213
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(partiql_tuple![("a", 2)]),
+            Value::from(partiql_list![
+                partiql_tuple![("a", 6)],
+                partiql_tuple![("b", 12)],
+                partiql_tuple![("a", 2)]
+            ]),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(10),
+            Value::from(partiql_bag!["a", "b", 11]),
+            Value::from(false),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(1),
+            Value::from(1),
+            Value::from(false),
+        );
+    }
+
+    #[test]
     fn select() {
         let mut lg = LogicalPlan::new();
 
@@ -526,7 +563,6 @@ mod tests {
     //  Expected: <<{'a': 1, 'b': 1}, {'a': 2, 'b': 2}>>
     #[test]
     fn select_value_tuple_constructor_1() {
-        // Plan for `select value {'test': a} from data`
         let mut lg = LogicalPlan::new();
 
         let from = lg.add_operator(scan("data", "v"));
@@ -616,7 +652,6 @@ mod tests {
     //  Expected: <<{'legit': 1}, {}>>
     #[test]
     fn select_value_with_tuple_mistype_attr() {
-        // Plan for `select value {'test': a} from data`
         let mut lg = LogicalPlan::new();
 
         let from = lg.add_operator(scan("data", "v"));
@@ -748,7 +783,6 @@ mod tests {
     //  Expected: <<[2], [4], [6]>>
     #[test]
     fn select_value_with_array_constructor_2() {
-        // Plan for `select value {'test': a} from data`
         let mut lg = LogicalPlan::new();
 
         let from = lg.add_operator(scan("data", "v"));
@@ -784,7 +818,6 @@ mod tests {
     //  Expected: << <<1, 1>>, <<2, 2>> >>
     #[test]
     fn select_value_bag_constructor() {
-        // Plan for `select value {'test': a} from data`
         let mut lg = LogicalPlan::new();
 
         let from = lg.add_operator(scan("data", "v"));
@@ -1037,6 +1070,52 @@ mod tests {
             let expected = partiql_bag![
                 partiql_tuple![("firstName", "jason"), ("doubleName", "jasonjason")],
                 partiql_tuple![("firstName", "miriam"), ("doubleName", "miriammiriam")],
+            ];
+            assert_eq!(*bag, expected);
+        });
+    }
+
+    #[test]
+    fn select_with_in_as_predicate() {
+        // Plan for `SELECT a AS b FROM data WHERE a IN [1]`
+        let mut logical = LogicalPlan::new();
+
+        let scan = logical.add_operator(scan("data", "data"));
+
+        let filter = logical.add_operator(BindingsExpr::Filter(logical::Filter {
+            expr: ValueExpr::BinaryExpr(
+                BinaryOp::In,
+                Box::new(ValueExpr::Path(
+                    Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                        "data".into(),
+                    ))),
+                    vec![PathComponent::Key("a".to_string())],
+                )),
+                Box::new(ValueExpr::Lit(Box::new(partiql_list![1].into()))),
+            ),
+        }));
+
+        let project = logical.add_operator(Project(logical::Project {
+            exprs: HashMap::from([(
+                "b".to_string(),
+                ValueExpr::Path(
+                    Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                        "data".into(),
+                    ))),
+                    vec![PathComponent::Key("a".to_string())],
+                ),
+            )]),
+        }));
+
+        let sink = logical.add_operator(BindingsExpr::Sink);
+
+        logical.extend_with_flows(&[(scan, filter), (filter, project), (project, sink)]);
+
+        let out = evaluate(logical, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
+            let expected = partiql_bag![
+                partiql_tuple![("b", 1)],
             ];
             assert_eq!(*bag, expected);
         });

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -532,7 +532,7 @@ mod tests {
             Value::from(Null),
         );
     }
-    
+
     #[test]
     fn comparison_ops() {
         // Lt

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -21,6 +21,7 @@ mod tests {
     };
 
     use partiql_value as value;
+    use partiql_value::Value::{Missing, Null};
     use partiql_value::{
         partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
     };
@@ -485,7 +486,37 @@ mod tests {
             BinaryOp::In,
             Value::from(1),
             Value::from(1),
-            Value::from(false),
+            Value::from(Null),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(1),
+            Value::from(partiql_list![10, Missing, "b"]),
+            Value::from(Null),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(Missing),
+            Value::from(partiql_list![1, Missing, "b"]),
+            Value::from(Null),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(Null),
+            Value::from(partiql_list![1, Missing, "b"]),
+            Value::from(Null),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(1),
+            Value::from(partiql_list![1, Null, "b"]),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::In,
+            Value::from(1),
+            Value::from(partiql_list![3, Null]),
+            Value::from(Null),
         );
     }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -127,6 +127,7 @@ impl EvaluatorPlanner {
                     BinaryOp::Div => EvalBinOp::Div,
                     BinaryOp::Mod => EvalBinOp::Mod,
                     BinaryOp::Exp => EvalBinOp::Exp,
+                    BinaryOp::In => EvalBinOp::In,
                 };
                 Box::new(EvalBinOpExpr { op, lhs, rhs })
             }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -88,6 +88,8 @@ pub enum BinaryOp {
     Div,
     Mod,
     Exp,
+
+    In,
 }
 
 #[derive(Clone, Debug)]
@@ -154,20 +156,20 @@ impl BagExpr {
 #[derive(Debug, Default)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum BindingsExpr {
-    Scan(Scan),
-    Unpivot(Unpivot),
+    Distinct,
     Filter(Filter),
-    OrderBy,
-    Offset,
-    Limit,
+    GroupBy,
     Join,
-    SetOp,
+    Limit,
+    Offset,
+    OrderBy,
     Project(Project),
     ProjectValue(ProjectValue),
-    Distinct,
-    GroupBy,
+    Scan(Scan),
+    SetOp,
     #[default]
     Sink,
+    Unpivot(Unpivot),
 }
 
 #[derive(Debug)]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -171,9 +171,9 @@ pub struct BetweenExpr {
 // Bindings -> Values   : Select Value
 
 #[derive(Debug, Default)]
-#[allow(dead_code)] // TODO remove once out of PoC
 pub enum BindingsExpr {
-    Distinct,
+    Scan(Scan),
+    Unpivot(Unpivot),
     Filter(Filter),
     OrderBy,
     Offset,
@@ -182,11 +182,10 @@ pub enum BindingsExpr {
     SetOp,
     Project(Project),
     ProjectValue(ProjectValue),
-    Scan(Scan),
-    SetOp,
+    Distinct,
+    GroupBy,
     #[default]
     Sink,
-    Unpivot(Unpivot),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
*Issue #, if available:*

Closes #219

*Description of changes:*
This commit adds the required changes to implement `IN` expression. The following test passes:

```SQL
SELECT a AS b FROM [{'a': 1}, {'a': 2}, {'a': 3}] WHERE a IN [1];
-- Expected << {'b': 1} >>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
