### PR TITLE
Implement `LIKE` for non-string, non-literals

### DIFF
--- a/partiql-conformance-tests/src/bin/generate_comparison_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_comparison_report.rs
@@ -135,7 +135,7 @@ Number failing in main but now pass: {}
         ).expect("write passing_orig_failing_new heading");
         for test_name in &passing_orig_failing_new {
             comparison_report_file
-                .write_all(format!("- {}\n", test_name).as_bytes())
+                .write_all(format!("- {test_name}\n").as_bytes())
                 .expect("write passing_orig_failing_new test case");
         }
         comparison_report_file
@@ -149,7 +149,7 @@ Number failing in main but now pass: {}
         ).expect("write failure_orig_passing_new heading");
         for test_name in &failure_orig_passing_new {
             comparison_report_file
-                .write_all(format!("- {}\n", test_name).as_bytes())
+                .write_all(format!("- {test_name}\n").as_bytes())
                 .expect("write failure_orig_passing_new test case");
         }
         comparison_report_file

--- a/partiql-conformance-tests/src/bin/generate_cts_report.rs
+++ b/partiql-conformance-tests/src/bin/generate_cts_report.rs
@@ -47,7 +47,7 @@ fn main() {
                     }
                 }
             }
-            Err(e) => panic!("Error reading line: {}", e),
+            Err(e) => panic!("Error reading line: {e}"),
         }
     }
 

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -1152,10 +1152,10 @@ impl EvalExpr for EvalLikeMatch {
     fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
         let value = self.value.evaluate(bindings, ctx);
         match value {
-            Null => Value::Null,
-            Missing => Value::Missing,
-            Value::String(s) => Value::Boolean(self.pattern.is_match(s.as_ref())),
-            _ => Value::Missing,
+            Null => Null,
+            Missing => Missing,
+            Value::String(s) => Boolean(self.pattern.is_match(s.as_ref())),
+            _ => Missing,
         }
     }
 }
@@ -1186,17 +1186,16 @@ impl EvalLikeNonStringNonLiteralMatch {
 impl EvalExpr for EvalLikeNonStringNonLiteralMatch {
     fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
         let value = self.value.evaluate(bindings, ctx);
-        // TODO: could do some short-circuiting here if `value` is MISSING/NULL/non-string
         let pattern = self.pattern.evaluate(bindings, ctx);
         let escape = self.escape.evaluate(bindings, ctx);
 
         match (value, pattern, escape) {
-            (Missing, _, _) => Value::Missing, // TODO: 3-value logic here? or 4-value logic?
-            (_, Missing, _) => Value::Missing,
-            (_, _, Missing) => Value::Missing,
-            (Null, _, _) => Value::Null,
-            (_, Null, _) => Value::Null,
-            (_, _, Null) => Value::Null,
+            (Missing, _, _) => Missing,
+            (_, Missing, _) => Missing,
+            (_, _, Missing) => Missing,
+            (Null, _, _) => Null,
+            (_, Null, _) => Null,
+            (_, _, Null) => Null,
             (Value::String(v), Value::String(p), Value::String(e)) => {
                 assert!(e.chars().count() <= 1);
                 let escape = e.chars().next();
@@ -1204,9 +1203,9 @@ impl EvalExpr for EvalLikeNonStringNonLiteralMatch {
                     .size_limit(RE_SIZE_LIMIT)
                     .build()
                     .expect("Like Pattern");
-                Value::Boolean(regex_pattern.is_match(v.as_ref()))
+                Boolean(regex_pattern.is_match(v.as_ref()))
             }
-            _ => Value::Missing,
+            _ => Missing,
         }
     }
 }

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -23,6 +23,7 @@ use partiql_logical::Type;
 
 use petgraph::graph::NodeIndex;
 
+use crate::pattern_match::like_to_re_pattern;
 use petgraph::visit::EdgeRef;
 use regex::{Regex, RegexBuilder};
 use std::borrow::Borrow;
@@ -1155,7 +1156,58 @@ impl EvalExpr for EvalLikeMatch {
             Null => Value::Null,
             Missing => Value::Missing,
             Value::String(s) => Value::Boolean(self.pattern.is_match(s.as_ref())),
-            _ => Value::Boolean(false),
+            _ => Value::Missing,
+        }
+    }
+}
+
+/// Represents an evaluation `LIKE` operator without string literals in the match and/or escape
+/// pattern, e.g. in `s LIKE match_str ESCAPE escape_char`.
+#[derive(Debug)]
+pub struct EvalLikeNonStringNonLiteralMatch {
+    pub value: Box<dyn EvalExpr>,
+    pub pattern: Box<dyn EvalExpr>,
+    pub escape: Box<dyn EvalExpr>,
+}
+
+impl EvalLikeNonStringNonLiteralMatch {
+    pub fn new(
+        value: Box<dyn EvalExpr>,
+        pattern: Box<dyn EvalExpr>,
+        escape: Box<dyn EvalExpr>,
+    ) -> Self {
+        EvalLikeNonStringNonLiteralMatch {
+            value,
+            pattern,
+            escape,
+        }
+    }
+}
+
+impl EvalExpr for EvalLikeNonStringNonLiteralMatch {
+    fn evaluate(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Value {
+        let value = self.value.evaluate(bindings, ctx);
+        // TODO: could do some short-circuiting here if `value` is MISSING/NULL/non-string
+        let pattern = self.pattern.evaluate(bindings, ctx);
+        let escape = self.escape.evaluate(bindings, ctx);
+
+        match (value, pattern, escape) {
+            (Missing, _, _) => Value::Missing, // TODO: 3-value logic here? or 4-value logic?
+            (_, Missing, _) => Value::Missing,
+            (_, _, Missing) => Value::Missing,
+            (Null, _, _) => Value::Null,
+            (_, Null, _) => Value::Null,
+            (_, _, Null) => Value::Null,
+            (Value::String(v), Value::String(p), Value::String(e)) => {
+                assert!(e.chars().count() <= 1);
+                let escape = e.chars().next();
+                let regex_pattern = RegexBuilder::new(&like_to_re_pattern(&p, escape))
+                    .size_limit(RE_SIZE_LIMIT)
+                    .build()
+                    .expect("Like Pattern");
+                Value::Boolean(regex_pattern.is_match(v.as_ref()))
+            }
+            _ => Value::Missing,
         }
     }
 }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -730,27 +730,27 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let pattern_ve = env.pop().unwrap();
         let value = Box::new(env.pop().unwrap());
 
-      let pattern = match (&pattern_ve, &escape_ve) {
-          (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
-              match (pattern_lit.as_ref(), escape_lit.as_ref()) {
-                  (Value::String(pattern), Value::String(escape)) => Pattern::Like(LikeMatch {
-                      pattern: pattern.to_string(),
-                      escape: escape.to_string(),
-                  }),
-                  _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
-                      pattern: Box::new(pattern_ve),
-                      escape: Box::new(escape_ve),
-                  }),
-              }
-          }
-          _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
-              pattern: Box::new(pattern_ve),
-              escape: Box::new(escape_ve),
-          }),
-      };
+        let pattern = match (&pattern_ve, &escape_ve) {
+            (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
+                match (pattern_lit.as_ref(), escape_lit.as_ref()) {
+                    (Value::String(pattern), Value::String(escape)) => Pattern::Like(LikeMatch {
+                        pattern: pattern.to_string(),
+                        escape: escape.to_string(),
+                    }),
+                    _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+                        pattern: Box::new(pattern_ve),
+                        escape: Box::new(escape_ve),
+                    }),
+                }
+            }
+            _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+                pattern: Box::new(pattern_ve),
+                escape: Box::new(escape_ve),
+            }),
+        };
 
