### PR TITLE
Stop ignoring evaluation conformance tests.

### DIFF
--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -32,8 +32,11 @@ miette = { version ="5.*", features = ["fancy"] }
 partiql-conformance-test-generator = { path = "../partiql-conformance-test-generator", version = "0.1.0" }
 
 [dependencies]
-partiql-parser = { path = "../partiql-parser", version = "0.1.0" }
+partiql-parser = { path = "../partiql-parser" }
+partiql-ast = { path = "../partiql-ast" }
+partiql-logical = { path = "../partiql-logical" }
 partiql-value = { path = "../partiql-value" }
+partiql-eval = { path = "../partiql-eval" }
 
 ion-rs = "0.14"
 

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -2,7 +2,7 @@ use ion_rs::{Integer, IonReader, IonType, Reader, StreamItem};
 use partiql_value::{Bag, List, Tuple, Value};
 
 pub(crate) struct TestValue {
-    value: Value,
+    pub value: Value,
 }
 
 impl From<&str> for TestValue {

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -15,7 +15,7 @@ use unicase::UniCase;
 
 mod ion;
 
-#[derive(Clone, Hash, Debug)]
+#[derive(Clone, Hash, Debug, Eq, PartialEq)]
 pub enum BindingsName {
     CaseSensitive(String),
     CaseInsensitive(String),
@@ -1463,7 +1463,7 @@ mod tests {
             Value::from(f64::INFINITY),
             Value::from(""),
             Value::from("abc"),
-            Value::Blob(Box::new(vec![])),
+            Value::Blob(Box::default()),
             Value::Blob(Box::new(vec![1, 2, 3])),
             Value::from(partiql_list!()),
             Value::from(partiql_list!(1, 2, 3)),


### PR DESCRIPTION
- eval tests fail with a `todo()`
- also fixes some bugs with embedded environements in test generation

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
