### PR TITLE
FIX: Coerce MISSING to an empty tuple

### DIFF
--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -513,11 +513,13 @@ impl Value {
 
     #[inline]
     pub fn coerce_to_tuple(self) -> Tuple {
-        if let Value::Tuple(t) = self {
-            *t
-        } else {
-            let fresh_key = "_1"; // TODO don't hard-code 'fresh' keys
-            Tuple::from([(fresh_key, self)])
+        match self {
+            Value::Tuple(t) => *t,
+            Value::Missing => partiql_tuple![],
+            _ => {
+                let fresh_key = "_1"; // TODO don't hard-code 'fresh' keys
+                partiql_tuple![(fresh_key, self)]
+            }
         }
     }
 


### PR DESCRIPTION
Coerce MISSING to `{}`, not `{ '_1': MISSING }`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
