### PR TITLE
Add documentation for Evaluator and minor fix for ast doc.

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -1,8 +1,9 @@
 //! A PartiQL abstract syntax tree (AST).
 //!
 //! This module contains the structures for the language AST.
-//! Two main entities in the module are [`Item`] and [`ItemKind`]. `Item` represents an AST element
-//! and `ItemKind` represents a concrete type with the data specific to the type of the item.
+//! Two main entities in the module are [`Item`] and [`AstNode`]. `AstNode` represents an AST node
+//! and `Item` represents a PartiQL statement type, e.g. query, data definition language (DDL)
+//! data manipulation language (DML).
 
 // As more changes to this AST are expected, unless explicitly advised, using the structures exposed
 // in this crate directly is not recommended.

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -530,18 +530,18 @@ impl Evaluable for EvalSelectValue {
 /// operational semantics, see section `6` of
 /// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
-pub struct EvalProject {
+pub struct EvalSelect {
     pub exprs: HashMap<String, Box<dyn EvalExpr>>,
     pub input: Option<Value>,
 }
 
-impl EvalProject {
+impl EvalSelect {
     pub fn new(exprs: HashMap<String, Box<dyn EvalExpr>>) -> Self {
-        EvalProject { exprs, input: None }
+        EvalSelect { exprs, input: None }
     }
 }
 
-impl Evaluable for EvalProject {
+impl Evaluable for EvalSelect {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value> {
         let input_value = self.input.take().expect("Error in retrieving input value");
 
@@ -576,17 +576,17 @@ impl Evaluable for EvalProject {
 /// Represents an evaluation `ProjectAll` operator; `ProjectAll` implements SQL's `SELECT *`
 /// semantics.
 #[derive(Debug, Default)]
-pub struct EvalProjectAll {
+pub struct EvalSelectAll {
     pub input: Option<Value>,
 }
 
-impl EvalProjectAll {
+impl EvalSelectAll {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl Evaluable for EvalProjectAll {
+impl Evaluable for EvalSelectAll {
     fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
         let input_value = self.input.take().expect("Error in retrieving input value");
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -780,7 +780,6 @@ impl EvalExpr for EvalPath {
     }
 }
 
-
 /// Represents an evaluation operator for sub-queries, e.g. `SELECT a FROM b` in
 /// `SELECT b.c, (SELECT a FROM b) FROM books AS b`.
 #[derive(Debug)]

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -487,7 +487,7 @@ impl Evaluable for EvalFilter {
 }
 
 /// Represents an evaluation `SelectValue` operator; `SelectValue` implements PartiQL Core's
-/// `SELECT VALUE` clause semantics. For`SelectValue` operational semantics, see section `6.1` of
+/// `SELECT VALUE` clause semantics. For `SelectValue` operational semantics, see section `6.1` of
 /// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalSelectValue {
@@ -526,7 +526,7 @@ impl Evaluable for EvalSelectValue {
 }
 
 /// Represents an evaluation `Project` operator; for a given bag of input binding tuples as input
-/// the `Project` selects attributes as specified by expressions in `exprs`. For`Project`
+/// the `Project` selects attributes as specified by expressions in `exprs`. For `Project`
 /// operational semantics, see section `6` of
 /// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
@@ -614,7 +614,7 @@ impl Evaluable for EvalProjectAll {
     }
 }
 
-/// Represents and evaluation `ExprQuery` operator; in PartiQL as opposed to SQL the following
+/// Represents an evaluation `ExprQuery` operator; in PartiQL as opposed to SQL, the following
 /// expression by its own is valid: `2 * 2`. Considering this, evaluation plan designates an operator
 /// for evaluating such stand-alone expressions.
 #[derive(Debug)]
@@ -1204,7 +1204,7 @@ impl EvalExpr for EvalFnUpper {
     }
 }
 
-/// Represents a built-in character length string function, e.g. char_length('123456789').
+/// Represents a built-in character length string function, e.g. `char_length('123456789')`.
 #[derive(Debug)]
 pub struct EvalFnCharLength {
     pub value: Box<dyn EvalExpr>,

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -923,7 +923,7 @@ impl EvalExpr for EvalUnaryOpExpr {
     }
 }
 
-/// Represents a PartiQL evaluation `IS` operator, e.g. `IS` in `a IS INT`.
+/// Represents a PartiQL evaluation `IS` operator, e.g. `a IS INT`.
 #[derive(Debug)]
 pub struct EvalIsTypeExpr {
     pub expr: Box<dyn EvalExpr>,
@@ -942,7 +942,7 @@ impl EvalExpr for EvalIsTypeExpr {
     }
 }
 
-/// Represents an evaluation binary operator, e.g. `+` in `a + b`.
+/// Represents an evaluation binary operator, e.g.`a + b`.
 #[derive(Debug)]
 pub struct EvalBinOpExpr {
     pub op: EvalBinOp,
@@ -1070,7 +1070,7 @@ impl EvalExpr for EvalBinOpExpr {
     }
 }
 
-/// Represents an evaluation PartiQL `BETWEEN` operator, e.g. in `x BETWEEN 10 AND 20`.
+/// Represents an evaluation PartiQL `BETWEEN` operator, e.g. `x BETWEEN 10 AND 20`.
 #[derive(Debug)]
 pub struct EvalBetweenExpr {
     pub value: Box<dyn EvalExpr>,

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -212,7 +212,7 @@ impl Evaluable for EvalScan {
 
 /// Represents an evaluation `Join` operator; `Join` joins the tuples from its LHS and RHS based on a logic defined
 /// by [`EvalJoinKind`]. For semantics of PartiQL joins and their distinction with SQL's see sections
-/// 5.3 – 5.7 of [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// 5.3 – 5.7 of [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalJoin {
     pub kind: EvalJoinKind,
@@ -385,7 +385,7 @@ impl Evaluable for EvalJoin {
 
 /// Represents an evaluation `Unpivot` operator; the `Unpivot` enables ranging over the
 /// attribute-value pairs of a tuple. For `Unpivot` operational semantics, see section `5.2` of
-/// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalUnpivot {
     pub expr: Box<dyn EvalExpr>,
@@ -461,7 +461,7 @@ impl EvalFilter {
             Boolean(bool_val) => bool_val,
             // Alike SQL, when the expression of the WHERE clause expression evaluates to
             // absent value or a value that is not a Boolean, PartiQL eliminates the corresponding
-            // binding. PartiQL Specification August 1, 2019 Draft, Section 8. `WHERE clause`
+            // binding. PartiQL Specification August 1, August 1, 2019 Draft, Section 8. `WHERE clause`
             _ => false,
         }
     }
@@ -488,7 +488,7 @@ impl Evaluable for EvalFilter {
 
 /// Represents an evaluation `SelectValue` operator; `SelectValue` implements PartiQL Core's
 /// `SELECT VALUE` clause semantics. For `SelectValue` operational semantics, see section `6.1` of
-/// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalSelectValue {
     pub expr: Box<dyn EvalExpr>,
@@ -528,7 +528,7 @@ impl Evaluable for EvalSelectValue {
 /// Represents an evaluation `Project` operator; for a given bag of input binding tuples as input
 /// the `Project` selects attributes as specified by expressions in `exprs`. For `Project`
 /// operational semantics, see section `6` of
-/// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalProject {
     pub exprs: HashMap<String, Box<dyn EvalExpr>>,
@@ -712,7 +712,7 @@ impl EvalExpr for EvalBagExpr {
 }
 
 /// Represents an evaluation operator for path navigation expressions as outlined in Section `4` of
-/// [PartiQL Specification — 2007](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalPath {
     pub expr: Box<dyn EvalExpr>,

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -72,9 +72,9 @@ impl EvaluatorPlanner {
                     .iter()
                     .map(|(k, v)| (k.clone(), self.plan_values(v.clone())))
                     .collect();
-                Box::new(eval::EvalProject::new(exprs))
+                Box::new(eval::EvalSelect::new(exprs))
             }
-            BindingsOp::ProjectAll => Box::new(eval::EvalProjectAll::new()),
+            BindingsOp::ProjectAll => Box::new(eval::EvalSelectAll::new()),
             BindingsOp::ProjectValue(logical::ProjectValue { expr }) => {
                 let expr = self.plan_values(expr.clone());
                 Box::new(eval::EvalSelectValue::new(expr))

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -75,7 +75,7 @@ impl EvaluatorPlanner {
             BindingsOp::ProjectAll => Box::new(eval::EvalProjectAll::new()),
             BindingsOp::ProjectValue(logical::ProjectValue { expr }) => {
                 let expr = self.plan_values(expr.clone());
-                Box::new(eval::EvalProjectValue::new(expr))
+                Box::new(eval::EvalSelectValue::new(expr))
             }
             BindingsOp::Filter(logical::Filter { expr }) => Box::new(eval::EvalFilter {
                 expr: self.plan_values(expr.clone()),


### PR DESCRIPTION
*Description of changes:*
Adds documentation for Evaluator. It also:
- Renames `EvalProjectValue` to `EvalSelectValue` to better conform to PartiQL core naming.
- Fixes `partiql-ast` documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
