### PR TITLE
Replace usages of lazy_static with once_cell

### DIFF
--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -41,7 +41,7 @@ logos = "~0.12.0"
 itertools = "~0.10.3"
 
 regex = "1.7"
-lazy_static = "~1.4.0"
+once_cell = "1"
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -8,9 +8,8 @@ mod parser_state;
 use crate::error::{ParseError, UnexpectedTokenData};
 use crate::lexer;
 use crate::parse::parser_state::{IdGenerator, ParserState};
-use crate::preprocessor::{built_ins, FnExprSet, PreprocessingPartiqlLexer};
+use crate::preprocessor::{PreprocessingPartiqlLexer, BUILT_INS};
 use lalrpop_util as lpop;
-use lazy_static::lazy_static;
 use partiql_ast::ast;
 use partiql_ast::ast::NodeId;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
@@ -50,10 +49,6 @@ pub(crate) struct ErrorData<'input> {
 }
 
 pub(crate) type AstResult<'input> = Result<AstData, ErrorData<'input>>;
-
-lazy_static! {
-    static ref BUILT_INS: FnExprSet<'static> = built_ins();
-}
 
 /// Parse PartiQL query text into an AST.
 pub(crate) fn parse_partiql(s: &str) -> AstResult {

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -10,7 +10,10 @@ use crate::error::LexError;
 use crate::lexer::{InternalLexResult, LexResult, PartiqlLexer, Spanned, Token};
 
 use crate::token_parser::{BufferedToken, TokenParser};
+use once_cell::sync::Lazy;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
+
+pub(crate) static BUILT_INS: Lazy<FnExprSet<'static>> = Lazy::new(|| built_ins());
 
 /// A single "function expression" argument match.
 #[derive(Debug, Clone)]
@@ -581,12 +584,6 @@ mod tests {
     use partiql_source_map::line_offset_tracker::LineOffsetTracker;
 
     use crate::ParseError;
-
-    use lazy_static::lazy_static;
-
-    lazy_static! {
-        static ref BUILT_INS: FnExprSet<'static> = built_ins();
-    }
 
     #[test]
     fn cast() -> Result<(), ParseError<'static>> {


### PR DESCRIPTION
`lazy_static` is old and relies on macros.
`OnceCell` uses more modern rust features and its API is under consideration for inclusion in `std` (See rust-lang issue 74465).
    

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
