### PR TITLE
Address binding case insensitivity TODOs; make PathComponent's Key BindingName rather than String

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -625,7 +625,7 @@ impl EvalExpr for EvalBagExpr {
 
 #[derive(Debug)]
 pub enum EvalPathComponent {
-    Key(String),
+    Key(BindingsName),
     Index(i64),
 }
 
@@ -640,8 +640,8 @@ impl EvalExpr for EvalPath {
         #[inline]
         fn path_into(value: Value, path: &EvalPathComponent) -> Value {
             match path {
-                EvalPathComponent::Key(s) => match value {
-                    Value::Tuple(mut tuple) => tuple.remove(s).unwrap_or(Missing),
+                EvalPathComponent::Key(k) => match value {
+                    Value::Tuple(mut tuple) => tuple.remove(k).unwrap_or(Missing),
                     _ => Missing,
                 },
                 EvalPathComponent::Index(idx) => match value {

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -77,7 +77,9 @@ mod tests {
             Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                 name.into(),
             ))),
-            vec![PathComponent::Key(component.to_string())],
+            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                component.to_string(),
+            ))],
         )
     }
 
@@ -176,7 +178,9 @@ mod tests {
                         Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                             "data".into(),
                         ))),
-                        vec![PathComponent::Key("lhs".to_string())],
+                        vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                            "lhs".to_string(),
+                        ))],
                     )),
                     Box::new(ValueExpr::Lit(Box::new(rhs))),
                 ),
@@ -658,7 +662,9 @@ mod tests {
                             Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                                 "data".into(),
                             ))),
-                            vec![PathComponent::Key("value".to_string())],
+                            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                                "value".to_string(),
+                            ))],
                         )),
                         from: Box::new(ValueExpr::Lit(Box::new(from))),
                         to: Box::new(ValueExpr::Lit(Box::new(to))),
@@ -1125,7 +1131,9 @@ mod tests {
                         Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                             "data".into(),
                         ))),
-                        vec![PathComponent::Key("expr".to_string())],
+                        vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                            "expr".to_string(),
+                        ))],
                     )),
                     is_type,
                 }),
@@ -1188,7 +1196,9 @@ mod tests {
                         Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                             "data".into(),
                         ))),
-                        vec![PathComponent::Key("lhs".to_string())],
+                        vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                            "lhs".to_string(),
+                        ))],
                     )),
                     rhs: Box::new(ValueExpr::Lit(Box::new(rhs))),
                 }),
@@ -1238,7 +1248,10 @@ mod tests {
                 Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                     "data".into(),
                 ))),
-                vec![PathComponent::Key(format!("arg{}", i))],
+                vec![PathComponent::Key(BindingsName::CaseInsensitive(format!(
+                    "arg{}",
+                    i
+                )))],
             )
         }
 
@@ -1318,7 +1331,9 @@ mod tests {
                     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                         "data".into(),
                     ))),
-                    vec![PathComponent::Key("a".to_string())],
+                    vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                        "a".to_string(),
+                    ))],
                 ),
             )]),
         }));
@@ -1832,7 +1847,9 @@ mod tests {
                     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                         "customer".into(),
                     ))),
-                    vec![PathComponent::Key("balance".to_string())],
+                    vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                        "balance".to_string(),
+                    ))],
                 )),
                 Box::new(ValueExpr::Lit(Box::new(Value::Integer(0)))),
             ),
@@ -1846,7 +1863,9 @@ mod tests {
                         Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                             "customer".into(),
                         ))),
-                        vec![PathComponent::Key("firstName".to_string())],
+                        vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                            "firstName".to_string(),
+                        ))],
                     ),
                 ),
                 (
@@ -1857,13 +1876,17 @@ mod tests {
                             Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                                 "customer".into(),
                             ))),
-                            vec![PathComponent::Key("firstName".to_string())],
+                            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                                "firstName".to_string(),
+                            ))],
                         )),
                         Box::new(ValueExpr::Path(
                             Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                                 "customer".into(),
                             ))),
-                            vec![PathComponent::Key("firstName".to_string())],
+                            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                                "firstName".to_string(),
+                            ))],
                         )),
                     ),
                 ),
@@ -1905,7 +1928,9 @@ mod tests {
                     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                         "data".into(),
                     ))),
-                    vec![PathComponent::Key("a".to_string())],
+                    vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                        "a".to_string(),
+                    ))],
                 )),
                 Box::new(ValueExpr::Lit(Box::new(partiql_list![1].into()))),
             ),
@@ -1918,7 +1943,9 @@ mod tests {
                     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
                         "data".into(),
                     ))),
-                    vec![PathComponent::Key("a".to_string())],
+                    vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                        "a".to_string(),
+                    ))],
                 ),
             )]),
         }));
@@ -2174,7 +2201,7 @@ mod tests {
                 expr: Box::new(table_ref),
                 components: vec![
                     EvalPathComponent::Index(0),
-                    EvalPathComponent::Key("a".into()),
+                    EvalPathComponent::Key(BindingsName::CaseInsensitive("a".into())),
                 ],
             };
             let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");
@@ -2201,7 +2228,7 @@ mod tests {
                 expr: Box::new(table_ref),
                 components: vec![
                     EvalPathComponent::Index(0),
-                    EvalPathComponent::Key("c".into()),
+                    EvalPathComponent::Key(BindingsName::CaseInsensitive("c".into())),
                 ],
             };
             let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -28,7 +28,7 @@
 ///     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
 ///         "v".into(),
 ///     ))),
-///     vec![PathComponent::Key("a".to_string())],
+///     vec![PathComponent::Key(BindingsName::CaseInsensitive("a".to_string()))],
 /// );
 ///
 /// let select_value = p.add_operator(BindingsOp::ProjectValue(ProjectValue {
@@ -287,7 +287,7 @@ pub enum BinaryOp {
 /// Represents a path component in a plan.
 pub enum PathComponent {
     /// E.g. `b` in `a.b`
-    Key(String),
+    Key(BindingsName),
     /// E.g. 4 in `a[4]`
     Index(i64),
 }


### PR DESCRIPTION
- Fixes some TODO's related to `Bindings` and `Tuple` case insensitivity
- Make `PathComponent`'s `Key` `BindingName` rather than a `String`
- Updates some benchmark code
- Makes `Tuple`'s `vals` field private

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
