### PR TITLE
Fix off by one error when checking preconditions to lower join `ON`

### DIFF
--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1024,7 +1024,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         assert_eq!(benv.len(), 2);
 
         let mut env = self.exit_env();
-        assert!((0..1).contains(&env.len()));
+        assert!((0..=1).contains(&env.len()));
 
         let Join { kind, .. } = join;
 


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
