### PR TITLE
Add simple and searched case when expressions to evaluator

### DIFF
--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -1,11 +1,16 @@
+use std::collections::HashMap;
 use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use partiql_eval::env::basic::MapBindings;
 use partiql_eval::eval::{
-    BasicContext, EvalPath, EvalPathComponent, EvalScan, EvalVarRef, Evaluable,
+    BasicContext, EvalPath, EvalPathComponent, EvalPlan, EvalScan, EvalVarRef, Evaluable, Evaluator,
 };
+use partiql_eval::plan;
+use partiql_logical as logical;
+use partiql_logical::BindingsExpr::Project;
+use partiql_logical::{BinaryOp, BindingsExpr, JoinKind, LogicalPlan, PathComponent, ValueExpr};
 use partiql_value::{
     partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
 };
@@ -47,7 +52,103 @@ fn data() -> MapBindings<Value> {
     p0
 }
 
+fn join_data() -> MapBindings<Value> {
+    let customers = partiql_list![
+        partiql_tuple![("id", 5), ("name", "Joe")],
+        partiql_tuple![("id", 7), ("name", "Mary")],
+    ];
+
+    let orders = partiql_list![
+        partiql_tuple![("custId", 7), ("productId", 101)],
+        partiql_tuple![("custId", 7), ("productId", 523)],
+    ];
+
+    let mut bindings = MapBindings::default();
+    bindings.insert("customers", customers.into());
+    bindings.insert("orders", orders.into());
+    bindings
+}
+
+fn scan(name: &str, as_key: &str) -> BindingsExpr {
+    BindingsExpr::Scan(logical::Scan {
+        expr: ValueExpr::VarRef(BindingsName::CaseInsensitive(name.into())),
+        as_key: as_key.to_string(),
+        at_key: None,
+    })
+}
+
+fn path_var(name: &str, component: &str) -> ValueExpr {
+    ValueExpr::Path(
+        Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+            name.into(),
+        ))),
+        vec![PathComponent::Key(component.to_string())],
+    )
+}
+
+fn logical_plan() -> LogicalPlan<BindingsExpr> {
+    let mut lg = LogicalPlan::new();
+
+    // Similar to ex 9 from spec with projected columns from different tables with an inner JOIN and ON condition
+    // SELECT c.id, c.name, o.custId, o.productId FROM customers AS c, orders AS o ON c.id = o.custId
+    let from_lhs = lg.add_operator(scan("customers", "c"));
+    let from_rhs = lg.add_operator(scan("orders", "o"));
+
+    let project = lg.add_operator(Project(logical::Project {
+        exprs: HashMap::from([
+            ("id".to_string(), path_var("c", "id")),
+            ("name".to_string(), path_var("c", "name")),
+            ("custId".to_string(), path_var("o", "custId")),
+            ("productId".to_string(), path_var("o", "productId")),
+        ]),
+    }));
+
+    let join = lg.add_operator(BindingsExpr::Join(logical::Join {
+        kind: JoinKind::Inner,
+        on: Some(ValueExpr::BinaryExpr(
+            BinaryOp::Eq,
+            Box::new(path_var("c", "id")),
+            Box::new(path_var("o", "custId")),
+        )),
+    }));
+
+    let sink = lg.add_operator(BindingsExpr::Sink);
+    lg.add_flow_with_branch_num(from_lhs, join, 0);
+    lg.add_flow_with_branch_num(from_rhs, join, 1);
+    lg.add_flow_with_branch_num(join, project, 0);
+    lg.add_flow_with_branch_num(project, sink, 0);
+
+    lg
+}
+
+fn eval_plan(logical: &LogicalPlan<BindingsExpr>) -> EvalPlan {
+    let planner = plan::EvaluatorPlanner;
+
+    planner.compile(logical)
+}
+
+fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> Value {
+    let mut evaluator = Evaluator::new(bindings);
+
+    if let Ok(out) = evaluator.execute(plan) {
+        out.result
+    } else {
+        Value::Missing
+    }
+}
+
 fn eval_bench(c: &mut Criterion) {
+    let join_data = join_data();
+    let logical_plan = logical_plan();
+    //let eval_plan = eval_plan(&logical_plan);
+    c.bench_function("join", |b| {
+        b.iter(|| {
+            let eval_plan = eval_plan(black_box(&logical_plan));
+            let bindings = join_data.clone();
+            evaluate(black_box(eval_plan), bindings)
+        })
+    });
+
     fn eval(eval: bool) {
         // eval plan for SELECT * FROM hr.employeesNestScalars
         let mut from = EvalScan::new(

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -21,7 +21,7 @@ pub mod basic {
     use super::*;
     use std::collections::HashMap;
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct MapBindings<T> {
         sensitive: HashMap<String, usize>,
         insensitive: HashMap<UniCase<String>, usize>,

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -690,7 +690,7 @@ impl EvalExpr for EvalBetweenExpr {
 #[derive(Debug)]
 pub struct EvalSearchedCaseExpr {
     pub cases: Vec<(Box<dyn EvalExpr>, Box<dyn EvalExpr>)>,
-    pub default: Option<Box<dyn EvalExpr>>,
+    pub default: Box<dyn EvalExpr>,
 }
 
 impl EvalExpr for EvalSearchedCaseExpr {
@@ -701,10 +701,7 @@ impl EvalExpr for EvalSearchedCaseExpr {
                 return then_expr.evaluate(bindings, ctx);
             }
         }
-        match &self.default {
-            None => Value::Null,
-            Some(default) => default.evaluate(bindings, ctx),
-        }
+        self.default.evaluate(bindings, ctx)
     }
 }
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -17,6 +17,7 @@ use partiql_value::{
 
 use crate::env::basic::MapBindings;
 use crate::env::Bindings;
+use partiql_logical::Type;
 
 #[derive(Debug)]
 pub struct EvalPlan(pub StableGraph<Box<dyn Evaluable>, u8, Directed>);
@@ -595,6 +596,24 @@ impl EvalExpr for EvalUnaryOpExpr {
             EvalUnaryOp::Neg => -value,
             EvalUnaryOp::Not => !value,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct EvalIsTypeExpr {
+    pub expr: Box<dyn EvalExpr>,
+    pub is_type: Type,
+}
+
+impl EvalExpr for EvalIsTypeExpr {
+    fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
+        let expr = self.expr.evaluate(bindings, ctx);
+        let result = match self.is_type {
+            Type::NullType => matches!(expr, Missing | Null),
+            Type::MissingType => matches!(expr, Missing),
+            _ => todo!("Implement `IS` for other types"),
+        };
+        Value::from(result)
     }
 }
 

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -20,7 +20,7 @@ mod tests {
         PathComponent, TupleExpr, ValueExpr,
     };
     use partiql_value as value;
-    use partiql_value::Value::Null;
+    use partiql_value::Value::{Missing, Null};
     use partiql_value::{
         partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
     };
@@ -107,6 +107,9 @@ mod tests {
             partiql_tuple![("a", 1)],
             partiql_tuple![("a", 2)],
             partiql_tuple![("a", 3)],
+            partiql_tuple![("a", Null)],
+            partiql_tuple![("a", Missing)],
+            partiql_tuple![("a", "foo")],
         ];
 
         let mut bindings = MapBindings::default();
@@ -151,7 +154,12 @@ mod tests {
 
         let result = evaluate(plan, bindings).coerce_to_bag();
         assert!(!&result.is_empty());
-        let expected_result = partiql_bag!(Tuple::from([("result", expected_first_elem)]));
+        let expected_result = if expected_first_elem != Missing {
+            partiql_bag!(Tuple::from([("result", expected_first_elem)]))
+        } else {
+            // Filter tuples with `MISSING` vals
+            partiql_bag!(Tuple::new())
+        };
         assert_eq!(expected_result, result);
     }
 
@@ -838,6 +846,9 @@ mod tests {
                 partiql_tuple![("a", 1), ("b", "one")],
                 partiql_tuple![("a", 2), ("b", "two")],
                 partiql_tuple![("a", 3), ("b", "other")],
+                partiql_tuple![("a", Null), ("b", "other")],
+                partiql_tuple![("b", "other")],
+                partiql_tuple![("a", "foo"), ("b", "other")],
             ];
             assert_eq!(*bag, expected);
         });
@@ -877,6 +888,9 @@ mod tests {
                 partiql_tuple![("a", 1), ("b", "one")],
                 partiql_tuple![("a", 2), ("b", "two")],
                 partiql_tuple![("a", 3), ("b", Null)],
+                partiql_tuple![("a", Null), ("b", Null)],
+                partiql_tuple![("b", Null)],
+                partiql_tuple![("a", "foo"), ("b", Null)],
             ];
             assert_eq!(*bag, expected);
         });
@@ -915,6 +929,9 @@ mod tests {
                 partiql_tuple![("a", 1), ("b", "one")],
                 partiql_tuple![("a", 2), ("b", "two")],
                 partiql_tuple![("a", 3), ("b", "other")],
+                partiql_tuple![("a", Null), ("b", "other")],
+                partiql_tuple![("b", "other")],
+                partiql_tuple![("a", "foo"), ("b", "other")],
             ];
             assert_eq!(*bag, expected);
         });
