### PR TITLE
Add PoC parsing of conformance test values encoded in ion

### DIFF
--- a/partiql-conformance-test-generator/src/generator.rs
+++ b/partiql-conformance-test-generator/src/generator.rs
@@ -268,7 +268,7 @@ impl Generator {
         scope.raw(
             quote! {
                 const ENV_ION_TEXT : &'static str = #envs;
-                fn environment() -> Option<TestValue<'static>> {
+                fn environment() -> Option<TestValue> {
                     Some(ENV_ION_TEXT.into())
                 }
             }
@@ -290,7 +290,7 @@ impl Generator {
         scope.raw(
             quote! {
                 const ENV_ION_TEXT : &'static str = include_str!(#data_file);
-                fn environment() -> Option<TestValue<'static>> {
+                fn environment() -> Option<TestValue> {
                     Some(ENV_ION_TEXT.into())
                 }
             }

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -33,6 +33,11 @@ partiql-conformance-test-generator = { path = "../partiql-conformance-test-gener
 
 [dependencies]
 partiql-parser = { path = "../partiql-parser", version = "0.1.0" }
+partiql-value = { path = "../partiql-value" }
+
+ion-rs = "0.14"
+
+rust_decimal = "1.27"
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 serde_json = { version = "1.*", optional = true }

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -1,19 +1,11 @@
 use partiql_parser::ParserResult;
+mod test_value;
+pub(crate) use test_value::TestValue;
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum EvaluationMode {
     Coerce,
     Error,
-}
-
-pub(crate) struct TestValue<'a> {
-    contents: &'a str,
-}
-
-impl<'a> From<&'a str> for TestValue<'a> {
-    fn from(contents: &'a str) -> Self {
-        TestValue { contents }
-    }
 }
 
 #[track_caller]
@@ -78,7 +70,7 @@ pub(crate) fn pass_eval(
     todo!("pass_eval")
 }
 
-pub(crate) fn environment() -> Option<TestValue<'static>> {
+pub(crate) fn environment() -> Option<TestValue> {
     None
 }
 

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -1,8 +1,5 @@
-use ion_rs::external::bigdecimal::BigDecimal;
 use ion_rs::{Integer, IonReader, IonType, Reader, StreamItem};
 use partiql_value::{Bag, List, Tuple, Value};
-use std::fs::read;
-use std::str::FromStr;
 
 pub(crate) struct TestValue {
     value: Value,
@@ -91,10 +88,7 @@ fn parse_test_value_tuple(reader: &mut Reader) -> Tuple {
                 reader.field_name().expect("field name"),
                 parse_test_value(reader, typ),
             ),
-            StreamItem::Null(_) => (
-                reader.field_name().expect("field name"),
-                parse_null(&reader),
-            ),
+            StreamItem::Null(_) => (reader.field_name().expect("field name"), parse_null(reader)),
             StreamItem::Nothing => break,
         };
         tuple.insert(key.text().unwrap(), value);
@@ -110,7 +104,7 @@ fn parse_test_value_sequence(reader: &mut Reader) -> Vec<Value> {
         let item = reader.next().expect("test value");
         let val = match item {
             StreamItem::Value(typ) => parse_test_value(reader, typ),
-            StreamItem::Null(_) => parse_null(&reader),
+            StreamItem::Null(_) => parse_null(reader),
             StreamItem::Nothing => break,
         };
         values.push(val);
@@ -123,7 +117,7 @@ fn parse_test_value_sequence(reader: &mut Reader) -> Vec<Value> {
 #[cfg(not(feature = "conformance_test"))]
 mod tests {
     use super::parse_test_value_str;
-    use ion_rs::Decimal;
+
     use partiql_value::{partiql_bag, partiql_list, partiql_tuple, Bag, List, Tuple, Value};
 
     #[track_caller]
@@ -156,6 +150,7 @@ mod tests {
             ("d", Value::Real(2.0.into())),
             ("s", 1)
         ]]);
+        parse(test, expected);
     }
 
     #[test]
@@ -227,5 +222,6 @@ mod tests {
             ("d", Value::Real(2.0.into())),
             ("s", 1)
         ]]);
+        parse(test, expected);
     }
 }

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -1,0 +1,231 @@
+use ion_rs::external::bigdecimal::BigDecimal;
+use ion_rs::{Integer, IonReader, IonType, Reader, StreamItem};
+use partiql_value::{Bag, List, Tuple, Value};
+use std::fs::read;
+use std::str::FromStr;
+
+pub(crate) struct TestValue {
+    value: Value,
+}
+
+impl From<&str> for TestValue {
+    fn from(contents: &str) -> Self {
+        TestValue {
+            value: parse_test_value_str(contents),
+        }
+    }
+}
+
+fn parse_test_value_str(contents: &str) -> Value {
+    let mut reader = ion_rs::ReaderBuilder::new()
+        .build(contents)
+        .expect("reading contents");
+
+    // expecting a single top-level value
+    let item = reader.next().expect("test value");
+    let val = match item {
+        StreamItem::Value(typ) => parse_test_value(&mut reader, typ),
+        StreamItem::Null(_) => parse_null(&reader),
+        StreamItem::Nothing => panic!("expecting a test value"),
+    };
+
+    assert_eq!(reader.next().expect("test end"), StreamItem::Nothing);
+
+    val
+}
+
+#[inline]
+fn parse_null(reader: &Reader) -> Value {
+    if has_annotation(reader, "$missing") {
+        Value::Missing
+    } else {
+        Value::Null
+    }
+}
+
+#[inline]
+fn has_annotation(reader: &Reader, annot: &str) -> bool {
+    reader.annotations().any(|a| a.unwrap().eq(&annot))
+}
+
+// TODO handle errors more gracefully than `expect`/`unwrap`
+fn parse_test_value(reader: &mut Reader, typ: IonType) -> Value {
+    match typ {
+        IonType::Null => parse_null(reader),
+        IonType::Boolean => Value::Boolean(reader.read_bool().unwrap()),
+        IonType::Integer => match reader.read_integer().unwrap() {
+            Integer::I64(i) => Value::Integer(i),
+            Integer::BigInt(_) => todo!("bigint"),
+        },
+        IonType::Float => Value::Real(reader.read_f64().unwrap().into()),
+        IonType::Decimal => {
+            // TODO ion Decimal doesn't give a lot of functionality to get at the data currently
+            // TODO    and it's not clear whether we'll continue with rust decimal or switch to big decimal
+            let ion_dec = reader.read_decimal().unwrap();
+            let ion_dec_str = format!("{}", ion_dec).replace('d', "e");
+            Value::Decimal(rust_decimal::Decimal::from_scientific(&ion_dec_str).unwrap())
+        }
+        IonType::Timestamp => todo!("timestamp"),
+        IonType::Symbol => Value::String(Box::new(reader.read_symbol().unwrap().to_string())),
+        IonType::String => Value::String(Box::new(reader.read_string().unwrap())),
+        IonType::Clob => todo!("clob"),
+        IonType::Blob => Value::Blob(Box::new(reader.read_blob().unwrap())),
+        IonType::List => {
+            if has_annotation(reader, "$bag") {
+                Bag::from(parse_test_value_sequence(reader)).into()
+            } else {
+                List::from(parse_test_value_sequence(reader)).into()
+            }
+        }
+        IonType::SExpression => todo!("sexp"),
+        IonType::Struct => parse_test_value_tuple(reader).into(),
+    }
+}
+
+fn parse_test_value_tuple(reader: &mut Reader) -> Tuple {
+    let mut tuple = Tuple::new();
+    reader.step_in().expect("step into struct");
+    while let item = reader.next().expect("struct value") {
+        let (key, value) = match item {
+            StreamItem::Value(typ) => (
+                reader.field_name().expect("field name"),
+                parse_test_value(reader, typ),
+            ),
+            StreamItem::Null(_) => (
+                reader.field_name().expect("field name"),
+                parse_null(&reader),
+            ),
+            StreamItem::Nothing => break,
+        };
+        tuple.insert(key.text().unwrap(), value);
+    }
+    reader.step_out().expect("step out of struct");
+    tuple
+}
+
+fn parse_test_value_sequence(reader: &mut Reader) -> Vec<Value> {
+    reader.step_in().expect("step into sequence");
+    let mut values = vec![];
+    loop {
+        let item = reader.next().expect("test value");
+        let val = match item {
+            StreamItem::Value(typ) => parse_test_value(reader, typ),
+            StreamItem::Null(_) => parse_null(&reader),
+            StreamItem::Nothing => break,
+        };
+        values.push(val);
+    }
+    reader.step_out().expect("step out of sequence");
+    values
+}
+
+#[cfg(test)]
+#[cfg(not(feature = "conformance_test"))]
+mod tests {
+    use super::parse_test_value_str;
+    use ion_rs::Decimal;
+    use partiql_value::{partiql_bag, partiql_list, partiql_tuple, Bag, List, Tuple, Value};
+
+    #[track_caller]
+    fn parse(test: &str, expected: Value) {
+        let val = parse_test_value_str(test);
+        assert_eq!(val, expected);
+    }
+
+    #[test]
+    fn simple() {
+        parse("null", Value::Null);
+        parse("$missing::null", Value::Missing);
+        parse("9", Value::Integer(9));
+        parse("true", Value::Boolean(true));
+        parse("false", Value::Boolean(false));
+        parse("\"str\"", Value::String(Box::new("str".into())));
+    }
+
+    #[test]
+    fn bag() {
+        let test = "$bag::[
+            {
+                f: 1,
+                d: 2e0,
+                s: 1
+            }
+        ]";
+        let expected = Value::from(partiql_bag![partiql_tuple![
+            ("f", 1),
+            ("d", Value::Real(2.0.into())),
+            ("s", 1)
+        ]]);
+    }
+
+    #[test]
+    fn tuple() {
+        parse(
+            "{
+                    sensor: 1,
+                    reading: 42
+                  }",
+            Value::Tuple(Box::new(partiql_tuple![("sensor", 1), ("reading", 42)])),
+        );
+    }
+
+    #[test]
+    fn tt2() {
+        parse(
+            "{
+                    sensors: [
+                        {
+                            sensor: 1
+                        },
+                        {
+                            sensor: 2
+                        }
+                    ],
+                    logs: [
+                        {
+                            sensor: 1,
+                            co: 4d-1
+                        },
+                        {
+                            sensor: 1,
+                            co: 2d-1
+                        },
+                        {
+                            sensor: 2,
+                            co: 3d-1
+                        }
+                    ]
+                }",
+            Value::Tuple(Box::new(partiql_tuple![
+                (
+                    "sensors",
+                    partiql_list![partiql_tuple![("sensor", 1)], partiql_tuple![("sensor", 2)]]
+                ),
+                (
+                    "logs",
+                    partiql_list![
+                        partiql_tuple![("sensor", 1), ("co", rust_decimal::Decimal::new(4, 1))],
+                        partiql_tuple![("sensor", 1), ("co", rust_decimal::Decimal::new(2, 1))],
+                        partiql_tuple![("sensor", 2), ("co", rust_decimal::Decimal::new(3, 1))]
+                    ]
+                )
+            ])),
+        );
+    }
+
+    #[test]
+    fn list() {
+        let test = "[
+            {
+                f: 1,
+                d: 2e0,
+                s: 1
+            }
+        ]";
+        let expected = Value::from(partiql_list![partiql_tuple![
+            ("f", 1),
+            ("d", Value::Real(2.0.into())),
+            ("s", 1)
+        ]]);
+    }
+}


### PR DESCRIPTION
Add PoC parsing of conformance test values encoded in ion

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
