### PR TITLE
Implement `PIVOT` in evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds some benchmarks for parsing, compiling, planning, & evaluation
+- Implements `PIVOT` operator in evaluator
 
 ### Fixes
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -411,9 +411,8 @@ impl Evaluable for EvalPivot {
         for binding in input_value.into_iter() {
             let binding = binding.coerce_to_tuple();
             let key = self.key.evaluate(&binding, ctx);
-            let value = self.value.evaluate(&binding, ctx);
-
             if let Value::String(s) = key {
+                let value = self.value.evaluate(&binding, ctx);
                 out.insert(&s, value)
             }
         }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -87,6 +87,10 @@ impl EvaluatorPlanner {
             }),
             BindingsOp::Distinct => Box::new(eval::EvalDistinct::new()),
             BindingsOp::Sink => Box::new(eval::EvalSink { input: None }),
+            BindingsOp::Pivot(logical::Pivot { key, value }) => Box::new(eval::EvalPivot::new(
+                self.plan_values(key),
+                self.plan_values(value),
+            )),
             BindingsOp::Unpivot(logical::Unpivot {
                 expr,
                 as_key,

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -621,7 +621,13 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
                 logical::BindingsOp::Project(logical::Project { exprs })
             }
-            ProjectionKind::ProjectPivot(_) => todo!("ProjectionKind::ProjectPivot"),
+            ProjectionKind::ProjectPivot(_) => {
+                assert_eq!(env.len(), 2);
+                let mut iter = env.into_iter();
+                let key = iter.next().unwrap();
+                let value = iter.next().unwrap();
+                logical::BindingsOp::Pivot(logical::Pivot { key, value })
+            }
             ProjectionKind::ProjectValue(_) => {
                 assert_eq!(env.len(), 1);
                 let expr = env.into_iter().next().unwrap();

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -188,7 +188,7 @@ pub struct Scan {
     pub at_key: Option<String>,
 }
 
-/// [`Filter`] represents a PIVOT operator, e.g. `PIVOT sp.price AT sp."symbol` in
+/// [`Pivot`] represents a PIVOT operator, e.g. `PIVOT sp.price AT sp."symbol` in
 /// `PIVOT sp.price AT sp."symbol" FROM todaysStockPrices sp`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Pivot {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -189,7 +189,9 @@ pub struct Scan {
 }
 
 /// [`Pivot`] represents a PIVOT operator, e.g. `PIVOT sp.price AT sp."symbol` in
-/// `PIVOT sp.price AT sp."symbol" FROM todaysStockPrices sp`.
+/// `PIVOT sp.price AT sp."symbol" FROM todaysStockPrices sp`. For `Pivot` operational semantics,
+/// see section `6.2` of
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Pivot {
     pub key: ValueExpr,

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -162,6 +162,7 @@ impl OpId {
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub enum BindingsOp {
     Scan(Scan),
+    Pivot(Pivot),
     Unpivot(Unpivot),
     Filter(Filter),
     OrderBy,
@@ -185,6 +186,14 @@ pub struct Scan {
     pub expr: ValueExpr,
     pub as_key: String,
     pub at_key: Option<String>,
+}
+
+/// [`Filter`] represents a PIVOT operator, e.g. `PIVOT sp.price AT sp."symbol` in
+/// `PIVOT sp.price AT sp."symbol" FROM todaysStockPrices sp`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Pivot {
+    pub key: ValueExpr,
+    pub value: ValueExpr,
 }
 
 /// [`Unpivot`] bridges from [`ValueExpr`]s to [`BindingsOp`]s.


### PR DESCRIPTION
Implements `PIVOT` operator in evaluator. Defined in section [6.2 of PartiQL spec](https://partiql.org/assets/PartiQL-Specification.pdf#subsection.6.2).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