@@ -954,6 +971,9 @@ mod tests {
                 partiql_tuple![("a", 1), ("b", "one")],
                 partiql_tuple![("a", 2), ("b", "two")],
                 partiql_tuple![("a", 3), ("b", Null)],
+                partiql_tuple![("a", Null), ("b", Null)],
+                partiql_tuple![("b", Null)],
+                partiql_tuple![("a", "foo"), ("b", Null)],
             ];
             assert_eq!(*bag, expected);
         });

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -16,8 +16,8 @@ mod tests {
     use partiql_logical as logical;
     use partiql_logical::BindingsExpr::{Distinct, Project, ProjectValue};
     use partiql_logical::{
-        BagExpr, BetweenExpr, BinaryOp, BindingsExpr, JoinKind, ListExpr, LogicalPlan,
-        PathComponent, TupleExpr, ValueExpr,
+        BagExpr, BetweenExpr, BinaryOp, BindingsExpr, CoalesceExpr, IsTypeExpr, JoinKind, ListExpr,
+        LogicalPlan, NullIfExpr, PathComponent, TupleExpr, Type, ValueExpr,
     };
     use partiql_value as value;
     use partiql_value::Value::{Missing, Null};
@@ -977,6 +977,206 @@ mod tests {
             ];
             assert_eq!(*bag, expected);
         });
