### PR TITLE
Add `ProjectAll` for use in `SELECT *`

### DIFF
--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -12,7 +12,7 @@ mod tests {
     use rust_decimal_macros::dec;
 
     use partiql_logical as logical;
-    use partiql_logical::BindingsOp::{Distinct, Project, ProjectValue};
+    use partiql_logical::BindingsOp::{Distinct, Project, ProjectAll, ProjectValue};
 
     use partiql_logical::{
         BagExpr, BetweenExpr, BinaryOp, BindingsOp, CoalesceExpr, ExprQuery, IsTypeExpr, JoinKind,
@@ -1366,6 +1366,32 @@ mod tests {
                 partiql_tuple![("b", 1)],
                 partiql_tuple![("b", 2)],
                 partiql_tuple![("b", 3)],
+            ];
+            assert_eq!(*bag, expected);
+        });
+    }
+
+    #[test]
+    fn select_star() {
+        // TODO `SELECT *` is underspecified w.r.t. nested data
+        let mut lg = LogicalPlan::new();
+
+        let from = lg.add_operator(scan("data", "data"));
+
+        let project = lg.add_operator(ProjectAll);
+
+        let sink = lg.add_operator(BindingsOp::Sink);
+
+        lg.add_flow(from, project);
+        lg.add_flow(project, sink);
+
+        let out = evaluate(lg, data_3_tuple());
+        println!("{:?}", &out);
+        assert_matches!(out, Value::Bag(bag) => {
+            let expected = partiql_bag![
+                partiql_tuple![("a", 1)],
+                partiql_tuple![("a", 2)],
+                partiql_tuple![("a", 3)],
             ];
             assert_eq!(*bag, expected);
         });

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -70,6 +70,7 @@ impl EvaluatorPlanner {
                     .collect();
                 Box::new(eval::EvalProject::new(exprs))
             }
+            BindingsOp::ProjectAll => Box::new(eval::EvalProjectAll::new()),
             BindingsOp::ProjectValue(logical::ProjectValue { expr }) => {
                 let expr = self.plan_values(expr.clone());
                 Box::new(eval::EvalProjectValue::new(expr))

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -166,6 +166,7 @@ pub enum BindingsOp {
     Join(Join),
     SetOp,
     Project(Project),
+    ProjectAll,
     ProjectValue(ProjectValue),
     ExprQuery(ExprQuery),
     Distinct,


### PR DESCRIPTION
Add `ProjectAll` for use in `SELECT *`

`SELECT *` is currently underspecified w.r.t. nested data, but this is at least a first cut at non-join results.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
