### PR TITLE
Add Serde json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds some benchmarks for parsing, compiling, planning, & evaluation
 - Implements `PIVOT` operator in evaluator
+- `serde` feature to `partiql-value` with `Serialize` and `Deserialize` json serde.
 
 ### Fixes
 

--- a/partiql-value/Cargo.toml
+++ b/partiql-value/Cargo.toml
@@ -26,7 +26,17 @@ itertools = "0.10.*"
 unicase = "2.*"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.26"
+serde = { version = "1.*", features = ["derive"], optional = true }
 ion-rs = "0.14"
 
 [dev-dependencies]
 criterion = "0.4"
+
+[features]
+default = []
+serde = [
+  "dep:serde",
+  "rust_decimal/serde-with-str",
+  "rust_decimal/serde",
+  "ordered-float/serde"
+]

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -15,6 +15,9 @@ use unicase::UniCase;
 
 mod ion;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone, Hash, Debug, Eq, PartialEq)]
 pub enum BindingsName {
     CaseSensitive(String),
@@ -26,6 +29,7 @@ pub enum BindingsName {
 #[derive(Hash, PartialEq, Eq, Clone)]
 #[allow(dead_code)] // TODO remove once out of PoC
 #[derive(Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Value {
     Null,
     #[default]
@@ -848,6 +852,7 @@ impl From<Bag> for Value {
 }
 
 #[derive(Default, Hash, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Represents a PartiQL List value, e.g. [1, 2, 'one']
 pub struct List(Vec<Value>);
 
@@ -999,6 +1004,7 @@ impl Ord for List {
 }
 
 #[derive(Default, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Represents a PartiQL BAG value, e.g.: <<1, 'two', 4>>
 pub struct Bag(Vec<Value>);
 
@@ -1156,6 +1162,7 @@ impl Hash for Bag {
 }
 
 #[derive(Default, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tuple {
     attrs: Vec<String>,
     vals: Vec<Value>,


### PR DESCRIPTION
*Description of changes:*

Adds the `serde-json`'s `Serialize` and `Deseralize` to `partiql_value::Value` as a feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
