### PR TITLE
Add ability to use `EvalExpr` in path components

### DIFF
--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -168,10 +168,16 @@ impl EvaluatorPlanner {
             ValueExpr::Path(expr, components) => Box::new(EvalPath {
                 expr: self.plan_values(*expr),
                 components: components
-                    .iter()
+                    .into_iter()
                     .map(|c| match c {
-                        PathComponent::Key(k) => eval::EvalPathComponent::Key(k.clone()),
-                        PathComponent::Index(i) => eval::EvalPathComponent::Index(*i),
+                        PathComponent::Key(k) => eval::EvalPathComponent::Key(k),
+                        PathComponent::Index(i) => eval::EvalPathComponent::Index(i),
+                        PathComponent::KeyExpr(k) => {
+                            eval::EvalPathComponent::KeyExpr(self.plan_values(*k))
+                        }
+                        PathComponent::IndexExpr(i) => {
+                            eval::EvalPathComponent::IndexExpr(self.plan_values(*i))
+                        }
                     })
                     .collect(),
             }),

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -298,6 +298,8 @@ pub enum PathComponent {
     Key(BindingsName),
     /// E.g. 4 in `a[4]`
     Index(i64),
+    KeyExpr(Box<ValueExpr>),
+    IndexExpr(Box<ValueExpr>),
 }
 
 /// Represents a PartiQL tuple expression, e.g: `{ a.b: a.c * 2, 'count': a.c + 10}`.


### PR DESCRIPTION
e.g. `[1,2,3][1+1]` <=> `[1,2,3][2]` <=> `3`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