-      let pattern = ValueExpr::PatternMatchExpr(PatternMatchExpr { value, pattern });
-      self.push_vexpr(pattern);
+        let pattern = ValueExpr::PatternMatchExpr(PatternMatchExpr { value, pattern });
+        self.push_vexpr(pattern);
     }
 
     fn enter_call(&mut self, _call: &'ast Call) {

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -14,8 +14,8 @@ use partiql_ast::ast::{
 use partiql_ast::visit::{Visit, Visitor};
 use partiql_logical as logical;
 use partiql_logical::{
-    BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch, ListExpr, LogicalPlan, OpId,
-    PathComponent, Pattern, PatternMatchExpr, TupleExpr, ValueExpr,
+    BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch, LikeNonStringNonLiteralMatch,
+    ListExpr, LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, TupleExpr, ValueExpr,
 };
 
 use partiql_value::{BindingsName, Value};
@@ -152,21 +152,6 @@ fn infer_id(expr: &ValueExpr) -> Option<SymbolPrimitive> {
             _ => None,
         },
         _ => None,
-    }
-}
-
-// TODO Error/Result
-fn require_lit(expr: &ValueExpr) -> &Value {
-    match expr {
-        ValueExpr::Lit(lit) => lit.as_ref(),
-        _ => todo!("Error on not-literal"),
-    }
-}
-
-fn require_str(lit: &Value) -> &str {
-    match lit {
-        Value::String(s) => s.as_ref(),
-        _ => todo!("Error on not-string"),
     }
 }
 
