### PR TITLE
Don't wrap `FromSource` in `AstNode` in AST

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -441,9 +441,11 @@ pub struct VarRef {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ScopeQualifier {
-    /// Use the default search order.
+    /// The variable was *NOT* prefixed with `@`.
+    /// Resolve the variable by looking first in the database environment, then in the 'lexical' scope.
     Unqualified,
-    /// Skip the globals, first check within FROM sources and resolve starting with the local scope.
+    /// The variable *WAS* prefixed with `@`.
+    /// Resolve the variable by looking first in the 'lexical' scope, then in the database environment.
     Qualified,
 }
 
@@ -672,7 +674,7 @@ pub struct LetBinding {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FromClause {
-    pub source: AstNode<FromSource>,
+    pub source: FromSource,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]
@@ -723,8 +725,8 @@ pub enum FromLetKind {
 pub struct Join {
     #[visit(skip)]
     pub kind: JoinKind,
-    pub left: Box<AstNode<FromSource>>,
-    pub right: Box<AstNode<FromSource>>,
+    pub left: Box<FromSource>,
+    pub right: Box<FromSource>,
     pub predicate: Option<AstNode<JoinSpec>>,
 }
 
@@ -868,7 +870,7 @@ pub struct CustomType {
     pub parts: Vec<CustomTypePart>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SymbolPrimitive {
     pub value: String,
@@ -876,7 +878,7 @@ pub struct SymbolPrimitive {
 }
 
 /// Is used to determine if variable lookup should be case-sensitive or not.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CaseSensitivity {
     CaseSensitive,

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -38,6 +38,7 @@ impl Default for NodeIdGenerator {
 }
 
 impl IdGenerator for NodeIdGenerator {
+    #[inline]
     fn id(&mut self) -> NodeId {
         let mut next = NodeId(&self.next_id.0 + 1);
         std::mem::swap(&mut self.next_id, &mut next);
@@ -89,6 +90,7 @@ impl<'input, Id: IdGenerator> ParserState<'input, Id> {
     }
 
     /// Create a new [`AstNode`] from the inner data which it is to hold and a [`ByteOffset`] range.
+    #[inline]
     pub fn node<T>(&mut self, ast: T, Range { start, end }: Range<ByteOffset>) -> AstNode<T> {
         self.create_node(ast, start.into()..end.into())
     }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -225,8 +225,17 @@ FromClause: ast::AstNode<ast::FromClause> = {
         froms.push(last);
         let source = froms.into_iter()
             .reduce(|lfrom, rfrom| {
-	            let start = state.locations.get(&lfrom.id).unwrap_or(&total).start.0.clone();
-                let end = state.locations.get(&rfrom.id).unwrap_or(&total).end.0.clone();
+                let start_id = match &lfrom {
+                    ast::FromSource::FromLet(node) => node.id,
+                    ast::FromSource::Join(node) => node.id,
+                };
+                let end_id = match &rfrom {
+                    ast::FromSource::FromLet(node) => node.id,
+                    ast::FromSource::Join(node) => node.id,
+                };
+
+	            let start = state.locations.get(&start_id).unwrap_or(&total).start.0.clone();
+                let end = state.locations.get(&end_id).unwrap_or(&total).end.0.clone();
                 let range = start..end;
                 let join = state.node(ast::Join {
                     kind: ast::JoinKind::Cross,
@@ -234,21 +243,21 @@ FromClause: ast::AstNode<ast::FromClause> = {
                     right: Box::new(rfrom),
                     predicate: None
                 }, range.clone());
-                state.node(ast::FromSource::Join( join ), range)
+                ast::FromSource::Join( join )
             })
             .unwrap(); // safe, because we know there's at least 1 input
         state.node(ast::FromClause{source}, lo..hi)
     }
 }
 
-TableReference: ast::AstNode<ast::FromSource> = {
+TableReference: ast::FromSource = {
     <TableNonJoin>,
     <TableJoined>,
 }
 
-TableNonJoin: ast::AstNode<ast::FromSource> = {
-    <lo:@L> <t:TableBaseReference> <hi:@R> => state.node(ast::FromSource::FromLet( t ), lo..hi),
-    <lo:@L> <t:TableUnpivot> <hi:@R> => state.node(ast::FromSource::FromLet( t ), lo..hi),
+TableNonJoin: ast::FromSource = {
+    <lo:@L> <t:TableBaseReference> <hi:@R> =>ast::FromSource::FromLet( t ),
+    <lo:@L> <t:TableUnpivot> <hi:@R> => ast::FromSource::FromLet( t ),
 }
 
 #[inline]
@@ -286,14 +295,14 @@ TableUnpivot: ast::AstNode<ast::FromLet> = {
     }
 }
 
-TableJoined: ast::AstNode<ast::FromSource> = {
+TableJoined: ast::FromSource = {
     <TableCrossJoin>,
     <TableQualifiedJoin>,
     "(" <TableJoined> ")",
 }
 
 #[inline]
-TableCrossJoin: ast::AstNode<ast::FromSource> = {
+TableCrossJoin: ast::FromSource = {
     // Note the `TableReference` on the lhs and the `JoinRhs` on the rhs of the `JOIN`.
     // This is to prevent ambiguity in the grammar and effectively treats `JOIN` like
     //    a left-associative operator
@@ -308,12 +317,12 @@ TableCrossJoin: ast::AstNode<ast::FromSource> = {
             right: Box::new(rtable),
             predicate: None
         }, lo..hi);
-        state.node(ast::FromSource::Join( join ), lo..hi)
+        ast::FromSource::Join( join )
     }
 }
 
 #[inline]
-TableQualifiedJoin: ast::AstNode<ast::FromSource> = {
+TableQualifiedJoin: ast::FromSource = {
     // Note the `TableReference` on the lhs and the `JoinRhs` on the rhs of the `JOIN`.
     // This is to prevent ambiguity in the grammar and effectively treats `JOIN` like
     //    a left-associative operator
@@ -324,7 +333,7 @@ TableQualifiedJoin: ast::AstNode<ast::FromSource> = {
             right: Box::new(rtable),
             predicate: Some(on),
         }, lo..hi);
-        state.node(ast::FromSource::Join( join ), lo..hi)
+        ast::FromSource::Join( join )
     },
     // Note the `TableReference` on the lhs and the `JoinRhs` on the rhs of the `JOIN`.
     // This is to prevent ambiguity in the grammar and effectively treats `JOIN` like
@@ -336,11 +345,11 @@ TableQualifiedJoin: ast::AstNode<ast::FromSource> = {
             right: Box::new(rtable),
             predicate: Some(spec)
         }, lo..hi);
-        state.node(ast::FromSource::Join( join ), lo..hi)
+        ast::FromSource::Join( join )
     },
 }
 #[inline]
-JoinRhs: ast::AstNode<ast::FromSource> = {
+JoinRhs: ast::FromSource = {
     <TableNonJoin>,
     "(" <TableJoined> ")"
 }


### PR DESCRIPTION
Don't wrap `FromSource` in `AstNode` in AST

The `AstNode` is extraneous when trying to manipulate/inspect the AST.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