+    }
+
+    // Creates the plan: `SELECT <expr> IS [<not>] <is_type> AS result FROM data` where <expr> comes from data
+    // Evaluates the plan and asserts the result is a bag of the tuple mapping to `expected_first_elem`
+    // (i.e. <<{'result': <expected_first_elem>}>>)
+    fn eval_is_op(not: bool, expr: Value, is_type: Type, expected_first_elem: Value) {
+        let mut plan = LogicalPlan::new();
+        let scan = plan.add_operator(BindingsExpr::Scan(logical::Scan {
+            expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+            as_key: "data".to_string(),
+            at_key: None,
+        }));
+
+        let project = plan.add_operator(Project(logical::Project {
+            exprs: HashMap::from([(
+                "result".to_string(),
+                ValueExpr::IsTypeExpr(IsTypeExpr {
+                    not,
+                    expr: Box::new(ValueExpr::Path(
+                        Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                            "data".into(),
+                        ))),
+                        vec![PathComponent::Key("expr".to_string())],
+                    )),
+                    is_type,
+                }),
+            )]),
+        }));
+
+        let sink = plan.add_operator(BindingsExpr::Sink);
+        plan.extend_with_flows(&[(scan, project), (project, sink)]);
+
+        let mut bindings = MapBindings::default();
+        bindings.insert("data", partiql_list![Tuple::from([("expr", expr)])].into());
+
+        let result = evaluate(plan, bindings).coerce_to_bag();
+        assert!(!&result.is_empty());
+        assert_eq!(
+            partiql_bag!(Tuple::from([("result", expected_first_elem)])),
+            result
+        );
+    }
+
+    #[test]
+    fn is_type_null_missing() {
+        // IS MISSING
+        eval_is_op(false, Value::from(1), Type::MissingType, Value::from(false));
+        eval_is_op(false, Value::Missing, Type::MissingType, Value::from(true));
+        eval_is_op(false, Value::Null, Type::MissingType, Value::from(false));
+
+        // IS NOT MISSING
+        eval_is_op(true, Value::from(1), Type::MissingType, Value::from(true));
+        eval_is_op(true, Value::Missing, Type::MissingType, Value::from(false));
+        eval_is_op(true, Value::Null, Type::MissingType, Value::from(true));
+
+        // IS NULL
+        eval_is_op(false, Value::from(1), Type::NullType, Value::from(false));
+        eval_is_op(false, Value::Missing, Type::NullType, Value::from(true));
+        eval_is_op(false, Value::Null, Type::NullType, Value::from(true));
+
+        // IS NOT NULL
+        eval_is_op(true, Value::from(1), Type::NullType, Value::from(true));
+        eval_is_op(true, Value::Missing, Type::NullType, Value::from(false));
+        eval_is_op(true, Value::Null, Type::NullType, Value::from(false));
+    }
+
+    // Creates the plan: `SELECT NULLIF(<lhs>, <rhs>) AS result FROM data` where <lhs> comes from data
+    // Evaluates the plan and asserts the result is a bag of the tuple mapping to `expected_first_elem`
+    // (i.e. <<{'result': <expected_first_elem>}>>)
+    fn eval_null_if_op(lhs: Value, rhs: Value, expected_first_elem: Value) {
+        let mut plan = LogicalPlan::new();
+        let scan = plan.add_operator(BindingsExpr::Scan(logical::Scan {
+            expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+            as_key: "data".to_string(),
+            at_key: None,
+        }));
+
+        let project = plan.add_operator(Project(logical::Project {
+            exprs: HashMap::from([(
+                "result".to_string(),
+                ValueExpr::NullIfExpr(NullIfExpr {
+                    lhs: Box::new(ValueExpr::Path(
+                        Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                            "data".into(),
+                        ))),
+                        vec![PathComponent::Key("lhs".to_string())],
+                    )),
+                    rhs: Box::new(ValueExpr::Lit(Box::new(rhs))),
+                }),
+            )]),
+        }));
+
+        let sink = plan.add_operator(BindingsExpr::Sink);
+        plan.extend_with_flows(&[(scan, project), (project, sink)]);
+
+        let mut bindings = MapBindings::default();
+        bindings.insert("data", partiql_list![Tuple::from([("lhs", lhs)])].into());
+
+        let result = evaluate(plan, bindings).coerce_to_bag();
+        assert!(!&result.is_empty());
+        let expected_result = if expected_first_elem != Missing {
+            partiql_bag!(Tuple::from([("result", expected_first_elem)]))
+        } else {
+            // Filter tuples with `MISSING` vals
+            partiql_bag!(Tuple::new())
+        };
+        assert_eq!(expected_result, result);
+    }
+
+    #[test]
+    fn test_null_if_op() {
+        eval_null_if_op(Value::from(1), Value::from(1), Value::Null);
+        eval_null_if_op(Value::from(1), Value::from("foo"), Value::from(1));
+        eval_null_if_op(Value::from("foo"), Value::from(1), Value::from("foo"));
+        eval_null_if_op(Value::from(Null), Value::from(Null), Value::Null);
+        eval_null_if_op(Value::from(Missing), Value::from(Null), Value::Missing);
+        eval_null_if_op(Value::from(Null), Value::from(Missing), Value::Null);
+    }
+
+    // Creates the plan: `SELECT COALESCE(data.arg1, data.arg2, ..., argN) AS result FROM data` where arg1...argN comes from data
+    // Evaluates the plan and asserts the result is a bag of the tuple mapping to `expected_first_elem`
+    // (i.e. <<{'result': <expected_first_elem>}>>)
+    fn eval_coalesce_op(elements: Vec<Value>, expected_first_elem: Value) {
+        let mut plan = LogicalPlan::new();
+        let scan = plan.add_operator(BindingsExpr::Scan(logical::Scan {
+            expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+            as_key: "data".to_string(),
+            at_key: None,
+        }));
+
+        fn index_to_valueexpr(i: usize) -> ValueExpr {
+            ValueExpr::Path(
+                Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+                    "data".into(),
+                ))),
+                vec![PathComponent::Key(format!("arg{}", i))],
+            )
+        }
+
+        let project = plan.add_operator(Project(logical::Project {
+            exprs: HashMap::from([(
+                "result".to_string(),
+                ValueExpr::CoalesceExpr(CoalesceExpr {
+                    elements: (0..elements.len()).map(|i| index_to_valueexpr(i)).collect(),
+                }),
+            )]),
+        }));
+
+        let sink = plan.add_operator(BindingsExpr::Sink);
+        plan.extend_with_flows(&[(scan, project), (project, sink)]);
+
+        let mut bindings = MapBindings::default();
+        let mut data = Tuple::new();
+        // Bindings created from `elements`. For each `e` in elements with index `i`, adds tuple pair ('argi', e)
+        elements
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, e)| data.insert(&*format!("arg{}", i), e));
+        bindings.insert("data", partiql_list![data].into());
+
+        let result = evaluate(plan, bindings).coerce_to_bag();
+        assert!(!&result.is_empty());
+        assert_eq!(
+            partiql_bag!(Tuple::from([("result", expected_first_elem)])),
+            result
+        );
+    }
+
+    #[test]
+    fn test_coalesce_op() {
+        // 1 elem
+        eval_coalesce_op(vec![Value::from(1)], Value::from(1));
+        eval_coalesce_op(vec![Null], Null);
+        eval_coalesce_op(vec![Missing], Null);
+
+        // Multiple elems
+        eval_coalesce_op(vec![Missing, Null, Value::from(1)], Value::from(1));
+        eval_coalesce_op(vec![Missing, Null, Value::from(1)], Value::from(1));
+        eval_coalesce_op(vec![Missing, Null, Null], Null);
+        eval_coalesce_op(
+            vec![
+                Missing,
+                Null,
+                Missing,
+                Null,
+                Missing,
+                Null,
+                Value::from(1),
+                Value::from(2),
+                Missing,
+                Null,
+            ],
+            Value::from(1),
+        );
+        eval_coalesce_op(
+            vec![
+                Missing, Null, Missing, Null, Missing, Null, Missing, Null, Missing, Null,
+            ],
+            Null,
+        );
     }
 
     #[test]

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -9,8 +9,8 @@ use partiql_logical::{
 use crate::eval;
 use crate::eval::{
     EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalJoinKind, EvalListExpr,
-    EvalLitExpr, EvalPath, EvalPlan, EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef,
-    Evaluable,
+    EvalLitExpr, EvalPath, EvalPlan, EvalSearchedCaseExpr, EvalSimpleCaseExpr, EvalTupleExpr,
+    EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
 };
 
 pub struct EvaluatorPlanner;
@@ -186,6 +186,35 @@ impl EvaluatorPlanner {
                 let from = self.plan_values(*expr.from);
                 let to = self.plan_values(*expr.to);
                 Box::new(EvalBetweenExpr { value, from, to })
+            }
+            ValueExpr::SimpleCase(e) => {
+                let expr = self.plan_values(*e.expr);
+                let cases = e
+                    .cases
+                    .into_iter()
+                    .map(|case| (self.plan_values(*case.0), self.plan_values(*case.1)))
+                    .collect();
+                let default = e
+                    .default
+                    .as_ref()
+                    .map(|default| self.plan_values(*default.clone()));
+                Box::new(EvalSimpleCaseExpr {
+                    expr,
+                    cases,
+                    default,
+                })
+            }
+            ValueExpr::SearchedCase(e) => {
+                let cases = e
+                    .cases
+                    .into_iter()
+                    .map(|case| (self.plan_values(*case.0), self.plan_values(*case.1)))
+                    .collect();
+                let default = e
+                    .default
+                    .as_ref()
+                    .map(|default| self.plan_values(*default.clone()));
+                Box::new(EvalSearchedCaseExpr { cases, default })
             }
         }
     }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -3,14 +3,15 @@ use std::collections::HashMap;
 
 use partiql_logical as logical;
 use partiql_logical::{
-    BinaryOp, BindingsExpr, JoinKind, LogicalPlan, OpId, PathComponent, UnaryOp, ValueExpr,
+    BinaryOp, BindingsExpr, IsTypeExpr, JoinKind, LogicalPlan, OpId, PathComponent, SearchedCase,
+    Type, UnaryOp, ValueExpr,
 };
 
 use crate::eval;
 use crate::eval::{
-    EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalJoinKind, EvalListExpr,
-    EvalLitExpr, EvalPath, EvalPlan, EvalSearchedCaseExpr, EvalTupleExpr, EvalUnaryOp,
-    EvalUnaryOpExpr, EvalVarRef, Evaluable,
+    EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalIsTypeExpr, EvalJoinKind,
+    EvalListExpr, EvalLitExpr, EvalPath, EvalPlan, EvalSearchedCaseExpr, EvalTupleExpr,
+    EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
 };
 use partiql_value::Value::Null;
 
