### PR TITLE
Fix comparison ops, add between op

### DIFF
--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -17,7 +17,8 @@ mod tests {
     use partiql_logical as logical;
     use partiql_logical::BindingsExpr::{Distinct, Project, ProjectValue};
     use partiql_logical::{
-        BagExpr, BinaryOp, BindingsExpr, ListExpr, LogicalPlan, PathComponent, TupleExpr, ValueExpr,
+        BagExpr, BetweenExpr, BinaryOp, BindingsExpr, ListExpr, LogicalPlan, PathComponent,
+        TupleExpr, ValueExpr,
     };
 
     use partiql_value as value;
@@ -449,6 +450,201 @@ mod tests {
             Value::Missing,
             Value::Missing,
             Value::Missing,
+        );
+    }
+
+    #[test]
+    fn comparison_ops() {
+        // Lt
+        // Plan for `select lhs < rhs as result from data`
+        eval_bin_op(
+            BinaryOp::Lt,
+            Value::from(1),
+            Value::from(2.),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::Lt,
+            Value::from("abc"),
+            Value::from("def"),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::Lt,
+            Value::Missing,
+            Value::from(2.),
+            Value::Missing,
+        );
+        eval_bin_op(BinaryOp::Lt, Value::Null, Value::from(2.), Value::Null);
+        eval_bin_op(
+            BinaryOp::Lt,
+            Value::from(1),
+            Value::from("foo"),
+            Value::Missing,
+        );
+
+        // Gt
+        // Plan for `select lhs > rhs as result from data`
+        eval_bin_op(
+            BinaryOp::Gt,
+            Value::from(1),
+            Value::from(2.),
+            Value::from(false),
+        );
+        eval_bin_op(
+            BinaryOp::Gt,
+            Value::from("abc"),
+            Value::from("def"),
+            Value::from(false),
+        );
+        eval_bin_op(
+            BinaryOp::Gt,
+            Value::Missing,
+            Value::from(2.),
+            Value::Missing,
+        );
+        eval_bin_op(BinaryOp::Gt, Value::Null, Value::from(2.), Value::Null);
+        eval_bin_op(
+            BinaryOp::Gt,
+            Value::from(1),
+            Value::from("foo"),
+            Value::Missing,
+        );
+
+        // Lteq
+        // Plan for `select lhs <= rhs as result from data`
+        eval_bin_op(
+            BinaryOp::Lteq,
+            Value::from(1),
+            Value::from(2.),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::Lteq,
+            Value::from("abc"),
+            Value::from("def"),
+            Value::from(true),
+        );
+        eval_bin_op(
+            BinaryOp::Lteq,
+            Value::Missing,
+            Value::from(2.),
+            Value::Missing,
+        );
+        eval_bin_op(BinaryOp::Lt, Value::Null, Value::from(2.), Value::Null);
+        eval_bin_op(
+            BinaryOp::Lteq,
+            Value::from(1),
+            Value::from("foo"),
+            Value::Missing,
+        );
+
+        // Gteq
+        // Plan for `select lhs >= rhs as result from data`
+        eval_bin_op(
+            BinaryOp::Gteq,
+            Value::from(1),
+            Value::from(2.),
+            Value::from(false),
+        );
+        eval_bin_op(
+            BinaryOp::Gteq,
+            Value::from("abc"),
+            Value::from("def"),
+            Value::from(false),
+        );
+        eval_bin_op(
+            BinaryOp::Gteq,
+            Value::Missing,
+            Value::from(2.),
+            Value::Missing,
+        );
+        eval_bin_op(BinaryOp::Gteq, Value::Null, Value::from(2.), Value::Null);
+        eval_bin_op(
+            BinaryOp::Gteq,
+            Value::from(1),
+            Value::from("foo"),
+            Value::Missing,
+        );
+    }
+
+    #[test]
+    fn between_op() {
+        fn eval_between_op(value: Value, from: Value, to: Value, expected_first_elem: Value) {
+            let mut plan = LogicalPlan::new();
+            let scan = plan.add_operator(BindingsExpr::Scan(logical::Scan {
+                expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+                as_key: "data".to_string(),
+                at_key: None,
+            }));
+
+            let project = plan.add_operator(Project(logical::Project {
+                exprs: HashMap::from([(
+                    "result".to_string(),
+                    ValueExpr::BetweenExpr(BetweenExpr {
+                        value: Box::new(ValueExpr::Path(
+                            Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                                "data".into(),
+                            ))),
+                            vec![PathComponent::Key("value".to_string())],
+                        )),
+                        from: Box::new(ValueExpr::Lit(Box::new(from))),
+                        to: Box::new(ValueExpr::Lit(Box::new(to))),
+                    }),
+                )]),
+            }));
+
+            let sink = plan.add_operator(BindingsExpr::Sink);
+            plan.extend_with_flows(&[(scan, project), (project, sink)]);
+
+            let mut bindings = MapBindings::default();
+            bindings.insert(
+                "data",
+                partiql_list![Tuple::from([("value".into(), value)])].into(),
+            );
+
+            let result = evaluate(plan, bindings).coerce_to_bag();
+            assert!(!&result.is_empty());
+            let expected_result =
+                partiql_bag!(Tuple::from([("result".into(), expected_first_elem)]));
+            assert_eq!(expected_result, result);
+        }
+        eval_between_op(
+            Value::from(2),
+            Value::from(1),
+            Value::from(3),
+            Value::from(true),
+        );
+        eval_between_op(
+            Value::from(2),
+            Value::from(1.),
+            Value::from(dec!(3.)),
+            Value::from(true),
+        );
+        eval_between_op(
+            Value::from(1),
+            Value::from(2),
+            Value::from(3),
+            Value::from(false),
+        );
+        eval_between_op(Value::Null, Value::from(1), Value::from(3), Value::Null);
+        eval_between_op(Value::from(2), Value::Null, Value::from(3), Value::Null);
+        eval_between_op(Value::from(2), Value::from(1), Value::Null, Value::Null);
+        eval_between_op(Value::Missing, Value::from(1), Value::from(3), Value::Null);
+        eval_between_op(Value::from(2), Value::Missing, Value::from(3), Value::Null);
+        eval_between_op(Value::from(2), Value::from(1), Value::Missing, Value::Null);
+        // left part of AND evaluates to false
+        eval_between_op(
+            Value::from(1),
+            Value::from(2),
+            Value::Null,
+            Value::from(false),
+        );
+        eval_between_op(
+            Value::from(1),
+            Value::from(2),
+            Value::Missing,
+            Value::from(false),
         );
     }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -5,8 +5,8 @@ use partiql_logical::{BinaryOp, BindingsExpr, LogicalPlan, PathComponent, UnaryO
 
 use crate::eval;
 use crate::eval::{
-    EvalBagExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalListExpr, EvalLitExpr, EvalPath, EvalPlan,
-    EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
+    EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalListExpr, EvalLitExpr,
+    EvalPath, EvalPlan, EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
 };
 
 pub struct EvaluatorPlanner;
@@ -120,7 +120,7 @@ impl EvaluatorPlanner {
                     BinaryOp::Gt => EvalBinOp::Gt,
                     BinaryOp::Gteq => EvalBinOp::Gteq,
                     BinaryOp::Lt => EvalBinOp::Lt,
-                    BinaryOp::Lteq => EvalBinOp::Gteq,
+                    BinaryOp::Lteq => EvalBinOp::Lteq,
                     BinaryOp::Add => EvalBinOp::Add,
                     BinaryOp::Sub => EvalBinOp::Sub,
                     BinaryOp::Mul => EvalBinOp::Mul,
@@ -170,6 +170,12 @@ impl EvaluatorPlanner {
                     .map(|elem| self.plan_values(elem))
                     .collect();
                 Box::new(EvalBagExpr { elements })
+            }
+            ValueExpr::BetweenExpr(expr) => {
+                let value = self.plan_values(*expr.value);
+                let from = self.plan_values(*expr.from);
+                let to = self.plan_values(*expr.to);
+                Box::new(EvalBetweenExpr { value, from, to })
             }
         }
     }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -108,6 +108,7 @@ pub enum ValueExpr {
     TupleExpr(TupleExpr),
     ListExpr(ListExpr),
     BagExpr(BagExpr),
+    BetweenExpr(BetweenExpr),
 }
 
 #[derive(Clone, Debug)]
@@ -145,6 +146,13 @@ impl BagExpr {
     pub fn new() -> Self {
         BagExpr { elements: vec![] }
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct BetweenExpr {
+    pub value: Box<ValueExpr>,
+    pub from: Box<ValueExpr>,
+    pub to: Box<ValueExpr>,
 }
 
 // Bindings -> Bindings : Where, OrderBy, Offset, Limit, Join, SetOp, Select, Distinct, GroupBy, Unpivot, Let


### PR DESCRIPTION
This PR:
- Fixes comparison ops (`<`, `>`, `<=`, `>=`). Previously didn't properly handle data type mismatches (returned boolean rather than missing)
- Adds `BETWEEN` op (e.g. `foo BETWEEN 1 AND 2`)
- Changes some PartiQL `Value` extension methods to operate on reference to `Value`s rather than `Value`s
- Some minor bug fixes from previous comparison implementation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
