### PR TITLE
Fix clippy warnings in partiql-value, partiql-parser, partiql-conformance-tests

### DIFF
--- a/partiql-conformance-tests/src/bin/generate_comparison_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_comparison_report.rs
@@ -44,8 +44,8 @@ fn main() {
     let orig_results = fs::read_to_string(orig_path).expect("read to string orig_results");
     let new_results = fs::read_to_string(new_path).expect("read to string new_results");
 
-    let orig_report: CTSReport = serde_json::from_str(&*orig_results).expect("from_str");
-    let new_report: CTSReport = serde_json::from_str(&*new_results).expect("from_str");
+    let orig_report: CTSReport = serde_json::from_str(&orig_results).expect("from_str");
+    let new_report: CTSReport = serde_json::from_str(&new_results).expect("from_str");
 
     let orig_failing: HashSet<String> = HashSet::from_iter(orig_report.failing);
     let new_failing: HashSet<String> = HashSet::from_iter(new_report.failing);
@@ -73,8 +73,8 @@ fn main() {
     let num_orig_ignored = orig_ignored.len() as i32;
     let num_new_ignored = new_ignored.len() as i32;
 
-    let total_orig = num_orig_passing + num_orig_failing + num_orig_ignored as i32;
-    let total_new = num_new_passing + num_new_failing + num_new_ignored as i32;
+    let total_orig = num_orig_passing + num_orig_failing + num_orig_ignored;
+    let total_new = num_new_passing + num_new_failing + num_new_ignored;
 
     let orig_passing = num_orig_passing as f32 / total_orig as f32 * 100.;
     let new_passing = num_new_passing as f32 / total_new as f32 * 100.;

--- a/partiql-conformance-tests/src/bin/generate_cts_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_cts_report.rs
@@ -35,7 +35,7 @@ fn main() {
     for line in reader.lines() {
         match line {
             Ok(line) => {
-                let v: Value = serde_json::from_str(&*line).expect("from_str");
+                let v: Value = serde_json::from_str(&line).expect("from_str");
                 if v["type"] == "test" {
                     let event = v["event"].as_str().expect("as_str");
                     if event == "ok" {

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -72,7 +72,7 @@ impl<'input, 'tracker> CommentLexer<'input, 'tracker> {
     fn next_internal(&mut self) -> Option<CommentStringResult<'input>> {
         let Span { start, .. } = self.lexer.span();
         let mut nesting = 0;
-        let nesting_inc = if self.comment_nesting { 1 } else { 0 };
+        let nesting_inc = i32::from(self.comment_nesting);
         'comment: loop {
             match self.lexer.next() {
                 Some(CommentToken::Any) => continue,

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -50,12 +50,12 @@ impl ops::Add for &Value {
             (Value::Integer(l), Value::Integer(r)) => Value::Integer(l + r),
             (Value::Real(l), Value::Real(r)) => Value::Real(*l + *r),
             (Value::Decimal(l), Value::Decimal(r)) => Value::Decimal(l + r),
-            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(&self) + rhs,
-            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) + rhs,
-            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) + rhs,
-            (Value::Real(_), Value::Integer(_)) => self + &coerce_int_to_real(&rhs),
-            (Value::Decimal(_), Value::Integer(_)) => self + &coerce_int_or_real_to_decimal(&rhs),
-            (Value::Decimal(_), Value::Real(_)) => self + &coerce_int_or_real_to_decimal(&rhs),
+            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(self) + rhs,
+            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) + rhs,
+            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) + rhs,
+            (Value::Real(_), Value::Integer(_)) => self + &coerce_int_to_real(rhs),
+            (Value::Decimal(_), Value::Integer(_)) => self + &coerce_int_or_real_to_decimal(rhs),
+            (Value::Decimal(_), Value::Real(_)) => self + &coerce_int_or_real_to_decimal(rhs),
             _ => Value::Missing, // data type mismatch => Missing
         }
     }
@@ -74,12 +74,12 @@ impl ops::Sub for &Value {
             (Value::Integer(l), Value::Integer(r)) => Value::Integer(l - r),
             (Value::Real(l), Value::Real(r)) => Value::Real(*l - *r),
             (Value::Decimal(l), Value::Decimal(r)) => Value::Decimal(l - r),
-            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(&self) - rhs,
-            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) - rhs,
-            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) - rhs,
-            (Value::Real(_), Value::Integer(_)) => self - &coerce_int_to_real(&rhs),
-            (Value::Decimal(_), Value::Integer(_)) => self - &coerce_int_or_real_to_decimal(&rhs),
-            (Value::Decimal(_), Value::Real(_)) => self - &coerce_int_or_real_to_decimal(&rhs),
+            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(self) - rhs,
+            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) - rhs,
+            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) - rhs,
+            (Value::Real(_), Value::Integer(_)) => self - &coerce_int_to_real(rhs),
+            (Value::Decimal(_), Value::Integer(_)) => self - &coerce_int_or_real_to_decimal(rhs),
+            (Value::Decimal(_), Value::Real(_)) => self - &coerce_int_or_real_to_decimal(rhs),
             _ => Value::Missing, // data type mismatch => Missing
         }
     }
