### PR TITLE
Fix clippy warnings following GH Actions Rust version bump

### DIFF
--- a/partiql-ast/partiql-ast-macros/src/lib.rs
+++ b/partiql-ast/partiql-ast-macros/src/lib.rs
@@ -50,11 +50,11 @@ fn should_skip_variant(variant: &syn::Variant) -> bool {
 fn impl_visit(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let visit_fn_name = &ast.ident.to_string().to_snake_case();
     let enter_fn_name = Ident::new(
-        &format!("enter_{}", visit_fn_name),
+        &format!("enter_{visit_fn_name}"),
         proc_macro2::Span::call_site(),
     );
     let exit_fn_name = Ident::new(
-        &format!("exit_{}", visit_fn_name),
+        &format!("exit_{visit_fn_name}"),
         proc_macro2::Span::call_site(),
     );
 

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -43,7 +43,7 @@ pub enum Item {
 impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Use Debug formatting for now
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/partiql-conformance-test-generator/src/generator.rs
+++ b/partiql-conformance-test-generator/src/generator.rs
@@ -290,7 +290,7 @@ impl Generator {
             .join("___")
             + ".env.ion";
 
-        let data_file = format!("{}/{}", TEST_DATA_DIR, env_file);
+        let data_file = format!("{TEST_DATA_DIR}/{env_file}");
         scope.raw(
             quote! {
                 const ENV_ION_TEXT : &'static str = include_str!(#data_file);
@@ -446,7 +446,7 @@ impl Generator {
                                 Node::Value(TestValueNode { value: expected }),
                             );
 
-                            let data_file = format!("{}/{}", TEST_DATA_DIR, expected_file);
+                            let data_file = format!("{TEST_DATA_DIR}/{expected_file}");
                             quote! {include_str!(#data_file)}
                         } else {
                             quote! {#expected}

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -50,9 +50,7 @@ pub(crate) fn fail_syntax(statement: &str) {
     let res = parse(statement);
     assert!(
         res.is_err(),
-        "For `{}`, expected `Err(_)`, but was `{:#?}`",
-        statement,
-        res
+        "For `{statement}`, expected `Err(_)`, but was `{res:#?}`"
     );
 }
 
@@ -63,9 +61,7 @@ pub(crate) fn pass_syntax(statement: &str) -> Parsed {
     let res = parse(statement);
     assert!(
         res.is_ok(),
-        "For `{}`, expected `Ok(_)`, but was `{:#?}`",
-        statement,
-        res
+        "For `{statement}`, expected `Ok(_)`, but was `{res:#?}`"
     );
     res.unwrap()
 }
@@ -86,9 +82,7 @@ pub(crate) fn pass_semantics(statement: &str) {
     let lowered: Result<_, ()> = Ok(lower(&parsed));
     assert!(
         lowered.is_ok(),
-        "For `{}`, expected `Ok(_)`, but was `{:#?}`",
-        statement,
-        lowered
+        "For `{statement}`, expected `Ok(_)`, but was `{lowered:#?}`"
     );
 }
 

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -60,7 +60,7 @@ fn parse_test_value(reader: &mut Reader, typ: IonType) -> Value {
             // TODO ion Decimal doesn't give a lot of functionality to get at the data currently
             // TODO    and it's not clear whether we'll continue with rust decimal or switch to big decimal
             let ion_dec = reader.read_decimal().unwrap();
-            let ion_dec_str = format!("{}", ion_dec).replace('d', "e");
+            let ion_dec_str = format!("{ion_dec}").replace('d', "e");
             Value::Decimal(rust_decimal::Decimal::from_scientific(&ion_dec_str).unwrap())
         }
         IonType::Timestamp => todo!("timestamp"),

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -43,7 +43,7 @@ pub mod basic {
                 self.sensitive.insert(name.to_string(), idx);
                 e.insert(idx);
             } else {
-                panic!("Cannot insert duplicate binding of name {}", name)
+                panic!("Cannot insert duplicate binding of name {name}")
             }
         }
     }

--- a/partiql-eval/src/eval.rs
+++ b/partiql-eval/src/eval.rs
@@ -91,8 +91,7 @@ impl EvalPlan {
             }
             Err(e) => Err(EvalErr {
                 errors: vec![EvaluationError::InvalidEvaluationPlan(format!(
-                    "Malformed evaluation plan detected: {:?}",
-                    e
+                    "Malformed evaluation plan detected: {e:?}"
                 ))],
             }),
         }
@@ -1050,14 +1049,14 @@ impl EvalExpr for EvalBinOpExpr {
                         let lhs = if let Value::String(s) = lhs {
                             *s
                         } else {
-                            format!("{:?}", lhs)
+                            format!("{lhs:?}")
                         };
                         let rhs = if let Value::String(s) = rhs {
                             *s
                         } else {
-                            format!("{:?}", rhs)
+                            format!("{rhs:?}")
                         };
-                        Value::String(Box::new(format!("{}{}", lhs, rhs)))
+                        Value::String(Box::new(format!("{lhs}{rhs}")))
                     }
                 }
             }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -1276,8 +1276,7 @@ mod tests {
                     "data".into(),
                 ))),
                 vec![PathComponent::Key(BindingsName::CaseInsensitive(format!(
-                    "arg{}",
-                    i
+                    "arg{i}"
                 )))],
             )
         }