@@ -227,6 +228,64 @@ impl EvaluatorPlanner {
                     Some(def) => self.plan_values(*def),
                 };
                 Box::new(EvalSearchedCaseExpr { cases, default })
+            }
+            ValueExpr::IsTypeExpr(i) => {
+                let expr = self.plan_values(*i.expr);
+                match i.not {
+                    true => Box::new(EvalUnaryOpExpr {
+                        op: EvalUnaryOp::Not,
+                        operand: Box::new(EvalIsTypeExpr {
+                            expr,
+                            is_type: i.is_type,
+                        }),
+                    }),
+                    false => Box::new(EvalIsTypeExpr {
+                        expr,
+                        is_type: i.is_type,
+                    }),
+                }
+            }
+            ValueExpr::NullIfExpr(n) => {
+                // NULLIF can be rewritten using CASE WHEN expressions as per section 6.9 pg 142 of SQL-92 spec:
+                //     1) NULLIF (V1, V2) is equivalent to the following <case specification>:
+                //         CASE WHEN V1=V2 THEN NULL ELSE V1 END
+                let rewritten_as_case = ValueExpr::SearchedCase(SearchedCase {
+                    cases: vec![(
+                        Box::new(ValueExpr::BinaryExpr(
+                            BinaryOp::Eq,
+                            Box::new(*n.lhs.clone()),
+                            Box::new(*n.rhs.clone()),
+                        )),
+                        Box::new(ValueExpr::Lit(Box::new(Null))),
+                    )],
+                    default: Some(Box::new(*n.lhs)),
+                });
+                self.plan_values(rewritten_as_case)
+            }
+            ValueExpr::CoalesceExpr(c) => {
+                // COALESCE can be rewritten using CASE WHEN expressions as per section 6.9 pg 142 of SQL-92 spec:
+                //     2) COALESCE (V1, V2) is equivalent to the following <case specification>:
+                //         CASE WHEN V1 IS NOT NULL THEN V1 ELSE V2 END
+                //
+                //     3) COALESCE (V1, V2, . . . ,n ), for n >= 3, is equivalent to the following <case specification>:
+                //         CASE WHEN V1 IS NOT NULL THEN V1 ELSE COALESCE (V2, . . . ,n )
+                //         END
+                assert!(!c.elements.is_empty());
+                fn as_case(v: &ValueExpr, elems: &[ValueExpr]) -> ValueExpr {
+                    let sc = SearchedCase {
+                        cases: vec![(
+                            Box::new(ValueExpr::IsTypeExpr(IsTypeExpr {
+                                not: true,
+                                expr: Box::new(v.clone()),
+                                is_type: Type::NullType,
+                            })),
+                            Box::new(v.clone()),
+                        )],
+                        default: elems.first().map(|v2| Box::new(as_case(v2, &elems[1..]))),
+                    };
+                    ValueExpr::SearchedCase(sc)
+                }
+                self.plan_values(as_case(c.elements.first().unwrap(), &c.elements[1..]))
             }
         }
     }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -109,6 +109,55 @@ pub enum PathComponent {
 }
 
 #[derive(Clone, Debug)]
