### PR TITLE
Add initial GROUP BY implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds `Display` for `LogicalPlan`
 - Expose `partiql_value::parse_ion` as a public API.
 - Implements `GROUP BY` operator in evaluator
+- Implements `HAVING` operator in evaluator
 
 ### Fixes
 - Fixes Tuple value duplicate equality and hashing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `serde` feature to `partiql-value` and `partiql-logical` with `Serialize` and `Deserialize` traits.
 - Adds `Display` for `LogicalPlan`
 - Expose `partiql_value::parse_ion` as a public API.
+- Implements `GROUP BY` operator in evaluator
 
 ### Fixes
 - Fixes Tuple value duplicate equality and hashing

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -672,8 +672,13 @@ impl Evaluable for EvalSelectAll {
 
         let values = input_value.into_iter().map(|val| {
             val.coerce_to_tuple()
-                .into_values()
-                .flat_map(|v| v.coerce_to_tuple().into_pairs())
+                .into_pairs()
+                .flat_map(|(k, v)| {
+                    match v {
+                        Value::Tuple(_) => v.coerce_to_tuple().into_pairs().collect::<Tuple>(), // unnest tuples
+                        _ => Tuple::from([(&*k, v)]),
+                    }
+                })
                 .collect::<Tuple>()
         });
 

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -676,6 +676,7 @@ impl Evaluable for EvalSelectAll {
                 .flat_map(|(k, v)| {
                     match v {
                         Value::Tuple(_) => v.coerce_to_tuple().into_pairs().collect::<Tuple>(), // unnest tuples
+                        Value::Missing => partiql_tuple![],
                         _ => Tuple::from([(&*k, v)]),
                     }
                 })

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -672,14 +672,8 @@ impl Evaluable for EvalSelectAll {
 
         let values = input_value.into_iter().map(|val| {
             val.coerce_to_tuple()
-                .into_pairs()
-                .flat_map(|(k, v)| {
-                    match v {
-                        Value::Tuple(_) => v.coerce_to_tuple().into_pairs().collect::<Tuple>(), // unnest tuples
-                        Value::Missing => partiql_tuple![],
-                        _ => Tuple::from([(&*k, v)]),
-                    }
-                })
+                .into_values()
+                .flat_map(|v| v.coerce_to_tuple().into_pairs())
                 .collect::<Tuple>()
         });
 

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -282,6 +282,9 @@ impl Evaluable for EvalJoin {
     }
 }
 
+/// Represents an evaluation `GROUP BY` operator. For `GROUP BY` operational semantics, see section
+/// `11` of
+/// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug)]
 pub struct EvalGroupBy {
     pub strategy: EvalGroupingStrategy,
@@ -290,12 +293,14 @@ pub struct EvalGroupBy {
     pub input: Option<Value>,
 }
 
+/// Represents the grouping qualifier: ALL or PARTIAL.
 #[derive(Debug)]
 pub enum EvalGroupingStrategy {
     GroupFull,
     GroupPartial,
 }
 
+/// Represents the items in a `GROUP BY` list. e.g. `t.a AS a` in `... GROUP BY t.a AS a`.
 #[derive(Debug)]
 pub struct GroupKey {
     pub expr: Box<dyn EvalExpr>,

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -328,15 +328,10 @@ impl Evaluable for EvalGroupBy {
                             evaluated_values.insert(alias.as_str(), evaluated_val);
                         }
                     });
-                    if groups.contains_key(&evaluated_values) {
-                        let mut group: Vec<Value> =
-                            groups.get(&evaluated_values).unwrap().to_owned();
-                        group.push(Value::Tuple(Box::new(v_as_tuple)));
-                        groups.insert(evaluated_values, group);
-                    } else {
-                        let group = vec![Value::Tuple(Box::new(v_as_tuple))];
-                        groups.insert(evaluated_values, group);
-                    }
+                    groups
+                        .entry(evaluated_values)
+                        .or_insert(vec![])
+                        .push(Value::Tuple(Box::new(v_as_tuple)));
                 }
 
                 let bag = groups

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -483,7 +483,7 @@ impl EvalFilter {
             Boolean(bool_val) => *bool_val,
             // Alike SQL, when the expression of the WHERE clause expression evaluates to
             // absent value or a value that is not a Boolean, PartiQL eliminates the corresponding
-            // binding. PartiQL Specification August 1, August 1, 2019 Draft, Section 8. `WHERE clause`
+            // binding. PartiQL Specification August 1, 2019 Draft, Section 8. `WHERE clause`
             _ => false,
         }
     }