@@ -1300,7 +1299,7 @@ mod tests {
         elements
             .into_iter()
             .enumerate()
-            .for_each(|(i, e)| data.insert(&format!("arg{}", i), e));
+            .for_each(|(i, e)| data.insert(&format!("arg{i}"), e));
         bindings.insert("data", partiql_list![data].into());
 
         let result = evaluate(plan, bindings).coerce_to_bag();

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -648,7 +648,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         // TODO intern strings
         let as_key = match as_key {
             name_resolver::Symbol::Known(sym) => sym.value.clone(),
-            name_resolver::Symbol::Unknown(id) => format!("_{}", id),
+            name_resolver::Symbol::Unknown(id) => format!("_{id}"),
         };
         self.push_value(as_key.into());
     }

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -737,16 +737,16 @@ impl<'input> fmt::Display for Token<'input> {
             Token::Caret => write!(f, "^"),
             Token::Period => write!(f, "."),
             Token::DblPipe => write!(f, "||"),
-            Token::UnquotedIdent(id) => write!(f, "<{}:UNQUOTED_IDENT>", id),
-            Token::QuotedIdent(id) => write!(f, "<{}:QUOTED_IDENT>", id),
-            Token::UnquotedAtIdentifier(id) => write!(f, "<{}:UNQUOTED_ATIDENT>", id),
-            Token::QuotedAtIdentifier(id) => write!(f, "<{}:QUOTED_ATIDENT>", id),
-            Token::Int(txt) => write!(f, "<{}:INT>", txt),
-            Token::ExpReal(txt) => write!(f, "<{}:REAL>", txt),
-            Token::Real(txt) => write!(f, "<{}:REAL>", txt),
-            Token::String(txt) => write!(f, "<{}:STRING>", txt),
+            Token::UnquotedIdent(id) => write!(f, "<{id}:UNQUOTED_IDENT>"),
+            Token::QuotedIdent(id) => write!(f, "<{id}:QUOTED_IDENT>"),
+            Token::UnquotedAtIdentifier(id) => write!(f, "<{id}:UNQUOTED_ATIDENT>"),
+            Token::QuotedAtIdentifier(id) => write!(f, "<{id}:QUOTED_ATIDENT>"),
+            Token::Int(txt) => write!(f, "<{txt}:INT>"),
+            Token::ExpReal(txt) => write!(f, "<{txt}:REAL>"),
+            Token::Real(txt) => write!(f, "<{txt}:REAL>"),
+            Token::String(txt) => write!(f, "<{txt}:STRING>"),
             Token::EmbeddedIonQuote => write!(f, "<ION>"),
-            Token::Ion(txt) => write!(f, "<{}:ION>", txt),
+            Token::Ion(txt) => write!(f, "<{txt}:ION>"),
 
             Token::All
             | Token::Asc
@@ -811,7 +811,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::With
             | Token::Without
             | Token::Zone => {
-                write!(f, "{}", format!("{:?}", self).to_uppercase())
+                write!(f, "{}", format!("{self:?}").to_uppercase())
             }
         }
     }

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -174,7 +174,7 @@ impl<'a> FnExprSet<'a> {
             } else {
                 spc.fn_names
                     .iter()
-                    .map(|n| format!("(?:{})", n))
+                    .map(|n| format!("(?:{n})"))
                     .collect::<Vec<_>>()
                     .join("|")
             }

--- a/partiql-source-map/src/location.rs
+++ b/partiql-source-map/src/location.rs
@@ -109,7 +109,7 @@ impl From<usize> for BytePosition {
 impl fmt::Display for BytePosition {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let BytePosition(ByteOffset(n)) = self;
-        write!(f, "b{}", n)
+        write!(f, "b{n}")
     }
 }
 
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(display, loc.into());
         assert_eq!(display, unsafe { LineAndColumn::new_unchecked(14, 43) });
         assert_eq!(display, LineAndColumn::new(14, 43).unwrap());
-        assert_eq!("14:43", format!("{}", display));
+        assert_eq!("14:43", format!("{display}"));
         assert_eq!("14:43", display.to_string());
     }
 }