+pub struct IsTypeExpr {
+    pub not: bool,
+    pub expr: Box<ValueExpr>,
+    pub is_type: Type,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Type {
+    NullType,
+    BooleanType,
+    Integer2Type,
+    Integer4Type,
+    Integer8Type,
+    DecimalType,
+    NumericType,
+    RealType,
+    DoublePrecisionType,
+    TimestampType,
+    CharacterType,
+    CharacterVaryingType,
+    MissingType,
+    StringType,
+    SymbolType,
+    BlobType,
+    ClobType,
+    DateType,
+    TimeType,
+    ZonedTimestampType,
+    StructType,
+    TupleType,
+    ListType,
+    SexpType,
+    BagType,
+    AnyType,
+    // TODO CustomType
+}
+
+#[derive(Clone, Debug)]
+pub struct NullIfExpr {
+    pub lhs: Box<ValueExpr>,
+    pub rhs: Box<ValueExpr>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CoalesceExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum ValueExpr {
     // TODO other variants
@@ -123,6 +172,9 @@ pub enum ValueExpr {
     BetweenExpr(BetweenExpr),
     SimpleCase(SimpleCase),
     SearchedCase(SearchedCase),
+    IsTypeExpr(IsTypeExpr),
+    NullIfExpr(NullIfExpr),
+    CoalesceExpr(CoalesceExpr),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -121,6 +121,8 @@ pub enum ValueExpr {
     ListExpr(ListExpr),
     BagExpr(BagExpr),
     BetweenExpr(BetweenExpr),
+    SimpleCase(SimpleCase),
+    SearchedCase(SearchedCase),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -162,6 +164,19 @@ pub struct BetweenExpr {
     pub value: Box<ValueExpr>,
     pub from: Box<ValueExpr>,
     pub to: Box<ValueExpr>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SimpleCase {
+    pub expr: Box<ValueExpr>,
+    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
+    pub default: Option<Box<ValueExpr>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SearchedCase {
+    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
+    pub default: Option<Box<ValueExpr>>,
 }
 
 // Bindings -> Bindings : Where, OrderBy, Offset, Limit, Join, SetOp, Select, Distinct, GroupBy, Unpivot, Let

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -317,6 +317,8 @@ pub trait NullableOrd {
 impl NullableEq for Value {
     type Output = Self;
 
+    // TODO: `eq` and `neq` are not quite right as implemented. Should be able to assert equality between
+    //  different comparable types (e.g. numerics)
     fn eq(&self, rhs: &Self) -> Self::Output {
         match (self, rhs) {
             (Value::Missing, _) => Value::Missing,

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
@@ -464,11 +465,47 @@ impl Value {
     }
 
     #[inline]
+    pub fn as_tuple_ref(&self) -> Cow<Tuple> {
+        if let Value::Tuple(t) = self {
+            Cow::Borrowed(t)
+        } else {
+            Cow::Owned(self.clone().coerce_to_tuple())
+        }
+    }
+
+    #[inline]
     pub fn coerce_to_bag(self) -> Bag {
         if let Value::Bag(b) = self {
             *b
         } else {
             Bag(vec![self])
+        }
+    }
+
+    #[inline]
+    pub fn as_bag_ref(&self) -> Cow<Bag> {
+        if let Value::Bag(b) = self {
+            Cow::Borrowed(b)
+        } else {
+            Cow::Owned(self.clone().coerce_to_bag())
+        }
+    }
+
+    #[inline]
+    pub fn coerce_to_list(self) -> List {
+        if let Value::List(b) = self {
+            *b
+        } else {
+            List(vec![self])
+        }
+    }
+
+    #[inline]
+    pub fn as_list_ref(&self) -> Cow<List> {
+        if let Value::List(l) = self {
+            Cow::Borrowed(l)
+        } else {
+            Cow::Owned(self.clone().coerce_to_list())
         }
     }
 }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -1107,10 +1107,8 @@ impl Tuple {
     }
 
     #[inline]
-    pub fn pairs(&self) -> Vec<(&str, &Value)> {
-        zip(&self.attrs, &self.vals)
-            .map(|(k, v)| (k.as_str(), v))
-            .collect()
+    pub fn pairs(&self) -> impl Iterator<Item = (&str, &Value)> + Clone {
+        zip(&self.attrs, &self.vals).map(|(k, v)| (k.as_str(), v))
     }
 }
 
@@ -1196,15 +1194,15 @@ impl Ord for Tuple {
     fn cmp(&self, other: &Self) -> Ordering {
         let self_pairs = self.pairs();
         let other_pairs = other.pairs();
-        let mut p1 = self_pairs.iter().sorted();
-        let mut p2 = other_pairs.iter().sorted();
+        let mut p1 = self_pairs.sorted();
+        let mut p2 = other_pairs.sorted();
 
         loop {
             return match (p1.next(), p2.next()) {
                 (None, None) => Ordering::Equal,
                 (Some(_), None) => Ordering::Greater,
                 (None, Some(_)) => Ordering::Less,
-                (Some(lv), Some(rv)) => match lv.cmp(rv) {
+                (Some(lv), Some(rv)) => match lv.cmp(&rv) {
                     Ordering::Less => Ordering::Less,
                     Ordering::Greater => Ordering::Greater,
                     Ordering::Equal => continue,

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -816,6 +816,17 @@ impl From<Bag> for List {
     }
 }
 
+impl<T> FromIterator<T> for List
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> List {
+        let iterator = iter.into_iter().map(Into::into);
+        iterator.collect::<Vec<_>>().into()
+    }
+}
+
 #[macro_export]
 macro_rules! partiql_list {
     () => (
@@ -950,6 +961,17 @@ impl From<List> for Bag {
     #[inline]
     fn from(list: List) -> Self {
         Bag(list.0)
+    }
+}
+
+impl<T> FromIterator<T> for Bag
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Bag {
+        let iterator = iter.into_iter().map(Into::into);
+        iterator.collect::<Vec<_>>().into()
     }
 }
 
@@ -1103,6 +1125,24 @@ where
                 acc.insert(attr, val.into());
                 acc
             })
+    }
+}
+
+impl<'a, T> FromIterator<(&'a str, T)> for Tuple
+where
+    T: Into<Value>,
+{
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (&'a str, T)>>(iter: I) -> Tuple {
+        let iterator = iter.into_iter();
+        let (lower, _) = iterator.size_hint();
+        let mut attrs = Vec::with_capacity(lower);
+        let mut vals = Vec::with_capacity(lower);
+        for (k, v) in iterator {
+            attrs.push(k.into());
+            vals.push(v.into());
+        }
+        Tuple { attrs, vals }
     }
 }
 


### PR DESCRIPTION
Note: target branch is `feat-value-iters`. Will create a new PR targeting `main` once that branch's PR is merged to `main`.

*Issue #, if available:* None.

*Description of changes:* Adds simple and searched case when expressions to the evaluator. Also fixes projection behavior when a tuple value is `MISSING` (previously included those tuple values; now omits).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