@@ -497,6 +497,51 @@ impl Evaluable for EvalFilter {
             .into_iter()
             .map(Value::coerce_to_tuple)
             .filter_map(|v| self.eval_filter(&v, ctx).then_some(v));
+        Some(Value::from(filtered.collect::<Bag>()))
+    }
+
+    fn update_input(&mut self, input: Value, _branch_num: u8) {
+        self.input = Some(input);
+    }
+}
+
+/// Represents an evaluation `Having` operator; for an input bag of binding tuples the `Having`
+/// operator filters out the binding tuples that does not meet the condition expressed as `expr`,
+/// e.g. `a = 10` in `HAVING a = 10` expression.
+#[derive(Debug)]
+pub struct EvalHaving {
+    pub expr: Box<dyn EvalExpr>,
+    pub input: Option<Value>,
+}
+
+impl EvalHaving {
+    pub fn new(expr: Box<dyn EvalExpr>) -> Self {
+        EvalHaving { expr, input: None }
+    }
+
+    #[inline]
+    fn eval_having(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> bool {
+        let result = self.expr.evaluate(bindings, ctx);
+        match result.as_ref() {
+            Boolean(bool_val) => *bool_val,
+            // Alike SQL, when the expression of the HAVING clause expression evaluates to
+            // absent value or a value that is not a Boolean, PartiQL eliminates the corresponding
+            // binding. PartiQL Specification August 1, 2019 Draft, Section 11.1.
+            // > HAVING behaves identical to a WHERE, once groups are already formulated earlier
+            // See Section 8 on WHERE semantics
+            _ => false,
+        }
+    }
+}
+
+impl Evaluable for EvalHaving {
+    fn evaluate(&mut self, ctx: &dyn EvalContext) -> Option<Value> {
+        let input_value = self.input.take().expect("Error in retrieving input value");
+
+        let filtered = input_value
+            .into_iter()
+            .map(Value::coerce_to_tuple)
+            .filter_map(|v| self.eval_having(&v, ctx).then_some(v));
         Some(Value::from(filtered.collect::<Bag>()))
     }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -91,6 +91,10 @@ impl EvaluatorPlanner {
                 expr: self.plan_values(expr),
                 input: None,
             }),
+            BindingsOp::Having(logical::Having { expr }) => Box::new(eval::evaluable::EvalHaving {
+                expr: self.plan_values(expr),
+                input: None,
+            }),
             BindingsOp::Distinct => Box::new(eval::evaluable::EvalDistinct::new()),
             BindingsOp::Sink => Box::new(eval::evaluable::EvalSink { input: None }),
             BindingsOp::Pivot(logical::Pivot { key, value }) => Box::new(

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 use partiql_logical as logical;
 
 use partiql_logical::{
-    BinaryOp, BindingsOp, CallName, IsTypeExpr, JoinKind, LogicalPlan, OpId, PathComponent,
-    Pattern, PatternMatchExpr, SearchedCase, Type, UnaryOp, ValueExpr,
+    BinaryOp, BindingsOp, CallName, GroupingStrategy, IsTypeExpr, JoinKind, LogicalPlan, OpId,
+    PathComponent, Pattern, PatternMatchExpr, SearchedCase, Type, UnaryOp, ValueExpr,
 };
 
 use crate::eval;
-use crate::eval::evaluable::{EvalJoinKind, EvalSubQueryExpr, Evaluable};
+use crate::eval::evaluable::{EvalGroupingStrategy, EvalJoinKind, EvalSubQueryExpr, Evaluable};
 use crate::eval::expr::pattern_match::like_to_re_pattern;
 use crate::eval::expr::{
     EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalDynamicLookup, EvalExpr, EvalFnAbs,
@@ -129,6 +129,27 @@ impl EvaluatorPlanner {
                     on,
                 ))
             }
+            BindingsOp::GroupBy(logical::GroupBy {
+                strategy,
+                exprs,
+                group_as_alias,
+            }) => {
+                let strategy = match strategy {
+                    GroupingStrategy::GroupFull => EvalGroupingStrategy::GroupFull,
+                    GroupingStrategy::GroupPartial => EvalGroupingStrategy::GroupPartial,
+                };
+                let exprs: HashMap<_, _> = exprs
+                    .iter()
+                    .map(|(k, v)| (k.clone(), self.plan_values(v)))
+                    .collect();
+                let group_as_alias = group_as_alias.as_ref().map(|alias| alias.to_string());
+                Box::new(eval::evaluable::EvalGroupBy {
+                    strategy,
+                    exprs,
+                    group_as_alias,
+                    input: None,
+                })
+            }
             BindingsOp::ExprQuery(logical::ExprQuery { expr }) => {
                 let expr = self.plan_values(expr);
                 Box::new(eval::evaluable::EvalExprQuery::new(expr))
@@ -143,7 +164,6 @@ impl EvaluatorPlanner {
             }
 
             BindingsOp::SetOp => todo!("SetOp"),
-            BindingsOp::GroupBy => todo!("GroupBy"),
         }
     }
 

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1135,7 +1135,6 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
 
     fn exit_group_key(&mut self, _group_key: &'ast GroupKey) {
-        println!("group key_registry: {:?}", self.key_registry);
         let as_key: &name_resolver::Symbol = self
             .key_registry
             .aliases

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1088,8 +1088,15 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
 
     fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) {
-        let _env = self.exit_env();
-        todo!("having clause");
+        let mut env = self.exit_env();
+        assert_eq!(env.len(), 1);
+
+        let having = BindingsOp::Having(logical::Having {
+            expr: env.pop().unwrap(),
+        });
+        let id = self.plan.add_operator(having);
+
+        self.current_clauses_mut().having_clause.replace(id);
     }
 
     fn enter_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -108,13 +108,17 @@ where
     /// Extends the logical plan with the given data flows.
     /// #Examples:
     /// ```
