### PR TITLE
Add configuration for `cargo-about`

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,25 @@
+# Configuration for cargo-about
+# See https://embarkstudios.github.io/cargo-about/index.html
+
+# Don't check the licenses of our private workspace crates
+private = { ignore = true }
+
+# Acceptable licenses.
+# Order matters here, `cargo-about` "will try to satisfy the licenses in the order that they are declared in this list."
+#    as per https://embarkstudios.github.io/cargo-about/cli/generate/config.html#the-accepted-field
+#
+# This list must be manually reconciled with the `allow`s and/or `exception`s in `deny.toml`
+# If you change this list, please also change `deny.toml`
+#    see https://github.com/EmbarkStudios/cargo-about/issues/201
+accepted = [
+    "MIT",
+    "Apache-2.0",
+    "0BSD",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "ISC",
+    "Zlib",
+    "ICU",
+    "Unicode-DFS-2016"
+]

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,6 @@
+# Configuration for cargo-deny
+# See https://embarkstudios.github.io/cargo-deny/
+
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:


### PR DESCRIPTION
Add configuration for `cargo-about`

See https://embarkstudios.github.io/cargo-about/index.html

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