--- a/partiql-value/src/ion.rs
+++ b/partiql-value/src/ion.rs
@@ -34,7 +34,7 @@ fn parse_value(reader: &mut Reader, typ: IonType) -> Value {
             // TODO ion Decimal doesn't give a lot of functionality to get at the data currently
             // TODO    and it's not clear whether we'll continue with rust decimal or switch to big decimal
             let ion_dec = reader.read_decimal().unwrap();
-            let ion_dec_str = format!("{}", ion_dec).replace('d', "e");
+            let ion_dec_str = format!("{ion_dec}").replace('d', "e");
             Value::Decimal(rust_decimal::Decimal::from_scientific(&ion_dec_str).unwrap())
         }
         IonType::Timestamp => todo!("timestamp"),

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -25,8 +25,10 @@ pub enum BindingsName {
 // TODO have an optional-like wrapper for null/missing instead of inlined here?
 #[derive(Hash, PartialEq, Eq, Clone)]
 #[allow(dead_code)] // TODO remove once out of PoC
+#[derive(Default)]
 pub enum Value {
     Null,
+    #[default]
     Missing,
     Boolean(bool),
     Integer(i64),
@@ -485,11 +487,7 @@ fn coerce_int_to_real(value: &Value) -> Value {
     }
 }
 
-impl Default for Value {
-    fn default() -> Self {
-        Value::Missing
-    }
-}
+
 
 impl Value {
     pub fn from_ion(ion: &str) -> Self {
@@ -635,12 +633,12 @@ impl Debug for Value {
         match self {
             Value::Null => write!(f, "NULL"),
             Value::Missing => write!(f, "MISSING"),
-            Value::Boolean(b) => write!(f, "{}", b),
-            Value::Integer(i) => write!(f, "{}", i),
+            Value::Boolean(b) => write!(f, "{b}"),
+            Value::Integer(i) => write!(f, "{i}"),
             Value::Real(r) => write!(f, "{}", r.0),
-            Value::Decimal(d) => write!(f, "{}", d),
-            Value::String(s) => write!(f, "'{}'", s),
-            Value::Blob(s) => write!(f, "'{:?}'", s),
+            Value::Decimal(d) => write!(f, "{d}"),
+            Value::String(s) => write!(f, "'{s}'"),
+            Value::Blob(s) => write!(f, "'{s:?}'"),
             Value::List(l) => l.fmt(f),
             Value::Bag(b) => b.fmt(f),
             Value::Tuple(t) => t.fmt(f),
@@ -1109,9 +1107,9 @@ impl Debug for Bag {
         let mut iter = self.iter().peekable();
         while let Some(v) = iter.next() {
             if iter.peek().is_some() {
-                write!(f, "{:?}, ", v)?;
+                write!(f, "{v:?}, ")?;
             } else {
-                write!(f, "{:?}", v)?;
+                write!(f, "{v:?}")?;
             }
         }
         write!(f, ">>")
@@ -1304,8 +1302,8 @@ impl Iterator for Tuple {
 
 impl PartialEq for Tuple {
     fn eq(&self, other: &Self) -> bool {
-        let s1: HashSet<(&str, &Value)> = self.pairs().into_iter().collect();
-        let s2: HashSet<(&str, &Value)> = other.pairs().into_iter().collect();
+        let s1: HashSet<(&str, &Value)> = self.pairs().collect();
+        let s2: HashSet<(&str, &Value)> = other.pairs().collect();
         s1.eq(&s2)
     }
 }
@@ -1328,12 +1326,12 @@ impl Hash for Tuple {
 impl Debug for Tuple {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
-        let mut iter = self.pairs().into_iter().peekable();
+        let mut iter = self.pairs().peekable();
         while let Some((k, v)) = iter.next() {
             if iter.peek().is_some() {
-                write!(f, " {}: {:?},", k, v)?;
+                write!(f, " {k}: {v:?},")?;
             } else {
-                write!(f, " {}: {:?} ", k, v)?;
+                write!(f, " {k}: {v:?} ")?;
             }
         }
         write!(f, "}}")

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -487,8 +487,6 @@ fn coerce_int_to_real(value: &Value) -> Value {
     }
 }
 
-
-
 impl Value {
     pub fn from_ion(ion: &str) -> Self {
         ion::parse_ion(ion)

--- a/partiql/benches/bench_eval_multi_like.rs
+++ b/partiql/benches/bench_eval_multi_like.rs
@@ -233,7 +233,7 @@ fn employee_data() -> Vec<Value> {
     let combined = name1
         .iter()
         .cartesian_product(name2.iter())
-        .map(|(n1, n2)| format!("{} {}", n1, n2));
+        .map(|(n1, n2)| format!("{n1} {n2}"));
 
     // seed the rng with a known value to assure same data across runs
     let mut rng = rand::rngs::StdRng::from_seed([42; 32]);
@@ -253,7 +253,7 @@ fn employee_data() -> Vec<Value> {
             let suffix: String = (0..suffix_size)
                 .map(|_| rng.sample(chars) as char)
                 .collect();
-            let full_name = format!("{} {} {}", prefix, person, suffix);
+            let full_name = format!("{prefix} {person} {suffix}");
             partiql_tuple![("id", id), ("name", full_name)].into()
         })
         .collect_vec();


### PR DESCRIPTION
The recent Rust toolchain upgrade PR https://github.com/partiql/partiql-lang-rust/pull/285 brought in a new Rust version, which shows a lot more clippy warnings. This PR just runs `cargo clippy --fix` to fix those warnings.

Mostly dealt with the following warning:
- variables can be used directly in the `format!` string (https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
