### PR TITLE
[WIP] Implements LATERAL JOINs using existing DAG flows and eval node structure

### DIFF
--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -99,7 +99,6 @@ impl EvaluatorPlanner {
                     JoinKind::Right => EvalJoinKind::Right,
                     JoinKind::Full => EvalJoinKind::Full,
                     JoinKind::Cross => EvalJoinKind::Cross,
-                    JoinKind::CrossLateral => EvalJoinKind::CrossLateral,
                 };
                 let on = on
                     .as_ref()

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -287,8 +287,6 @@ pub enum JoinKind {
     Right,
     Full,
     Cross,
-    // TODO revisit JOINS to consider the `Lateral` logic as part of current joins
-    CrossLateral,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
[WIP] -- still testing if `LEFT` JOINs can be modeled using the existing DAG flows and evaluation node structure.

Models `CROSS` and `INNER` JOINs as lateral JOINs (i.e. make LHS JOIN bindings available to RHS JOIN expression), which is how the PartiQL spec defines `CROSS` and `INNER` JOINs. This allows us to remove the `CrossLateral` JOIN type specified in #227 and resolves the [comment](https://github.com/partiql/partiql-lang-rust/pull/227#discussion_r1038661582) mentioned in that PR. The current approach in this PR moves the "JOIN"-ing/chaining of tuples together to within the RHS scan, which keeps the previous DAG modeling.

This is still a POC as I'm still seeing how easily other JOINs can be implemented with this approach. I'm also experimenting with another approach that refactors how JOINs are modeled in the eval nodes and DAG.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