@@ -98,12 +98,12 @@ impl ops::Mul for &Value {
             (Value::Integer(l), Value::Integer(r)) => Value::Integer(l * r),
             (Value::Real(l), Value::Real(r)) => Value::Real(*l * *r),
             (Value::Decimal(l), Value::Decimal(r)) => Value::Decimal(l * r),
-            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(&self) * rhs,
-            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) * rhs,
-            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) * rhs,
-            (Value::Real(_), Value::Integer(_)) => self * &coerce_int_to_real(&rhs),
-            (Value::Decimal(_), Value::Integer(_)) => self * &coerce_int_or_real_to_decimal(&rhs),
-            (Value::Decimal(_), Value::Real(_)) => self * &coerce_int_or_real_to_decimal(&rhs),
+            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(self) * rhs,
+            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) * rhs,
+            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) * rhs,
+            (Value::Real(_), Value::Integer(_)) => self * &coerce_int_to_real(rhs),
+            (Value::Decimal(_), Value::Integer(_)) => self * &coerce_int_or_real_to_decimal(rhs),
+            (Value::Decimal(_), Value::Real(_)) => self * &coerce_int_or_real_to_decimal(rhs),
             _ => Value::Missing, // data type mismatch => Missing
         }
     }
@@ -122,12 +122,12 @@ impl ops::Div for &Value {
             (Value::Integer(l), Value::Integer(r)) => Value::Integer(l / r),
             (Value::Real(l), Value::Real(r)) => Value::Real(*l / *r),
             (Value::Decimal(l), Value::Decimal(r)) => Value::Decimal(l / r),
-            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(&self) / rhs,
-            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) / rhs,
-            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) / rhs,
-            (Value::Real(_), Value::Integer(_)) => self / &coerce_int_to_real(&rhs),
-            (Value::Decimal(_), Value::Integer(_)) => self / &coerce_int_or_real_to_decimal(&rhs),
-            (Value::Decimal(_), Value::Real(_)) => self / &coerce_int_or_real_to_decimal(&rhs),
+            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(self) / rhs,
+            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) / rhs,
+            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) / rhs,
+            (Value::Real(_), Value::Integer(_)) => self / &coerce_int_to_real(rhs),
+            (Value::Decimal(_), Value::Integer(_)) => self / &coerce_int_or_real_to_decimal(rhs),
+            (Value::Decimal(_), Value::Real(_)) => self / &coerce_int_or_real_to_decimal(rhs),
             _ => Value::Missing, // data type mismatch => Missing
         }
     }
@@ -146,12 +146,12 @@ impl ops::Rem for &Value {
             (Value::Integer(l), Value::Integer(r)) => Value::Integer(l % r),
             (Value::Real(l), Value::Real(r)) => Value::Real(*l % *r),
             (Value::Decimal(l), Value::Decimal(r)) => Value::Decimal(l % r),
-            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(&self) % rhs,
-            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) % rhs,
-            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(&self) % rhs,
-            (Value::Real(_), Value::Integer(_)) => self % &coerce_int_to_real(&rhs),
-            (Value::Decimal(_), Value::Integer(_)) => self % &coerce_int_or_real_to_decimal(&rhs),
-            (Value::Decimal(_), Value::Real(_)) => self % &coerce_int_or_real_to_decimal(&rhs),
+            (Value::Integer(_), Value::Real(_)) => &coerce_int_to_real(self) % rhs,
+            (Value::Integer(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) % rhs,
+            (Value::Real(_), Value::Decimal(_)) => &coerce_int_or_real_to_decimal(self) % rhs,
+            (Value::Real(_), Value::Integer(_)) => self % &coerce_int_to_real(rhs),
+            (Value::Decimal(_), Value::Integer(_)) => self % &coerce_int_or_real_to_decimal(rhs),
+            (Value::Decimal(_), Value::Real(_)) => self % &coerce_int_or_real_to_decimal(rhs),
             _ => Value::Missing, // data type mismatch => Missing
         }
     }


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Some clippy warnings were causing a lot of noise in PRs. Fixed some clippy warnings in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
