### PR TITLE
Improve performance by removing extraneous `clone`s and tweaking initial buffer sizes.

### DIFF
--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -473,7 +473,7 @@ impl Evaluable for EvalFilter {
 
         let mut out = partiql_bag![];
         for v in input_value.into_iter() {
-            if self.eval_filter(&v.clone().coerce_to_tuple(), ctx) {
+            if self.eval_filter(&v.as_tuple_ref(), ctx) {
                 out.push(v);
             }
         }
@@ -823,7 +823,7 @@ impl EvalDistinct {
 
 impl Evaluable for EvalDistinct {
     fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
-        let out = self.input.clone().unwrap();
+        let out = self.input.take().unwrap();
         let u: Vec<Value> = out.into_iter().unique().collect();
         Some(Value::Bag(Box::new(Bag::from(u))))
     }
@@ -841,7 +841,7 @@ pub struct EvalSink {
 
 impl Evaluable for EvalSink {
     fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
-        self.input.clone()
+        self.input.take()
     }
 
     fn update_input(&mut self, input: Value, _branch_num: u8) {

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -24,6 +24,7 @@ use partiql_value::Value::Null;
 pub struct EvaluatorPlanner;
 
 impl EvaluatorPlanner {
+    #[inline]
     pub fn compile(&self, plan: &LogicalPlan<BindingsOp>) -> EvalPlan {
         self.plan_eval(plan)
     }
@@ -60,28 +61,28 @@ impl EvaluatorPlanner {
             }) => {
                 if let Some(at_key) = at_key {
                     Box::new(eval::EvalScan::new_with_at_key(
-                        self.plan_values(expr.clone()),
+                        self.plan_values(&expr),
                         as_key,
                         at_key,
                     ))
                 } else {
-                    Box::new(eval::EvalScan::new(self.plan_values(expr.clone()), as_key))
+                    Box::new(eval::EvalScan::new(self.plan_values(&expr), as_key))
                 }
             }
             BindingsOp::Project(logical::Project { exprs }) => {
                 let exprs: HashMap<_, _> = exprs
                     .iter()
-                    .map(|(k, v)| (k.clone(), self.plan_values(v.clone())))
+                    .map(|(k, v)| (k.clone(), self.plan_values(&v)))
                     .collect();
                 Box::new(eval::EvalSelect::new(exprs))
             }
             BindingsOp::ProjectAll => Box::new(eval::EvalSelectAll::new()),
             BindingsOp::ProjectValue(logical::ProjectValue { expr }) => {
-                let expr = self.plan_values(expr.clone());
+                let expr = self.plan_values(&expr);
                 Box::new(eval::EvalSelectValue::new(expr))
             }
             BindingsOp::Filter(logical::Filter { expr }) => Box::new(eval::EvalFilter {
-                expr: self.plan_values(expr.clone()),
+                expr: self.plan_values(&expr),
                 input: None,
             }),
             BindingsOp::Distinct => Box::new(eval::EvalDistinct::new()),
@@ -91,7 +92,7 @@ impl EvaluatorPlanner {
                 as_key,
                 at_key,
             }) => Box::new(eval::EvalUnpivot::new(
-                self.plan_values(expr.clone()),
+                self.plan_values(&expr),
                 as_key,
                 at_key.clone(),
             )),
@@ -111,7 +112,7 @@ impl EvaluatorPlanner {
                 };
                 let on = on
                     .as_ref()
-                    .map(|on_condition| self.plan_values(on_condition.clone()));
+                    .map(|on_condition| self.plan_values(on_condition));
                 Box::new(eval::EvalJoin::new(
                     kind,
                     self.get_eval_node(left),
@@ -120,7 +121,7 @@ impl EvaluatorPlanner {
                 ))
             }
             BindingsOp::ExprQuery(logical::ExprQuery { expr }) => {
-                let expr = self.plan_values(expr.clone());
+                let expr = self.plan_values(expr);
                 Box::new(eval::EvalExprQuery::new(expr))
             }
             BindingsOp::OrderBy => todo!("OrderBy"),
@@ -131,10 +132,10 @@ impl EvaluatorPlanner {
         }
     }
 
-    fn plan_values(&self, ve: ValueExpr) -> Box<dyn EvalExpr> {
+    fn plan_values(&self, ve: &ValueExpr) -> Box<dyn EvalExpr> {
         match ve {
             ValueExpr::UnExpr(unary_op, operand) => {
-                let operand = self.plan_values(*operand);
+                let operand = self.plan_values(operand);
                 let op = match unary_op {
                     UnaryOp::Pos => EvalUnaryOp::Pos,
                     UnaryOp::Neg => EvalUnaryOp::Neg,
@@ -143,8 +144,8 @@ impl EvaluatorPlanner {
                 Box::new(EvalUnaryOpExpr { op, operand })
             }
             ValueExpr::BinaryExpr(binop, lhs, rhs) => {
-                let lhs = self.plan_values(*lhs);
-                let rhs = self.plan_values(*rhs);
+                let lhs = self.plan_values(lhs);
+                let rhs = self.plan_values(rhs);
                 let op = match binop {
                     BinaryOp::And => EvalBinOp::And,
                     BinaryOp::Or => EvalBinOp::Or,
@@ -165,33 +166,33 @@ impl EvaluatorPlanner {
                 };
                 Box::new(EvalBinOpExpr { op, lhs, rhs })
             }
-            ValueExpr::Lit(lit) => Box::new(EvalLitExpr { lit }),
+            ValueExpr::Lit(lit) => Box::new(EvalLitExpr { lit: lit.clone() }),
             ValueExpr::Path(expr, components) => Box::new(EvalPath {
-                expr: self.plan_values(*expr),
+                expr: self.plan_values(expr),
                 components: components
                     .into_iter()
                     .map(|c| match c {
-                        PathComponent::Key(k) => eval::EvalPathComponent::Key(k),
-                        PathComponent::Index(i) => eval::EvalPathComponent::Index(i),
+                        PathComponent::Key(k) => eval::EvalPathComponent::Key(k.clone()),
+                        PathComponent::Index(i) => eval::EvalPathComponent::Index(i.clone()),
                         PathComponent::KeyExpr(k) => {
-                            eval::EvalPathComponent::KeyExpr(self.plan_values(*k))
+                            eval::EvalPathComponent::KeyExpr(self.plan_values(k))
                         }
                         PathComponent::IndexExpr(i) => {
-                            eval::EvalPathComponent::IndexExpr(self.plan_values(*i))
+                            eval::EvalPathComponent::IndexExpr(self.plan_values(i))
                         }
                     })
                     .collect(),
             }),
-            ValueExpr::VarRef(name) => Box::new(EvalVarRef { name }),
+            ValueExpr::VarRef(name) => Box::new(EvalVarRef { name: name.clone() }),
             ValueExpr::TupleExpr(expr) => {
                 let attrs: Vec<Box<dyn EvalExpr>> = expr
                     .attrs
-                    .into_iter()
+                    .iter()
                     .map(|attr| self.plan_values(attr))
                     .collect();
                 let vals: Vec<Box<dyn EvalExpr>> = expr
                     .values
-                    .into_iter()
+                    .iter()
                     .map(|attr| self.plan_values(attr))
                     .collect();
                 Box::new(EvalTupleExpr { attrs, vals })
@@ -199,7 +200,7 @@ impl EvaluatorPlanner {
             ValueExpr::ListExpr(expr) => {
                 let elements: Vec<Box<dyn EvalExpr>> = expr
                     .elements
-                    .into_iter()
+                    .iter()
                     .map(|elem| self.plan_values(elem))
                     .collect();
                 Box::new(EvalListExpr { elements })
@@ -207,19 +208,19 @@ impl EvaluatorPlanner {
             ValueExpr::BagExpr(expr) => {
                 let elements: Vec<Box<dyn EvalExpr>> = expr
                     .elements
-                    .into_iter()
+                    .iter()
                     .map(|elem| self.plan_values(elem))
                     .collect();
                 Box::new(EvalBagExpr { elements })
             }
             ValueExpr::BetweenExpr(expr) => {
-                let value = self.plan_values(*expr.value);
-                let from = self.plan_values(*expr.from);
-                let to = self.plan_values(*expr.to);
+                let value = self.plan_values(expr.value.as_ref());
+                let from = self.plan_values(expr.from.as_ref());
+                let to = self.plan_values(expr.to.as_ref());
                 Box::new(EvalBetweenExpr { value, from, to })
             }
             ValueExpr::PatternMatchExpr(PatternMatchExpr { value, pattern }) => {
-                let value = self.plan_values(*value);
+                let value = self.plan_values(value);
                 match pattern {
                     Pattern::LIKE(logical::LikeMatch { pattern, escape }) => {
                         // TODO statically assert escape length
@@ -236,24 +237,24 @@ impl EvaluatorPlanner {
             ValueExpr::SimpleCase(e) => {
                 let cases = e
                     .cases
-                    .into_iter()
+                    .iter()
                     .map(|case| {
                         (
-                            self.plan_values(ValueExpr::BinaryExpr(
+                            self.plan_values(&ValueExpr::BinaryExpr(
                                 BinaryOp::Eq,
                                 e.expr.clone(),
-                                case.0,
+                                case.0.clone(),
                             )),
-                            self.plan_values(*case.1),
+                            self.plan_values(case.1.as_ref()),
                         )
                     })
                     .collect();
-                let default = match e.default {
+                let default = match &e.default {
                     // If no `ELSE` clause is specified, use implicit `ELSE NULL` (see section 6.9, pg 142 of SQL-92 spec)
                     None => Box::new(EvalLitExpr {
                         lit: Box::new(Null),
                     }),
-                    Some(def) => self.plan_values(*def),
+                    Some(def) => self.plan_values(def),
                 };
                 // Here, rewrite `SimpleCaseExpr`s as `SearchedCaseExpr`s
                 Box::new(EvalSearchedCaseExpr { cases, default })
@@ -261,31 +262,36 @@ impl EvaluatorPlanner {
             ValueExpr::SearchedCase(e) => {
                 let cases = e
                     .cases
-                    .into_iter()
-                    .map(|case| (self.plan_values(*case.0), self.plan_values(*case.1)))
+                    .iter()
+                    .map(|case| {
+                        (
+                            self.plan_values(case.0.as_ref()),
+                            self.plan_values(case.1.as_ref()),
+                        )
+                    })
                     .collect();
-                let default = match e.default {
+                let default = match &e.default {
                     // If no `ELSE` clause is specified, use implicit `ELSE NULL` (see section 6.9, pg 142 of SQL-92 spec)
                     None => Box::new(EvalLitExpr {
                         lit: Box::new(Null),
                     }),
-                    Some(def) => self.plan_values(*def),
+                    Some(def) => self.plan_values(def.as_ref()),
                 };
                 Box::new(EvalSearchedCaseExpr { cases, default })
             }
             ValueExpr::IsTypeExpr(i) => {
-                let expr = self.plan_values(*i.expr);
+                let expr = self.plan_values(i.expr.as_ref());
                 match i.not {
                     true => Box::new(EvalUnaryOpExpr {
                         op: EvalUnaryOp::Not,
                         operand: Box::new(EvalIsTypeExpr {
                             expr,
-                            is_type: i.is_type,
+                            is_type: i.is_type.clone(),
                         }),
                     }),
                     false => Box::new(EvalIsTypeExpr {
                         expr,
-                        is_type: i.is_type,
+                        is_type: i.is_type.clone(),
                     }),
                 }
             }
@@ -297,14 +303,14 @@ impl EvaluatorPlanner {
                     cases: vec![(
                         Box::new(ValueExpr::BinaryExpr(
                             BinaryOp::Eq,
-                            Box::new(*n.lhs.clone()),
-                            Box::new(*n.rhs.clone()),
+                            n.lhs.clone(),
+                            n.rhs.clone(),
                         )),
                         Box::new(ValueExpr::Lit(Box::new(Null))),
                     )],
-                    default: Some(Box::new(*n.lhs)),
+                    default: Some(n.lhs.clone()),
                 });
-                self.plan_values(rewritten_as_case)
+                self.plan_values(&rewritten_as_case)
             }
             ValueExpr::CoalesceExpr(c) => {
                 // COALESCE can be rewritten using CASE WHEN expressions as per section 6.9 pg 142 of SQL-92 spec:
@@ -329,11 +335,11 @@ impl EvaluatorPlanner {
                     };
                     ValueExpr::SearchedCase(sc)
                 }
-                self.plan_values(as_case(c.elements.first().unwrap(), &c.elements[1..]))
+                self.plan_values(&as_case(c.elements.first().unwrap(), &c.elements[1..]))
             }
             ValueExpr::DynamicLookup(lookups) => {
                 let lookups = lookups
-                    .into_iter()
+                    .iter()
                     .map(|lookup| self.plan_values(lookup))
                     .collect_vec();
 

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -15,7 +15,7 @@ type ParseErrorRecovery<'input> =
     ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
 type ParseErrors<'input> = Vec<ParseErrorRecovery<'input>>;
 
-const INIT_LOCATIONS: usize = 50;
+const INIT_LOCATIONS: usize = 100;
 
 /// A provider of 'fresh' [`NodeId`]s.
 // NOTE `pub` instead of `pub(crate)` only because LALRPop's generated code uses this in `pub trait __ToTriple`


### PR DESCRIPTION
Improve performance by removing extraneous `clone`s and tweaking initial buffer sizes.

```
10:38❯ cargo bench
    Finished bench [optimized + debuginfo] target(s) in 0.68s
     Running benches/bench_eval_multi_like.rs (target/release/deps/bench_eval_multi_like-40a62f267e10d031)
parse-1                 time:   [6.7670 µs 6.8086 µs 6.8564 µs]
                        change: [-8.6514% -7.1434% -5.6991%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

parse-15                time:   [58.581 µs 58.882 µs 59.206 µs]
                        change: [-4.1975% -2.8944% -1.4224%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

parse-30                time:   [118.08 µs 118.62 µs 119.16 µs]
                        change: [-4.8603% -3.3925% -2.2699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

compile-1               time:   [20.189 µs 20.269 µs 20.357 µs]
                        change: [+0.4576% +1.5569% +2.7740%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

compile-15              time:   [58.767 µs 59.281 µs 59.992 µs]
                        change: [-1.3774% -0.2256% +0.9734%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

compile-30              time:   [100.08 µs 100.74 µs 101.44 µs]
                        change: [-4.9675% -2.5715% -0.6447%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

plan-1                  time:   [21.575 µs 21.696 µs 21.828 µs]
                        change: [-3.6081% -2.9408% -2.1841%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

plan-15                 time:   [335.78 µs 337.69 µs 339.75 µs]
                        change: [-2.9899% -2.3007% -1.6301%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

plan-30                 time:   [674.52 µs 676.98 µs 679.50 µs]
                        change: [-4.7574% -3.9435% -3.0584%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

eval-1                  time:   [24.502 ms 24.629 ms 24.774 ms]
                        change: [-25.058% -24.374% -23.704%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Benchmarking eval-15: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.6s, or reduce sample count to 30.
eval-15                 time:   [164.89 ms 165.41 ms 165.97 ms]
                        change: [-6.9389% -6.4914% -6.0866%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Benchmarking eval-30: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 31.9s, or reduce sample count to 10.
eval-30                 time:   [321.79 ms 322.94 ms 324.26 ms]
                        change: [-5.0670% -4.2883% -3.6095%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running benches/bench_eval.rs (target/release/deps/bench_eval-314331151edf3f8b)
join                    time:   [33.455 µs 33.737 µs 34.092 µs]
                        change: [-8.5408% -7.3388% -6.3447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

simple                  time:   [8.3750 µs 8.4392 µs 8.5179 µs]
                        change: [-1.4552% -0.4105% +0.5757%] (p = 0.45 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

simple-no               time:   [3.8393 µs 3.8610 µs 3.8858 µs]
                        change: [-2.4937% -1.3078% -0.2708%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  9 (9.00%) high mild
  3 (3.00%) high severe

numbers                 time:   [110.93 ns 111.48 ns 112.08 ns]
                        change: [-2.0647% -0.6473% +0.5693%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe

     Running benches/bench_parse.rs (target/release/deps/bench_parse-b606eba6d5f82c02)
parse-simple            time:   [1.0609 µs 1.0677 µs 1.0753 µs]
                        change: [-1.9550% -0.9580% -0.0189%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

parse-ion               time:   [3.0233 µs 3.0427 µs 3.0651 µs]
                        change: [-1.4378% -0.4134% +0.6009%] (p = 0.44 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe

parse-group             time:   [9.4457 µs 9.6779 µs 9.9555 µs]
                        change: [-0.1578% +1.2818% +2.7020%] (p = 0.09 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

parse-complex           time:   [23.061 µs 23.302 µs 23.600 µs]
                        change: [-2.5563% -1.4074% -0.2360%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe

parse-complex-fexpr     time:   [36.844 µs 36.970 µs 37.109 µs]
                        change: [-4.0745% -3.0001% -1.9867%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
