### PR TITLE
Refactors JOINs to use fewer clone()s.

### DIFF
--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -140,7 +140,7 @@ fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> Value {
 fn eval_bench(c: &mut Criterion) {
     let join_data = join_data();
     let logical_plan = logical_plan();
-    //let eval_plan = eval_plan(&logical_plan);
+
     c.bench_function("join", |b| {
         b.iter(|| {
             let eval_plan = eval_plan(black_box(&logical_plan));

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -1,11 +1,16 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use partiql_eval::env::basic::MapBindings;
 use partiql_eval::eval::{
-    BasicContext, EvalPath, EvalPathComponent, EvalScan, EvalVarRef, Evaluable,
+    BasicContext, EvalPath, EvalPathComponent, EvalPlan, EvalScan, EvalVarRef, Evaluable, Evaluator,
 };
+use partiql_eval::plan;
+use partiql_logical as logical;
+use partiql_logical::BindingsExpr::Project;
+use partiql_logical::{BinaryOp, BindingsExpr, JoinKind, LogicalPlan, PathComponent, ValueExpr};
 use partiql_value::{
     partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
 };
@@ -47,7 +52,103 @@ fn data() -> MapBindings<Value> {
     p0
 }
 
+fn join_data() -> MapBindings<Value> {
+    let customers = partiql_list![
+        partiql_tuple![("id", 5), ("name", "Joe")],
+        partiql_tuple![("id", 7), ("name", "Mary")],
+    ];
+
+    let orders = partiql_list![
+        partiql_tuple![("custId", 7), ("productId", 101)],
+        partiql_tuple![("custId", 7), ("productId", 523)],
+    ];
+
+    let mut bindings = MapBindings::default();
+    bindings.insert("customers", customers.into());
+    bindings.insert("orders", orders.into());
+    bindings
+}
+
+fn scan(name: &str, as_key: &str) -> BindingsExpr {
+    BindingsExpr::Scan(logical::Scan {
+        expr: ValueExpr::VarRef(BindingsName::CaseInsensitive(name.into())),
+        as_key: as_key.to_string(),
+        at_key: None,
+    })
+}
+
+fn path_var(name: &str, component: &str) -> ValueExpr {
+    ValueExpr::Path(
+        Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+            name.into(),
+        ))),
+        vec![PathComponent::Key(component.to_string())],
+    )
+}
+
+fn logical_plan() -> LogicalPlan<BindingsExpr> {
+    let mut lg = LogicalPlan::new();
+
+    // Similar to ex 9 from spec with projected columns from different tables with an inner JOIN and ON condition
+    // SELECT c.id, c.name, o.custId, o.productId FROM customers AS c, orders AS o ON c.id = o.custId
+    let from_lhs = lg.add_operator(scan("customers", "c"));
+    let from_rhs = lg.add_operator(scan("orders", "o"));
+
+    let project = lg.add_operator(Project(logical::Project {
+        exprs: HashMap::from([
+            ("id".to_string(), path_var("c", "id")),
+            ("name".to_string(), path_var("c", "name")),
+            ("custId".to_string(), path_var("o", "custId")),
+            ("productId".to_string(), path_var("o", "productId")),
+        ]),
+    }));
+
+    let join = lg.add_operator(BindingsExpr::Join(logical::Join {
+        kind: JoinKind::Inner,
+        on: Some(ValueExpr::BinaryExpr(
+            BinaryOp::Eq,
+            Box::new(path_var("c", "id")),
+            Box::new(path_var("o", "custId")),
+        )),
+    }));
+
+    let sink = lg.add_operator(BindingsExpr::Sink);
+    lg.add_flow_with_branch_num(from_lhs, join, 0);
+    lg.add_flow_with_branch_num(from_rhs, join, 1);
+    lg.add_flow_with_branch_num(join, project, 0);
+    lg.add_flow_with_branch_num(project, sink, 0);
+
+    lg
+}
+
+fn eval_plan(logical: &LogicalPlan<BindingsExpr>) -> EvalPlan {
+    let planner = plan::EvaluatorPlanner;
+
+    planner.compile(logical)
+}
+
+fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> Value {
+    let mut evaluator = Evaluator::new(bindings);
+
+    if let Ok(out) = evaluator.execute(plan) {
+        out.result
+    } else {
+        Value::Missing
+    }
+}
+
 fn eval_bench(c: &mut Criterion) {
+    let join_data = join_data();
+    let logical_plan = logical_plan();
+    //let eval_plan = eval_plan(&logical_plan);
+    c.bench_function("join", |b| {
+        b.iter(|| {
+            let eval_plan = eval_plan(black_box(&logical_plan));
+            let bindings = join_data.clone();
+            evaluate(black_box(eval_plan), bindings)
+        })
+    });
+
     fn eval(eval: bool) {
         // eval plan for SELECT * FROM hr.employeesNestScalars
         let mut from = EvalScan::new(

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -21,7 +21,7 @@ pub mod basic {
     use super::*;
     use std::collections::HashMap;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct MapBindings<T> {
         sensitive: HashMap<String, usize>,
         insensitive: HashMap<UniCase<String>, usize>,

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use thiserror::Error;
 
 use petgraph::algo::toposort;
-use petgraph::data::DataMapMut;
 use petgraph::prelude::StableGraph;
 use petgraph::{Directed, Outgoing};
 
@@ -171,7 +170,7 @@ impl Evaluable for EvalJoin {
             EvalJoinKind::Inner => match &self.on {
                 None => cross(l_vals, r_vals).collect(),
                 Some(condition) => cross(l_vals, r_vals)
-                    .filter(|t| matches!(condition.evaluate(&t, ctx), Value::Boolean(true)))
+                    .filter(|t| matches!(condition.evaluate(t, ctx), Value::Boolean(true)))
                     .collect(),
             },
             EvalJoinKind::Left => {

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
@@ -464,11 +465,47 @@ impl Value {
     }
 
     #[inline]
+    pub fn as_tuple_ref(&self) -> Cow<Tuple> {
+        if let Value::Tuple(t) = self {
+            Cow::Borrowed(t)
+        } else {
+            Cow::Owned(self.clone().coerce_to_tuple())
+        }
+    }
+
+    #[inline]
     pub fn coerce_to_bag(self) -> Bag {
         if let Value::Bag(b) = self {
             *b
         } else {
             Bag(vec![self])
+        }
+    }
+
+    #[inline]
+    pub fn as_bag_ref(&self) -> Cow<Bag> {
+        if let Value::Bag(b) = self {
+            Cow::Borrowed(b)
+        } else {
+            Cow::Owned(self.clone().coerce_to_bag())
+        }
+    }
+
+    #[inline]
+    pub fn coerce_to_list(self) -> List {
+        if let Value::List(b) = self {
+            *b
+        } else {
+            List(vec![self])
+        }
+    }
+
+    #[inline]
+    pub fn as_list_ref(&self) -> Cow<List> {
+        if let Value::List(l) = self {
+            Cow::Borrowed(l)
+        } else {
+            Cow::Owned(self.clone().coerce_to_list())
         }
     }
 }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -1107,10 +1107,8 @@ impl Tuple {
     }
 
     #[inline]
-    pub fn pairs(&self) -> Vec<(&str, &Value)> {
-        zip(&self.attrs, &self.vals)
-            .map(|(k, v)| (k.as_str(), v))
-            .collect()
+    pub fn pairs(&self) -> impl Iterator<Item = (&str, &Value)> + Clone {
+        zip(&self.attrs, &self.vals).map(|(k, v)| (k.as_str(), v))
     }
 }
 
@@ -1196,15 +1194,15 @@ impl Ord for Tuple {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_pairs = self.pairs();
         let other_pairs = other.pairs();
-        let mut p1 = self_pairs.iter().sorted();
-        let mut p2 = other_pairs.iter().sorted();
+        let mut p1 = self_pairs.sorted();
+        let mut p2 = other_pairs.sorted();
 
         loop {
             return match (p1.next(), p2.next()) {
                 (None, None) => Ordering::Equal,
                 (Some(_), None) => Ordering::Greater,
                 (None, Some(_)) => Ordering::Less,
-                (Some(lv), Some(rv)) => match lv.cmp(rv) {
+                (Some(lv), Some(rv)) => match lv.cmp(&rv) {
                     Ordering::Less => Ordering::Less,
                     Ordering::Greater => Ordering::Greater,
                     Ordering::Equal => continue,

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -816,6 +816,17 @@ impl From<Bag> for List {
     }
 }
 
+impl<T> FromIterator<T> for List
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> List {
+        let iterator = iter.into_iter().map(Into::into);
+        iterator.collect::<Vec<_>>().into()
+    }
+}
+
 #[macro_export]
 macro_rules! partiql_list {
     () => (
@@ -950,6 +961,17 @@ impl From<List> for Bag {
     #[inline]
     fn from(list: List) -> Self {
         Bag(list.0)
+    }
+}
+
+impl<T> FromIterator<T> for Bag
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Bag {
+        let iterator = iter.into_iter().map(Into::into);
+        iterator.collect::<Vec<_>>().into()
     }
 }
 
@@ -1103,6 +1125,24 @@ where
                 acc.insert(attr, val.into());
                 acc
             })
+    }
+}
+
+impl<'a, T> FromIterator<(&'a str, T)> for Tuple
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (&'a str, T)>>(iter: I) -> Tuple {
+        let iterator = iter.into_iter();
+        let (lower, _) = iterator.size_hint();
+        let mut attrs = Vec::with_capacity(lower);
+        let mut vals = Vec::with_capacity(lower);
+        for (k, v) in iterator {
+            attrs.push(k.into());
+            vals.push(v.into());
+        }
+        Tuple { attrs, vals }
     }
 }
 


### PR DESCRIPTION
Refactors `JOIN`s (Cf. #218) to use fewer `clone()`s. 

Adds to `Value`:
 - coercions to Tuple, Bag, and List that do not require taking ownership of the value
 - `iter()` for Tuple, Bag, and List and corresponding `Iterator` implementations over the reference values
 - `FromIterator` implementations for Tuple, Bag, and List to allow `collect()`ing into them from iterators



---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