-    /// use partiql_logical::{BindingsOp, LimitOffset, LogicalPlan};
+    /// use partiql_logical::{BindingsOp, GroupBy, GroupingStrategy, LimitOffset, LogicalPlan};
     /// let mut p: LogicalPlan<BindingsOp> = LogicalPlan::new();
     ///
     /// let a = p.add_operator(BindingsOp::OrderBy);
     /// let b = p.add_operator(BindingsOp::Sink);
     /// let c = p.add_operator(BindingsOp::LimitOffset(LimitOffset{limit:None, offset:None}));
-    /// let d = p.add_operator(BindingsOp::GroupBy);
+    /// let d = p.add_operator(BindingsOp::GroupBy(GroupBy {
+    ///     strategy: GroupingStrategy::GroupFull,
+    ///     exprs: Default::default(),
+    ///     group_as_alias: None,
+    /// }));
     ///
     /// p.add_flow(a, b);
     ///
@@ -196,7 +200,7 @@ pub enum BindingsOp {
     ProjectValue(ProjectValue),
     ExprQuery(ExprQuery),
     Distinct,
-    GroupBy,
+    GroupBy(GroupBy),
     #[default]
     Sink,
 }
@@ -265,6 +269,28 @@ pub enum JoinKind {
     Right,
     Full,
     Cross,
+}
+
+/// Represents `GROUP BY` <strategy> <group_key>[, <group_key>] ... \[AS <as_alias>\]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct GroupBy {
+    pub strategy: GroupingStrategy,
+    pub exprs: HashMap<String, ValueExpr>,
+    pub group_as_alias: Option<String>,
+}
+
+/// <expr> [AS <as_alias>]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct GroupKey {
+    pub expr: ValueExpr,
+    pub as_alias: Option<ValueExpr>,
+}
+
+/// Grouping qualifier: ALL or PARTIAL
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum GroupingStrategy {
+    GroupFull,
+    GroupPartial,
 }
 
 /// Represents a projection, e.g. `SELECT a` in `SELECT a FROM t`.
@@ -574,7 +600,11 @@ mod tests {
             limit: None,
             offset: None,
         }));
-        let d = p.add_operator(BindingsOp::GroupBy);
+        let d = p.add_operator(BindingsOp::GroupBy(GroupBy {
+            strategy: GroupingStrategy::GroupFull,
+            exprs: Default::default(),
+            group_as_alias: None,
+        }));
         p.add_flow(a, b);
         p.add_flow(a, c);
         p.extend_with_flows(&[(c, d), (b, c)]);

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -288,14 +288,6 @@ pub struct GroupBy {
     pub group_as_alias: Option<String>,
 }
 
