### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2022-08-11
+          toolchain: stable
       # Run benchmark with `cargo bench` and stores the output to a file
       - name: Run benchmark
         run: cargo bench -- --output-format bencher | tee output.txt

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,12 +28,10 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
           toolchain: nightly-2022-08-11
-          override: true
       # Run benchmark with `cargo bench` and stores the output to a file
       - name: Run benchmark
         run: cargo bench -- --output-format bencher | tee output.txt

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -23,7 +23,7 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install llvm -y
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain
@@ -105,7 +105,7 @@ jobs:
     steps:
       # Pull down the cached `partiql-lang-rust` build from the `Build and Test` job. This allows us to reuse without
       # needing to rebuild. If pulling the build fails, the subsequent `cargo test` will rebuild.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain
@@ -147,7 +147,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       # Pull down cached `cargo build` and conformance report
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -195,11 +195,11 @@ jobs:
       - id: get-comment-body
         continue-on-error: true
         run: |
+          delimiter="$(openssl rand -hex 8)"
           body="$(cat ./cts-comparison-report.md)"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "::set-output name=body::$body"
+          echo "body<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$body" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
       # Create or update (if previous comment exists) with markdown version of comparison report
       - name: Create or update comment
         continue-on-error: true

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -68,7 +68,7 @@ jobs:
       # Cache the `cargo build` so future jobs can reuse build
       - name: Cache cargo build
         if: matrix.os == 'ubuntu-20.04'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*
@@ -114,7 +114,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: restore-build
         with:
           path: ./*
@@ -135,7 +135,7 @@ jobs:
       # Cache the `cargo build` and conformance report for `conformance-report-comparison` job (pull_request event only)
       - name: Cache `cargo build` and conformance report
         if: github.event_name == 'pull_request'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: restore-build-and-conformance
         with:
           path: ./*
@@ -156,7 +156,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: restore-build-and-conformance
         with:
           path: ./*

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -191,15 +191,6 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: Conformance
-      # Convert the markdown comparison report to a readable form for GitHub PR comments
-      - id: get-comment-body
-        continue-on-error: true
-        run: |
-          delimiter="$(openssl rand -hex 8)"
-          body="$(cat ./cts-comparison-report.md)"
-          echo "body<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo "$body" >> "${GITHUB_OUTPUT}"
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
       # Create or update (if previous comment exists) with markdown version of comparison report
       - name: Create or update comment
         continue-on-error: true
@@ -207,5 +198,5 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.get-comment-body.outputs.body }}
+          body-file: cts-comparison-report.md
           edit-mode: replace

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -27,37 +27,17 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+          components: clippy, rustfmt
       - name: Cargo Build 
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --workspace
+        run: cargo build --verbose --workspace
       - name: Cargo Test excluding conformance tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --workspace
+        run: cargo test --verbose --workspace
       - name: Rustfmt Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --verbose --all -- --check
-      # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
-      # permissions, the behavior of the Action is different depending on the source of the PR. If the
-      # PR comes from the partiql-lang-rust project itself, any suggestions will be added to the PR as comments.
-      # If the PR comes from a fork, any suggestions will be added to the Action's STDOUT for review.
-      # For details, see: https://github.com/actions-rs/clippy-check/issues/2
-      - name: Install Clippy
-        # The clippy check depends on setup steps defined above, but we don't want it to run
-        # for every OS because it posts its comments to the PR. These `if` checks limit clippy to
-        # only running on the Linux test. (The choice of OS was arbitrary.)
         if: matrix.os == 'ubuntu-20.04'
-        run: rustup component add clippy
+        run: cargo fmt --verbose --all -- --check
       - name: Run Clippy
         if: matrix.os == 'ubuntu-20.04'
         uses: actions-rs/clippy-check@v1
@@ -109,11 +89,9 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - uses: actions/cache@v3
         id: restore-build
         with:
@@ -151,11 +129,9 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - uses: actions/cache@v3
         id: restore-build-and-conformance
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Rust Toolchain

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,21 +23,16 @@ jobs:
         with:
           submodules: recursive
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           # nightly can be very volatile--pin this to a version we know works well...
           toolchain: nightly-2022-08-11
-          override: true
       # Conformance tests are run with 'conformance_test' feature. Since step runs with 'all-features', the conformance
       # test are also run, which can cause `cargo test` to fail. Add 'continue-on-error' step to prevent GH Actions
       # failure.
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
         continue-on-error: true
-        with:
-          command: test
-          args: --verbose --workspace --all-features --no-fail-fast -- -Z unstable-options --ensure-time
+        run: cargo test --verbose --workspace --all-features --no-fail-fast -- -Z unstable-options --ensure-time
         env:
           CARGO_INCREMENTAL: '0'
           # https://github.com/marketplace/actions/rust-grcov


### PR DESCRIPTION
## Update CI actions
- Update still-supported actions to versions that don't use deprecated features
- Replace  `actions-rs/toolchain` with `dtolnay/rust-toolchain`
- Updates our conformance report commenting to not use `set-output`

### TODO
- replace `clippy-check`

## Why?
Node.js 12 actions and `set-output` are deprecated.

See:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Also, The `actions-rs` actions appear unmaintained:
- https://github.com/actions-rs/toolchain/issues/216

## Result

Compare warning annotations for:
 - old: https://github.com/partiql/partiql-lang-rust/actions/runs/4001004554
 - new: https://github.com/partiql/partiql-lang-rust/actions/runs/4001578956

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
