### PR TITLE
Make tests in conformance report GH comment collapsible

### DIFF
--- a/partiql-conformance-tests/src/bin/generate_comparison_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_comparison_report.rs
@@ -131,23 +131,29 @@ Number failing in main but now pass: {}
 
     if !passing_orig_failing_new.is_empty() {
         comparison_report_file.write_all(
-            "\n:interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing but now fail:\n".as_bytes()
+            "\n:interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing but now fail:\n<details><summary>Click here to see</summary>\n\n".as_bytes()
         ).expect("write passing_orig_failing_new heading");
         for test_name in &passing_orig_failing_new {
             comparison_report_file
                 .write_all(format!("- {}\n", test_name).as_bytes())
                 .expect("write passing_orig_failing_new test case");
         }
+        comparison_report_file
+            .write_all("\n</details>".as_bytes())
+            .expect("write passing_orig_failing_new closing");
     };
 
     if !failure_orig_passing_new.is_empty() {
         comparison_report_file.write_all(
-            "\nThe following test(s) were previously failing but now pass. Before merging, confirm they are intended to pass: \n".as_bytes()
+            "\nThe following test(s) were previously failing but now pass. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n".as_bytes()
         ).expect("write failure_orig_passing_new heading");
         for test_name in &failure_orig_passing_new {
             comparison_report_file
                 .write_all(format!("- {}\n", test_name).as_bytes())
                 .expect("write failure_orig_passing_new test case");
         }
+        comparison_report_file
+            .write_all("\n</details>".as_bytes())
+            .expect("write failure_orig_passing_new closing");
     }
 }


### PR DESCRIPTION
Previously if a PR, fixed or renamed a bunch of conformance tests, the conformance report comment in the PR would have a long list of failing tests.

 
![Screenshot 2023-01-06 at 6 00 37 PM](https://user-images.githubusercontent.com/23245405/211113999-d1548b00-321f-4501-a43f-c74c6b5d1c33.png)

(above taken from https://github.com/partiql/partiql-lang-rust/pull/257#issuecomment-1371531091 and lists about 900 tests)

Changed to hide behind a "Summary" link that can be clicked to expand:

![Screenshot 2023-01-06 at 6 01 58 PM](https://user-images.githubusercontent.com/23245405/211114172-2173fb4d-3ff6-4232-a760-09a53b694d8b.png)

(above taken from https://github.com/partiql/partiql-lang-rust/pull/253#issuecomment-1362213443, in which I altered the comment to include this PR's changes)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