-/// <expr> [AS <as_alias>]
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct GroupKey {
-    pub expr: ValueExpr,
-    pub as_alias: Option<ValueExpr>,
-}
-
 /// Grouping qualifier: ALL or PARTIAL
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -201,6 +201,7 @@ pub enum BindingsOp {
     ExprQuery(ExprQuery),
     Distinct,
     GroupBy(GroupBy),
+    Having(Having),
     #[default]
     Sink,
 }
@@ -238,6 +239,13 @@ pub struct Unpivot {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Filter {
+    pub expr: ValueExpr,
+}
+
+/// [`Having`] represents the having operator, e.g. `HAVING a = 10` in `SELECT b FROM t GROUP BY a, b HAVING a = 10`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Having {
     pub expr: ValueExpr,
 }
 

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -273,6 +273,7 @@ pub enum JoinKind {
 
 /// Represents `GROUP BY` <strategy> <group_key>[, <group_key>] ... \[AS <as_alias>\]
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupBy {
     pub strategy: GroupingStrategy,
     pub exprs: HashMap<String, ValueExpr>,
@@ -281,6 +282,7 @@ pub struct GroupBy {
 
 /// <expr> [AS <as_alias>]
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupKey {
     pub expr: ValueExpr,
     pub as_alias: Option<ValueExpr>,
@@ -288,6 +290,7 @@ pub struct GroupKey {
 
 /// Grouping qualifier: ALL or PARTIAL
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GroupingStrategy {
     GroupFull,
     GroupPartial,

--- a/partiql-value/src/datetime.rs
+++ b/partiql-value/src/datetime.rs
@@ -82,19 +82,19 @@ impl Debug for DateTime {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             DateTime::Date(d) => {
-                write!(f, "DATE '{:?}'", d)
+                write!(f, "DATE '{d:?}'")
             }
             DateTime::Time(t) => {
-                write!(f, "TIME '{:?}'", t)
+                write!(f, "TIME '{t:?}'")
             }
             DateTime::TimeWithTz(t, tz) => {
-                write!(f, "TIME WITH TIME ZONE '{:?} {:?}'", t, tz)
+                write!(f, "TIME WITH TIME ZONE '{t:?} {tz:?}'")
             }
             DateTime::Timestamp(dt) => {
-                write!(f, "TIMESTAMP '{:?}'", dt)
+                write!(f, "TIMESTAMP '{dt:?}'")
             }
             DateTime::TimestampWithTz(dt) => {
-                write!(f, "TIMESTAMP WITH TIME ZONE '{:?}'", dt)
+                write!(f, "TIMESTAMP WITH TIME ZONE '{dt:?}'")
             }
         }
     }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 
 use std::borrow::Cow;
 
-use ion_rs::Timestamp;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 
 use std::borrow::Cow;
 
+use ion_rs::Timestamp;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
@@ -52,7 +53,7 @@ pub enum Value {
     List(Box<List>),
     Bag(Box<Bag>),
     Tuple(Box<Tuple>),
-    // TODO: add other supported PartiQL values -- timestamp, date, time, sexp
+    // TODO: add other supported PartiQL values -- sexp
 }
 
 impl ops::Add for &Value {


### PR DESCRIPTION
Provides the initial implementation of `GROUP BY ... GROUP AS ...` bindings expression. Fixes about 60+ `GROUP BY` conformance tests. Remaining failing conformance tests are due to:

- Unimplemented `HAVING` clause https://github.com/partiql/partiql-lang-rust/issues/326
- Unimplemented aggregation functions https://github.com/partiql/partiql-lang-rust/issues/327
- `SELECT *` used with `GROUP BY`
  - Spec behavior is unclear on `SELECT *` with `GROUP BY` and current `SELECT *` is buggy
  - Plan to update those tests to not use `SELECT *`. These tests pass if `SELECT`ing on the `GROUP BY` aliases explitly
- Some tests where the `GROUP` value contains `MISSING` but not `NULL` https://github.com/partiql/partiql-lang-rust/issues/328
- Unimplemented `CAST` function https://github.com/partiql/partiql-lang-rust/issues/329
- Some tests with SELECT LIST referencing table alias and column https://github.com/partiql/partiql-lang-rust/issues/330
- Spec tests that include `GROUP BY` and subqueries within `SELECT` 
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
