### PR TITLE
Implements `IS` (unknown types only), `NULLIF`, and `COALESCE`

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -17,6 +17,7 @@ use partiql_value::{
 
 use crate::env::basic::MapBindings;
 use crate::env::Bindings;
+use partiql_logical::Type;
 
 #[derive(Debug)]
 pub struct EvalPlan(pub StableGraph<Box<dyn Evaluable>, u8, Directed>);
@@ -595,6 +596,24 @@ impl EvalExpr for EvalUnaryOpExpr {
             EvalUnaryOp::Neg => -value,
             EvalUnaryOp::Not => !value,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct EvalIsTypeExpr {
+    pub expr: Box<dyn EvalExpr>,
+    pub is_type: Type,
+}
+
+impl EvalExpr for EvalIsTypeExpr {
+    fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
+        let expr = self.expr.evaluate(bindings, ctx);
+        let result = match self.is_type {
+            Type::NullType => matches!(expr, Missing | Null),
+            Type::MissingType => matches!(expr, Missing),
+            _ => todo!("Implement `IS` for other types"),
+        };
+        Value::from(result)
     }
 }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -8,9 +8,9 @@ use partiql_logical::{
 
 use crate::eval;
 use crate::eval::{
-    EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalJoinKind, EvalListExpr,
-    EvalLitExpr, EvalPath, EvalPlan, EvalSearchedCaseExpr, EvalTupleExpr, EvalUnaryOp,
-    EvalUnaryOpExpr, EvalVarRef, Evaluable,
+    EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalExpr, EvalIsTypeExpr, EvalJoinKind,
+    EvalListExpr, EvalLitExpr, EvalPath, EvalPlan, EvalSearchedCaseExpr, EvalTupleExpr,
+    EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef, Evaluable,
 };
 use partiql_value::Value::Null;
 
@@ -227,6 +227,22 @@ impl EvaluatorPlanner {
                     Some(def) => self.plan_values(*def),
                 };
                 Box::new(EvalSearchedCaseExpr { cases, default })
+            }
+            ValueExpr::IsTypeExpr(i) => {
+                let expr = self.plan_values(*i.expr);
+                match i.not {
+                    true => Box::new(EvalUnaryOpExpr {
+                        op: EvalUnaryOp::Not,
+                        operand: Box::new(EvalIsTypeExpr {
+                            expr,
+                            is_type: i.is_type,
+                        }),
+                    }),
+                    false => Box::new(EvalIsTypeExpr {
+                        expr,
+                        is_type: i.is_type,
+                    }),
+                }
             }
         }
     }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -147,6 +147,17 @@ pub enum Type {
 }
 
 #[derive(Clone, Debug)]
+pub struct NullIfExpr {
+    pub lhs: Box<ValueExpr>,
+    pub rhs: Box<ValueExpr>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CoalesceExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum ValueExpr {
     // TODO other variants
@@ -162,6 +173,8 @@ pub enum ValueExpr {
     SimpleCase(SimpleCase),
     SearchedCase(SearchedCase),
     IsTypeExpr(IsTypeExpr),
+    NullIfExpr(NullIfExpr),
+    CoalesceExpr(CoalesceExpr),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -109,6 +109,44 @@ pub enum PathComponent {
 }
 
 #[derive(Clone, Debug)]
+pub struct IsTypeExpr {
+    pub not: bool,
+    pub expr: Box<ValueExpr>,
+    pub is_type: Type,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Type {
+    NullType,
+    BooleanType,
+    Integer2Type,
+    Integer4Type,
+    Integer8Type,
+    DecimalType,
+    NumericType,
+    RealType,
+    DoublePrecisionType,
+    TimestampType,
+    CharacterType,
+    CharacterVaryingType,
+    MissingType,
+    StringType,
+    SymbolType,
+    BlobType,
+    ClobType,
+    DateType,
+    TimeType,
+    ZonedTimestampType,
+    StructType,
+    TupleType,
+    ListType,
+    SexpType,
+    BagType,
+    AnyType,
+    // TODO CustomType
+}
+
+#[derive(Clone, Debug)]
 #[allow(dead_code)] // TODO remove once out of PoC
 pub enum ValueExpr {
     // TODO other variants
@@ -123,6 +161,7 @@ pub enum ValueExpr {
     BetweenExpr(BetweenExpr),
     SimpleCase(SimpleCase),
     SearchedCase(SearchedCase),
+    IsTypeExpr(IsTypeExpr),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -317,6 +317,8 @@ pub trait NullableOrd {
 impl NullableEq for Value {
     type Output = Self;
 
+    // TODO: `eq` and `neq` are not quite right as implemented. Should be able to assert equality between
+    //  different comparable types (e.g. numerics)
     fn eq(&self, rhs: &Self) -> Self::Output {
         match (self, rhs) {
             (Value::Missing, _) => Value::Missing,


### PR DESCRIPTION
Note: target branch is `case-expressions`. Will create a new PR targeting `main` once that branch's PR (#228) is merged to `main`.

*Issue #, if available:* None.

*Description of changes:* Implements `IS` (unknown types only -- i.e. `IS [NOT] NULL` and `IS [NOT] MISSING`), `NULLIF`, and `COALESCE`. `NULLIF` and `COALESCE` are implemented using the rewrites mentioned in the SQL-92 spec (section 6.9, pg 142).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