@@ -737,18 +722,52 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     fn exit_like(&mut self, _like: &'ast Like) {
         let mut env = self.exit_env();
         assert!((2..=3).contains(&env.len()));
-        let escape = if env.len() == 3 {
-            require_str(require_lit(&env.pop().unwrap())).to_string()
+        let escape_ve = if env.len() == 3 {
+            env.pop().unwrap()
         } else {
-            "".to_string()
+            ValueExpr::Lit(Box::new(Value::String(Box::new("".to_string()))))
         };
-        let pattern = require_str(require_lit(&env.pop().unwrap())).to_string();
+        let pattern_ve = env.pop().unwrap();
         let value = Box::new(env.pop().unwrap());
-        let pattern = Pattern::LIKE(LikeMatch { pattern, escape });
-        self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
-            value,
-            pattern,
-        }));
+
+        match (&pattern_ve, &escape_ve) {
+            (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
+                match (pattern_lit.as_ref(), escape_lit.as_ref()) {
+                    (Value::String(pattern), Value::String(escape)) => {
+                        let pattern = Pattern::Like(LikeMatch {
+                            pattern: pattern.to_string(),
+                            escape: escape.to_string(),
+                        });
+                        self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
+                            value,
+                            pattern,
+                        }));
+                    }
+                    _ => {
+                        let pattern_non_string_literals =
+                            Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+                                pattern: Box::new(pattern_ve),
+                                escape: Box::new(escape_ve),
+                            });
+                        self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
+                            value,
+                            pattern: pattern_non_string_literals,
+                        }))
+                    }
+                }
+            }
+            _ => {
+                let pattern_non_string_literals =
+                    Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+                        pattern: Box::new(pattern_ve),
+                        escape: Box::new(escape_ve),
+                    });
+                self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
+                    value,
+                    pattern: pattern_non_string_literals,
+                }))
+            }
+        }
     }
 
     fn enter_call(&mut self, _call: &'ast Call) {

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -730,44 +730,27 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let pattern_ve = env.pop().unwrap();
         let value = Box::new(env.pop().unwrap());
 
-        match (&pattern_ve, &escape_ve) {
-            (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
-                match (pattern_lit.as_ref(), escape_lit.as_ref()) {
-                    (Value::String(pattern), Value::String(escape)) => {
-                        let pattern = Pattern::Like(LikeMatch {
-                            pattern: pattern.to_string(),
-                            escape: escape.to_string(),
-                        });
-                        self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
-                            value,
-                            pattern,
-                        }));
-                    }
-                    _ => {
-                        let pattern_non_string_literals =
-                            Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
-                                pattern: Box::new(pattern_ve),
-                                escape: Box::new(escape_ve),
-                            });
-                        self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
-                            value,
-                            pattern: pattern_non_string_literals,
-                        }))
-                    }
-                }
-            }
-            _ => {
-                let pattern_non_string_literals =
-                    Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
-                        pattern: Box::new(pattern_ve),
-                        escape: Box::new(escape_ve),
-                    });
-                self.push_vexpr(ValueExpr::PatternMatchExpr(PatternMatchExpr {
-                    value,
-                    pattern: pattern_non_string_literals,
-                }))
-            }
-        }
+      let pattern = match (&pattern_ve, &escape_ve) {
+          (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
+              match (pattern_lit.as_ref(), escape_lit.as_ref()) {
+                  (Value::String(pattern), Value::String(escape)) => Pattern::Like(LikeMatch {
+                      pattern: pattern.to_string(),
+                      escape: escape.to_string(),
+                  }),
+                  _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+                      pattern: Box::new(pattern_ve),
+                      escape: Box::new(escape_ve),
+                  }),
+              }
+          }
+          _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
+              pattern: Box::new(pattern_ve),
+              escape: Box::new(escape_ve),
+          }),
+      };
+
+      let pattern = ValueExpr::PatternMatchExpr(PatternMatchExpr { value, pattern });
+      self.push_vexpr(pattern);
     }
 
     fn enter_call(&mut self, _call: &'ast Call) {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -377,13 +377,20 @@ pub struct PatternMatchExpr {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Pattern {
-    LIKE(LikeMatch), // TODO other e.g., SIMILAR_TO, or regex match
+    Like(LikeMatch), // TODO other e.g., SIMILAR_TO, or regex match
+    LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LikeMatch {
     pub pattern: String,
     pub escape: String,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LikeNonStringNonLiteralMatch {
+    pub pattern: Box<ValueExpr>,
+    pub escape: Box<ValueExpr>,
 }
 
 /// Represents a sub-query expression, e.g. `SELECT v.a*2 AS u FROM t AS v` in

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -381,12 +381,16 @@ pub enum Pattern {
     LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch),
 }
 
+/// Represents a LIKE expression where both the `pattern` and `escape` are string literals,
+/// e.g. `'foo%' ESCAPE '/'`
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LikeMatch {
     pub pattern: String,
     pub escape: String,
 }
 
+/// Represents a LIKE expression where one of `pattern` and `escape` is not a string literal,
+/// e.g. `some_pattern ESCAPE '/'`
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LikeNonStringNonLiteralMatch {
     pub pattern: Box<ValueExpr>,


### PR DESCRIPTION
(Additional LIKE tests are in pending partiql-tests PR: https://github.com/partiql/partiql-tests/pull/49. Once that's merged, will update the partiql-tests submodule).

Implements `LIKE` for non-string, non-literals. Previous implementation only accounted for scenario in which `LIKE` was given non-string, non-literal arguments. This resulted in some queries given NULL or MISSING pattern or escape arguments to fail an assertion while lowering to the logical plan.

Remaining TODOs:
- [x]  Documentation + cleanup
- [x] Sorting out if `LIKE` follows 3 or 4 value logic
- [x] Add some edge cases missing from the conformance tests (pending merging of https://github.com/partiql/partiql-tests/pull/49) -- this should also fulfill the codecoverage requirements

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
