### PR TITLE
Add serde to partiql-logical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds some benchmarks for parsing, compiling, planning, & evaluation
 - Implements `PIVOT` operator in evaluator
-- `serde` feature to `partiql-value` with `Serialize` and `Deserialize` json serde.
+- `serde` feature to `partiql-value` and `partiql-logical` with `Serialize` and `Deserialize` traits.
 
 ### Fixes
 

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -26,4 +26,11 @@ ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.*"
 
+serde = { version = "1.*", features = ["derive"], optional = true }
 
+[features]
+default = []
+serde = [
+  "dep:serde",
+  "ordered-float/serde"
+]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -51,8 +51,12 @@
 use partiql_value::{BindingsName, Value};
 use std::collections::HashMap;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Represents a PartiQL logical plan.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalPlan<T>
 where
     T: Default,
@@ -148,6 +152,7 @@ where
 
 /// Represents an operator identifier in a [`LogicalPlan`]
 #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OpId(usize);
 
 impl OpId {


### PR DESCRIPTION
*Description of changes:*

Adds `serde` w/ `Serialize` and `Deserialize` traits to `partiql-logical`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
