### PR TITLE
Add ExprQuery BindingsOp

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -565,6 +565,35 @@ impl Evaluable for EvalProjectValue {
 }
 
 #[derive(Debug)]
+pub struct EvalExprQuery {
+    pub expr: Box<dyn EvalExpr>,
+    pub input: Option<Value>,
+    pub output: Option<Value>,
+}
+
+impl EvalExprQuery {
+    pub fn new(expr: Box<dyn EvalExpr>) -> Self {
+        EvalExprQuery {
+            expr,
+            input: None,
+            output: None,
+        }
+    }
+}
+
+impl Evaluable for EvalExprQuery {
+    fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value> {
+        let input_value = self.input.as_ref().unwrap_or(&Value::Null);
+        self.output = Some(self.expr.evaluate(&input_value.as_tuple_ref(), ctx));
+        self.output.clone()
+    }
+
+    fn update_input(&mut self, input: &Value, _branch_num: u8) {
+        self.input = Some(input.clone());
+    }
+}
+
+#[derive(Debug)]
 pub struct EvalTupleExpr {
     pub attrs: Vec<Box<dyn EvalExpr>>,
     pub vals: Vec<Box<dyn EvalExpr>>,

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -13,9 +13,10 @@ mod tests {
 
     use partiql_logical as logical;
     use partiql_logical::BindingsOp::{Distinct, Project, ProjectValue};
+
     use partiql_logical::{
-        BagExpr, BetweenExpr, BinaryOp, BindingsOp, CoalesceExpr, IsTypeExpr, JoinKind, ListExpr,
-        LogicalPlan, NullIfExpr, PathComponent, TupleExpr, Type, ValueExpr,
+        BagExpr, BetweenExpr, BinaryOp, BindingsOp, CoalesceExpr, ExprQuery, IsTypeExpr, JoinKind,
+        ListExpr, LogicalPlan, NullIfExpr, PathComponent, TupleExpr, Type, ValueExpr,
     };
     use partiql_value as value;
     use partiql_value::Value::{Missing, Null};
@@ -1311,6 +1312,26 @@ mod tests {
             ],
             Null,
         );
+    }
+
+    #[test]
+    fn expr_query() {
+        let mut lg = LogicalPlan::new();
+        let expq = lg.add_operator(BindingsOp::ExprQuery(ExprQuery {
+            expr: ValueExpr::BinaryExpr(
+                BinaryOp::Add,
+                Box::new(ValueExpr::Lit(Box::new(40.into()))),
+                Box::new(ValueExpr::Lit(Box::new(2.into()))),
+            ),
+        }));
+
+        let sink = lg.add_operator(BindingsOp::Sink);
+
+        lg.add_flow(expq, sink);
+
+        let out = evaluate(lg, MapBindings::default());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Integer(42));
     }
 
     #[test]

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -117,6 +117,10 @@ impl EvaluatorPlanner {
                     on,
                 ))
             }
+            BindingsOp::ExprQuery(logical::ExprQuery { expr }) => {
+                let expr = self.plan_values(expr.clone());
+                Box::new(eval::EvalExprQuery::new(expr))
+            }
             BindingsOp::OrderBy => todo!("OrderBy"),
             BindingsOp::Offset => todo!("Offset"),
             BindingsOp::Limit => todo!("Limit"),

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -167,6 +167,7 @@ pub enum BindingsOp {
     SetOp,
     Project(Project),
     ProjectValue(ProjectValue),
+    ExprQuery(ExprQuery),
     Distinct,
     GroupBy,
     #[default]
@@ -225,6 +226,12 @@ pub struct Project {
 ///`SELECT VALUE t.a * 2 IN tbl AS t`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ProjectValue {
+    pub expr: ValueExpr,
+}
+
+/// Represents an expression query e.g. `a * 2` in `a * 2` or an expression like `2+2`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ExprQuery {
     pub expr: ValueExpr,
 }
 


### PR DESCRIPTION
Models a query that is entirely an expression, such as `2+2` or `table.a *10`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
