### PR TITLE
Recognize aggregate fn names in parser

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -582,6 +582,14 @@ pub struct Sexp {
 
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct CallAgg {
+    #[visit(skip)]
+    pub func_name: SymbolPrimitive,
+    pub args: Vec<AstNode<CallArg>>,
+}
+
+#[derive(Visit, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Call {
     #[visit(skip)]
     pub func_name: SymbolPrimitive,
@@ -620,16 +628,6 @@ pub struct CallArgNamedType {
     pub name: SymbolPrimitive,
     #[visit(skip)]
     pub ty: Type,
-}
-
-#[derive(Visit, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct CallAgg {
-    #[visit(skip)]
-    pub func_name: SymbolPrimitive,
-    #[visit(skip)]
-    pub setq: Option<SetQuantifier>,
-    pub args: Vec<AstNode<CallArg>>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -1,5 +1,10 @@
 use partiql_ast::ast;
 
+pub(crate) enum CallSite {
+    Call(ast::Call),
+    CallAgg(ast::CallAgg),
+}
+
 // if this is just a parenthesized expr, lift it out of the query AST, otherwise return input
 //      e.g. `(1+2)` should be a ExprKind::Expr, not wrapped deep in a ExprKind::Query
 pub(crate) fn strip_query(q: Box<ast::Expr>) -> Box<ast::Expr> {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -9,7 +9,7 @@ use partiql_ast::ast;
 
 use partiql_source_map::location::{ByteOffset, BytePosition, Location, ToLocated};
 
-use crate::parse::parse_util::{strip_query};
+use crate::parse::parse_util::{strip_query, CallSite};
 use crate::parse::parser_state::{ParserState, IdGenerator};
 
 grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'input, Id>) where Id: IdGenerator;
@@ -819,7 +819,12 @@ PathExpr: ast::Path = {
 
 #[inline]
 ExprPrecedence01: ast::Expr = {
-    <lo:@L> <call:FunctionCall> <hi:@R> => ast::Expr::Call( state.node(call, lo..hi) ),
+    <lo:@L> <call:FunctionCall> <hi:@R> => {
+        match call {
+            CallSite::Call(call) => ast::Expr::Call( state.node(call, lo..hi) ),
+            CallSite::CallAgg(call_agg)  => ast::Expr::CallAgg( state.node(call_agg, lo..hi) ),
+        }
+    },
     <ExprTerm>,
 }
 
@@ -910,9 +915,14 @@ ExprPair: ast::ExprPair = {
 }
 
 #[inline]
-FunctionCall: ast::Call = {
-    <func_name:FunctionName> "(" <args:CommaSepStar<FunctionCallArg>> ")" =>
-        ast::Call{ func_name, args }
+FunctionCall: CallSite = {
+    <func_name:FunctionName> "(" <args:CommaSepStar<FunctionCallArg>> ")" => {
+        if state.is_agg_fn(&func_name) {
+            CallSite::CallAgg(ast::CallAgg{ func_name, args })
+        } else {
+            CallSite::Call(ast::Call{ func_name, args })
+        }
+    },
 }
 
 #[inline]

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -114,6 +114,7 @@ mod built_ins {
 
     pub(crate) fn built_in_aggs() -> FnExpr<'static> {
         FnExpr {
+            // TODO: currently needs to be manually kept in-sync with parsers's `KNOWN_AGGREGATES`
             fn_names: vec!["count", "avg", "min", "max", "sum"],
             #[rustfmt::skip]
             patterns: vec![
@@ -865,6 +866,17 @@ mod tests {
         assert_eq!(preprocess(q_count_1)?, lex(q_count_1)?);
         let q_count_star = r#"count(*)"#;
         assert_eq!(preprocess(q_count_star)?, lex(q_count_star)?);
+
+        assert_eq!(preprocess(r#"sum(a)"#)?, lex(r#"sum(a)"#)?);
+        assert_eq!(
+            preprocess(r#"sum(DISTINCT a)"#)?,
+            lex(r#"sum("DISTINCT": a)"#)?
+        );
+        assert_eq!(preprocess(r#"sum(all a)"#)?, lex(r#"sum("all": a)"#)?);
+        let q_sum_1 = r#"sum(1)"#;
+        assert_eq!(preprocess(q_sum_1)?, lex(q_sum_1)?);
+        let q_sum_star = r#"sum(*)"#;
+        assert_eq!(preprocess(q_sum_star)?, lex(q_sum_star)?);
 
         let empty_q = "";
         assert_eq!(preprocess(empty_q)?, lex(empty_q)?);


### PR DESCRIPTION

e.g., for `SELECT SUM(x) ...`,  `SUM` used to be parsed into a `ast::Call`, but will now be parsed into a `ast::CallAgg`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
