### PR TITLE
Add `LogicalPlan` documentation and some clean-up

### DIFF
--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -9,8 +9,8 @@ use partiql_eval::eval::{
 };
 use partiql_eval::plan;
 use partiql_logical as logical;
-use partiql_logical::BindingsExpr::Project;
-use partiql_logical::{BinaryOp, BindingsExpr, JoinKind, LogicalPlan, PathComponent, ValueExpr};
+use partiql_logical::BindingsOp::Project;
+use partiql_logical::{BinaryOp, BindingsOp, JoinKind, LogicalPlan, PathComponent, ValueExpr};
 use partiql_value::{
     partiql_bag, partiql_list, partiql_tuple, Bag, BindingsName, List, Tuple, Value,
 };
@@ -69,8 +69,8 @@ fn join_data() -> MapBindings<Value> {
     bindings
 }
 
-fn scan(name: &str, as_key: &str) -> BindingsExpr {
-    BindingsExpr::Scan(logical::Scan {
+fn scan(name: &str, as_key: &str) -> BindingsOp {
+    BindingsOp::Scan(logical::Scan {
         expr: ValueExpr::VarRef(BindingsName::CaseInsensitive(name.into())),
         as_key: as_key.to_string(),
         at_key: None,
@@ -86,7 +86,7 @@ fn path_var(name: &str, component: &str) -> ValueExpr {
     )
 }
 
-fn logical_plan() -> LogicalPlan<BindingsExpr> {
+fn logical_plan() -> LogicalPlan<BindingsOp> {
     let mut lg = LogicalPlan::new();
 
     // Similar to ex 9 from spec with projected columns from different tables with an inner JOIN and ON condition
@@ -103,7 +103,7 @@ fn logical_plan() -> LogicalPlan<BindingsExpr> {
         ]),
     }));
 
-    let join = lg.add_operator(BindingsExpr::Join(logical::Join {
+    let join = lg.add_operator(BindingsOp::Join(logical::Join {
         kind: JoinKind::Inner,
         on: Some(ValueExpr::BinaryExpr(
             BinaryOp::Eq,
@@ -112,7 +112,7 @@ fn logical_plan() -> LogicalPlan<BindingsExpr> {
         )),
     }));
 
-    let sink = lg.add_operator(BindingsExpr::Sink);
+    let sink = lg.add_operator(BindingsOp::Sink);
     lg.add_flow_with_branch_num(from_lhs, join, 0);
     lg.add_flow_with_branch_num(from_rhs, join, 1);
     lg.add_flow_with_branch_num(join, project, 0);
@@ -121,7 +121,7 @@ fn logical_plan() -> LogicalPlan<BindingsExpr> {
     lg
 }
 
-fn eval_plan(logical: &LogicalPlan<BindingsExpr>) -> EvalPlan {
+fn eval_plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
     let planner = plan::EvaluatorPlanner;
 
     planner.compile(logical)

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use partiql_logical as logical;
 use partiql_logical::{
-    BinaryOp, BindingsExpr, IsTypeExpr, JoinKind, LogicalPlan, OpId, PathComponent, SearchedCase,
+    BinaryOp, BindingsOp, IsTypeExpr, JoinKind, LogicalPlan, OpId, PathComponent, SearchedCase,
     Type, UnaryOp, ValueExpr,
 };
 
@@ -18,12 +18,12 @@ use partiql_value::Value::Null;
 pub struct EvaluatorPlanner;
 
 impl EvaluatorPlanner {
-    pub fn compile(&self, plan: &LogicalPlan<BindingsExpr>) -> EvalPlan {
+    pub fn compile(&self, plan: &LogicalPlan<BindingsOp>) -> EvalPlan {
         self.plan_eval(plan)
     }
 
     #[inline]
-    fn plan_eval(&self, lg: &LogicalPlan<BindingsExpr>) -> EvalPlan {
+    fn plan_eval(&self, lg: &LogicalPlan<BindingsOp>) -> EvalPlan {
         let ops = lg.operators();
         let flows = lg.flows();
 
@@ -45,9 +45,9 @@ impl EvaluatorPlanner {
         EvalPlan(graph)
     }
 
-    fn get_eval_node(&self, be: &BindingsExpr) -> Box<dyn Evaluable> {
+    fn get_eval_node(&self, be: &BindingsOp) -> Box<dyn Evaluable> {
         match be {
-            BindingsExpr::Scan(logical::Scan {
+            BindingsOp::Scan(logical::Scan {
                 expr,
                 as_key,
                 at_key,
@@ -62,28 +62,28 @@ impl EvaluatorPlanner {
                     Box::new(eval::EvalScan::new(self.plan_values(expr.clone()), as_key))
                 }
             }
-            BindingsExpr::Project(logical::Project { exprs }) => {
+            BindingsOp::Project(logical::Project { exprs }) => {
                 let exprs: HashMap<_, _> = exprs
                     .iter()
                     .map(|(k, v)| (k.clone(), self.plan_values(v.clone())))
                     .collect();
                 Box::new(eval::EvalProject::new(exprs))
             }
-            BindingsExpr::ProjectValue(logical::ProjectValue { expr }) => {
+            BindingsOp::ProjectValue(logical::ProjectValue { expr }) => {
                 let expr = self.plan_values(expr.clone());
                 Box::new(eval::EvalProjectValue::new(expr))
             }
-            BindingsExpr::Filter(logical::Filter { expr }) => Box::new(eval::EvalFilter {
+            BindingsOp::Filter(logical::Filter { expr }) => Box::new(eval::EvalFilter {
                 expr: self.plan_values(expr.clone()),
                 input: None,
                 output: None,
             }),
-            BindingsExpr::Distinct => Box::new(eval::EvalDistinct::new()),
-            BindingsExpr::Sink => Box::new(eval::EvalSink {
+            BindingsOp::Distinct => Box::new(eval::EvalDistinct::new()),
+            BindingsOp::Sink => Box::new(eval::EvalSink {
                 input: None,
                 output: None,
             }),
-            BindingsExpr::Unpivot(logical::Unpivot {
+            BindingsOp::Unpivot(logical::Unpivot {
                 expr,
                 as_key,
                 at_key,
@@ -92,7 +92,7 @@ impl EvaluatorPlanner {
                 as_key,
                 at_key.as_ref().unwrap(),
             )),
-            BindingsExpr::Join(logical::Join { kind, on }) => {
+            BindingsOp::Join(logical::Join { kind, on }) => {
                 let kind = match kind {
                     JoinKind::Inner => EvalJoinKind::Inner,
                     JoinKind::Left => EvalJoinKind::Left,

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,15 +1,57 @@
+//! A PartiQL logical plan.
+//!
+//! This module contains the structures for a PartiQL logical plan. Three main entities in the
+//! module are [`LogicalPlan`], [`BindingsOp`], and [`ValueExpr`].
+//! `LogicalPlan` represents a graph based logical plan. `BindingsOp` represent operations that
+//! operate on binding tuples and `ValueExpr` represents PartiQL expressions that produce PartiQL
+//! values; all as specified in [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
+//!
+//! Plan graph nodes are called _operators_ and edges are called _flows_ re-instating the fact that
+//! the plan captures data flows for a given PartiQL statement.
+//!
+/// # Examples
+/// ```
+/// use partiql_logical::{BinaryOp, BindingsOp, LogicalPlan, PathComponent, ProjectValue, Scan, ValueExpr};
+/// use partiql_value::{BindingsName, Value};
+///
+/// // Plan for `SELECT VALUE 2*v.a FROM [{'a': 1}, {'a': 2}, {'a': 3}] AS v`
+///
+/// let mut p: LogicalPlan<BindingsOp> = LogicalPlan::new();
+///
+/// let from = p.add_operator(BindingsOp::Scan(Scan {
+///     expr: ValueExpr::VarRef(BindingsName::CaseInsensitive("data".into())),
+///     as_key: "v".to_string(),
+///     at_key: None,
+/// }));
+///
+/// let va = ValueExpr::Path(
+///     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
+///         "v".into(),
+///     ))),
+///     vec![PathComponent::Key("a".to_string())],
+/// );
+///
+/// let select_value = p.add_operator(BindingsOp::ProjectValue(ProjectValue {
+///     expr: ValueExpr::BinaryExpr(
+///         BinaryOp::Mul,
+///         Box::new(va),
+///         Box::new(ValueExpr::Lit(Box::new(Value::Integer(2)))),
+///     ),
+/// }));
+///
+/// let sink = p.add_operator(BindingsOp::Sink);
+///
+/// // Define the data flow as SCAN -> PROJECT_VALUE -> SINK
+/// p.add_flow(from, select_value);
+/// p.add_flow(select_value, sink);
+///
+/// assert_eq!(3, p.operators().len());
+/// assert_eq!(2, p.flows().len());
+/// ```
 use partiql_value::{BindingsName, Value};
 use std::collections::HashMap;
 
-#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
-pub struct OpId(usize);
-
-impl OpId {
-    pub fn index(&self) -> usize {
-        self.0
-    }
-}
-
+/// Represents a PartiQL logical plan.
 #[derive(Debug, Clone, Default)]
 pub struct LogicalPlan<T>
 where
@@ -24,15 +66,18 @@ impl<T> LogicalPlan<T>
 where
     T: Default,
 {
+    /// Creates a new default logical plan.
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Adds a new operator to the plan.
     pub fn add_operator(&mut self, op: T) -> OpId {
         self.nodes.push(op);
         OpId(self.operator_count())
     }
 
+    /// Adds a data flow to the plan.
     #[inline]
     pub fn add_flow(&mut self, src: OpId, dst: OpId) {
         assert!(src.index() <= self.operator_count());
@@ -41,6 +86,8 @@ where
         self.edges.push((src, dst, 0));
     }
 
+    /// Adds a data flow with a branch number. One application of branch number is in data flows to
+    /// [`Join`] operator to distinguish between LHS and RHS of a JOIN.
     #[inline]
     pub fn add_flow_with_branch_num(&mut self, src: OpId, dst: OpId, branch_num: u8) {
         assert!(src.index() <= self.operator_count());
@@ -49,30 +96,158 @@ where
         self.edges.push((src, dst, branch_num));
     }
 
+    /// Extends the logical plan with the given data flows.
+    /// #Examples:
+    /// ```
+    /// use partiql_logical::{BindingsOp, LogicalPlan};
+    /// let mut p: LogicalPlan<BindingsOp> = LogicalPlan::new();
+    ///
+    /// let a = p.add_operator(BindingsOp::OrderBy);
+    /// let b = p.add_operator(BindingsOp::Sink);
+    /// let c = p.add_operator(BindingsOp::Limit);
+    /// let d = p.add_operator(BindingsOp::GroupBy);
+    /// let e = p.add_operator(BindingsOp::Offset);
+    ///
+    /// p.add_flow(a, b);
+    /// p.add_flow(a, c);
+    ///
+    /// p.extend_with_flows(&[(c, d), (d, e)]);
+    /// assert_eq!(4, p.flows().len());
+    /// ```
     #[inline]
     pub fn extend_with_flows(&mut self, flows: &[(OpId, OpId)]) {
         flows.iter().for_each(|&(s, d)| self.add_flow(s, d));
     }
 
+    /// Returns the number of operators in the plan.
     #[inline]
     pub fn operator_count(&self) -> usize {
         self.nodes.len()
     }
 
+    /// Returns the operators of the plan.
     pub fn operators(&self) -> &Vec<T> {
         &self.nodes
     }
 
+    /// Returns the data flows of the plan.
     pub fn flows(&self) -> &Vec<(OpId, OpId, u8)> {
         &self.edges
     }
+
+    // TODO add DAG validation method.
 }
 
-// TODO: other expressions modeled in logical plan and evaluator -- IN, IS, BETWEEN
+/// Represents an operator identifier in a [`LogicalPlan`]
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
+pub struct OpId(usize);
+
+impl OpId {
+    /// Returns operator's index
+    pub fn index(&self) -> usize {
+        self.0
+    }
+}
+
+/// Represents PartiQL binding operators; A `BindingOp` is an operator that operates on
+/// binding tuples as specified by [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
+#[derive(Debug, Clone, Default)]
+pub enum BindingsOp {
+    Scan(Scan),
+    Unpivot(Unpivot),
+    Filter(Filter),
+    OrderBy,
+    Offset,
+    Limit,
+    Join(Join),
+    SetOp,
+    Project(Project),
+    ProjectValue(ProjectValue),
+    Distinct,
+    GroupBy,
+    #[default]
+    Sink,
+}
+
+/// [`Scan`] bridges from [`ValueExpr`]s to [`BindingsOp`]s.
+#[derive(Debug, Clone)]
+pub struct Scan {
+    pub expr: ValueExpr,
+    pub as_key: String,
+    pub at_key: Option<String>,
+}
+
+/// [`Unpivot`] bridges from [`ValueExpr`]s to [`BindingsOp`]s.
+#[derive(Debug, Clone)]
+pub struct Unpivot {
+    pub expr: ValueExpr,
+    pub as_key: String,
+    pub at_key: Option<String>,
+}
+
+/// [`Filter`] represents a filter operator, e.g. `WHERE a = 10` in `SELECT a FROM t WHERE a = 10`.
+#[derive(Debug, Clone)]
+pub struct Filter {
+    pub expr: ValueExpr,
+}
+
+/// ['Join`] represents a join operator, e.g. implicit `CROSS JOIN` specified by comma in `FROM`
+/// clause in `SELECT t1.a, t2.b FROM tbl1 AS t1, tbl2 AS t2`.
+#[derive(Debug, Clone)]
+pub struct Join {
+    pub kind: JoinKind,
+    pub on: Option<ValueExpr>,
+}
+
+/// Represents join types.
+#[derive(Debug, Clone)]
+pub enum JoinKind {
+    Inner,
+    Left,
+    Right,
+    Full,
+    Cross,
+    // TODO revisit JOINS to consider the `Lateral` logic as part of current joins
+    CrossLateral,
+}
+
+/// Represents a projection, e.g. `SELECT a` in `SELECT a FROM t`.
+#[derive(Debug, Clone)]
+pub struct Project {
+    pub exprs: HashMap<String, ValueExpr>,
+}
+
+/// Represents a value projection (SELECT VALUE) e.g. `SELECT VALUE t.a * 2` in
+///`SELECT VALUE t.a * 2 IN tbl AS t`.
+#[derive(Debug, Clone)]
+pub struct ProjectValue {
+    pub expr: ValueExpr,
+}
+
+/// Represents a PartiQL value expression. Evaluation of a [`ValueExpr`] leads to a PartiQL value as
+/// specified by [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
+#[derive(Clone, Debug)]
+pub enum ValueExpr {
+    UnExpr(UnaryOp, Box<ValueExpr>),
+    BinaryExpr(BinaryOp, Box<ValueExpr>, Box<ValueExpr>),
+    Lit(Box<Value>),
+    Path(Box<ValueExpr>, Vec<PathComponent>),
+    VarRef(BindingsName),
+    TupleExpr(TupleExpr),
+    ListExpr(ListExpr),
+    BagExpr(BagExpr),
+    BetweenExpr(BetweenExpr),
+    SubQueryExpr(SubQueryExpr),
+    SimpleCase(SimpleCase),
+    SearchedCase(SearchedCase),
+    IsTypeExpr(IsTypeExpr),
+    NullIfExpr(NullIfExpr),
+    CoalesceExpr(CoalesceExpr),
+}
 
 // TODO we should replace this enum with some identifier that can be looked up in a symtab/funcregistry?
+/// Represents logical plan's unary operators.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
 pub enum UnaryOp {
     Pos,
     Neg,
@@ -80,8 +255,8 @@ pub enum UnaryOp {
 }
 
 // TODO we should replace this enum with some identifier that can be looked up in a symtab/funcregistry?
+/// Represents logical plan's binary operators.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
 pub enum BinaryOp {
     And,
     Or,
@@ -105,11 +280,87 @@ pub enum BinaryOp {
 }
 
 #[derive(Clone, Debug)]
+/// Represents a path component in a plan.
 pub enum PathComponent {
+    /// E.g. `b` in `a.b`
     Key(String),
+    /// E.g. 4 in `a[4]`
     Index(i64),
 }
 
+/// Represents a PartiQL tuple expression, e.g: `{ a.b: a.c * 2, 'count': a.c + 10}`.
+#[derive(Clone, Debug, Default)]
+pub struct TupleExpr {
+    pub attrs: Vec<ValueExpr>,
+    pub values: Vec<ValueExpr>,
+}
+
+impl TupleExpr {
+    /// Creates a new default [`TupleExpr`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Represents a PartiQL list expression, e.g. `[a.c * 2, 5]`.
+#[derive(Clone, Debug, Default)]
+pub struct ListExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+impl ListExpr {
+    /// Creates a new default [`ListExpr`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Represents a PartiQL bag expression, e.g. `<<a.c * 2, 5>>`.
+#[derive(Clone, Debug, Default)]
+pub struct BagExpr {
+    pub elements: Vec<ValueExpr>,
+}
+
+impl BagExpr {
+    /// Creates a new default [`BagExpr`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// Represents a PartiQL `BETWEEN` expression, e.g. `BETWEEN 500 AND 600`.
+#[derive(Clone, Debug)]
+pub struct BetweenExpr {
+    pub value: Box<ValueExpr>,
+    pub from: Box<ValueExpr>,
+    pub to: Box<ValueExpr>,
+}
+
+/// Represents a sub-query expression, e.g. `SELECT v.a*2 AS u FROM t AS v` in
+/// `SELECT t.a, s FROM data AS t, (SELECT v.a*2 AS u FROM t AS v) AS s`
+#[derive(Clone, Debug)]
+pub struct SubQueryExpr {
+    pub plan: LogicalPlan<BindingsOp>,
+}
+
+/// Represents a PartiQL's simple case expressions,
+/// e.g.`CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END`.
+#[derive(Clone, Debug)]
+pub struct SimpleCase {
+    pub expr: Box<ValueExpr>,
+    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
+    pub default: Option<Box<ValueExpr>>,
+}
+
+/// Represents a PartiQL's searched case expressions,
+/// e.g.`CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END`.
+#[derive(Clone, Debug)]
+pub struct SearchedCase {
+    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
+    pub default: Option<Box<ValueExpr>>,
+}
+
+/// Represents an `IS` expression, e.g. `IS TRUE`.
 #[derive(Clone, Debug)]
 pub struct IsTypeExpr {
     pub not: bool,
@@ -117,6 +368,7 @@ pub struct IsTypeExpr {
     pub is_type: Type,
 }
 
+/// Represents a PartiQL Type.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Type {
     NullType,
@@ -148,173 +400,18 @@ pub enum Type {
     // TODO CustomType
 }
 
+/// Represents a `NULLIF` expression, e.g. `NULLIF(v1, v2)` in `SELECT NULLIF(v1, v2) FROM data`.
 #[derive(Clone, Debug)]
 pub struct NullIfExpr {
     pub lhs: Box<ValueExpr>,
     pub rhs: Box<ValueExpr>,
 }
 
+/// Represents a `COALESCE` expression, e.g.
+/// `COALESCE(NULL, 10)` in `SELECT COALESCE(NULL, 10) FROM data`.
 #[derive(Clone, Debug)]
 pub struct CoalesceExpr {
     pub elements: Vec<ValueExpr>,
-}
-
-#[derive(Clone, Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
-pub enum ValueExpr {
-    // TODO other variants
-    UnExpr(UnaryOp, Box<ValueExpr>),
-    BinaryExpr(BinaryOp, Box<ValueExpr>, Box<ValueExpr>),
-    Lit(Box<Value>),
-    Path(Box<ValueExpr>, Vec<PathComponent>),
-    VarRef(BindingsName),
-    TupleExpr(TupleExpr),
-    ListExpr(ListExpr),
-    BagExpr(BagExpr),
-    BetweenExpr(BetweenExpr),
-    SubQueryExpr(SubQueryExpr),
-    SimpleCase(SimpleCase),
-    SearchedCase(SearchedCase),
-    IsTypeExpr(IsTypeExpr),
-    NullIfExpr(NullIfExpr),
-    CoalesceExpr(CoalesceExpr),
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct TupleExpr {
-    pub attrs: Vec<ValueExpr>,
-    pub values: Vec<ValueExpr>,
-}
-
-impl TupleExpr {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct ListExpr {
-    pub elements: Vec<ValueExpr>,
-}
-
-impl ListExpr {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct BagExpr {
-    pub elements: Vec<ValueExpr>,
-}
-
-impl BagExpr {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BetweenExpr {
-    pub value: Box<ValueExpr>,
-    pub from: Box<ValueExpr>,
-    pub to: Box<ValueExpr>,
-}
-
-#[derive(Clone, Debug)]
-pub struct SimpleCase {
-    pub expr: Box<ValueExpr>,
-    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
-    pub default: Option<Box<ValueExpr>>,
-}
-
-#[derive(Clone, Debug)]
-pub struct SearchedCase {
-    pub cases: Vec<(Box<ValueExpr>, Box<ValueExpr>)>,
-    pub default: Option<Box<ValueExpr>>,
-}
-
-// Bindings -> Bindings : Where, OrderBy, Offset, Limit, Join, SetOp, Select, Distinct, GroupBy, Unpivot, Let
-// Values   -> Bindings : From
-// Bindings -> Values   : Select Value
-
-#[derive(Debug, Clone, Default)]
-pub enum BindingsExpr {
-    Scan(Scan),
-    Unpivot(Unpivot),
-    Filter(Filter),
-    OrderBy,
-    Offset,
-    Limit,
-    Join(Join),
-    SetOp,
-    Project(Project),
-    ProjectValue(ProjectValue),
-    Distinct,
-    GroupBy,
-    #[default]
-    Sink,
-}
-
-#[derive(Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
-pub enum BindingsToValueExpr {}
-
-#[derive(Debug)]
-#[allow(dead_code)] // TODO remove once out of PoC
-pub enum ValueToBindingsExpr {}
-
-/// [`Scan`] bridges from [`ValueExpr`]s to [`BindingExpr`]s
-#[derive(Debug, Clone)]
-pub struct Scan {
-    pub expr: ValueExpr,
-    pub as_key: String,
-    pub at_key: Option<String>,
-}
-
-/// [`Unpivot`] bridges from [`ValueExpr`]s to [`BindingExpr`]s
-#[derive(Debug, Clone)]
-pub struct Unpivot {
-    pub expr: ValueExpr,
-    pub as_key: String,
-    pub at_key: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub enum JoinKind {
-    Inner,
-    Left,
-    Right,
-    Full,
-    Cross,
-    // TODO revisit JOINS to consider the `Lateral` logic as part of current joins
-    CrossLateral,
-}
-
-#[derive(Debug, Clone)]
-pub struct Join {
-    pub kind: JoinKind,
-    pub on: Option<ValueExpr>,
-}
-
-#[derive(Debug, Clone)]
-pub struct Filter {
-    pub expr: ValueExpr,
-}
-
-#[derive(Debug, Clone)]
-pub struct Project {
-    pub exprs: HashMap<String, ValueExpr>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ProjectValue {
-    pub expr: ValueExpr,
-}
-
-#[derive(Clone, Debug)]
-pub struct SubQueryExpr {
-    pub plan: LogicalPlan<BindingsExpr>,
 }
 
 #[cfg(test)]
@@ -323,12 +420,12 @@ mod tests {
 
     #[test]
     fn test_plan() {
-        let mut p: LogicalPlan<BindingsExpr> = LogicalPlan::new();
-        let a = p.add_operator(BindingsExpr::OrderBy);
-        let b = p.add_operator(BindingsExpr::Sink);
-        let c = p.add_operator(BindingsExpr::Limit);
-        let d = p.add_operator(BindingsExpr::GroupBy);
-        let e = p.add_operator(BindingsExpr::Offset);
+        let mut p: LogicalPlan<BindingsOp> = LogicalPlan::new();
+        let a = p.add_operator(BindingsOp::OrderBy);
+        let b = p.add_operator(BindingsOp::Sink);
+        let c = p.add_operator(BindingsOp::Limit);
+        let d = p.add_operator(BindingsOp::GroupBy);
+        let e = p.add_operator(BindingsOp::Offset);
         p.add_flow(a, b);
         p.add_flow(a, c);
         p.add_flow(b, c);


### PR DESCRIPTION
*Description of changes:*
In addition
- re-organizes the code in `partiql-logical/src/lib.rs`.
- renames `BindingsExpr` to `BindingsOp` to reflect the fact that the related variants are operators on binding expressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
