### PR TITLE
Make `BY <x>` optional in `GROUP` clause

### DIFF
--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -384,7 +384,8 @@ WhereClause: Box<ast::AstNode<ast::WhereClause>> = {
 //                                   GROUP BY                                     //
 // ------------------------------------------------------------------------------ //
 GroupClause: Box<ast::AstNode<ast::GroupByExpr>> = {
-    <lo:@L> "GROUP" <strategy: GroupStrategy> "BY" <keys:CommaSepPlus<GroupKey>> <group_as_alias:GroupAlias?> <hi:@R> => {
+    <lo:@L> "GROUP" <strategy: GroupStrategy>  <keys:GroupByKeys?> <group_as_alias:GroupAlias?> <hi:@R> => {
+        let keys = keys.unwrap_or_else(Vec::new);
         Box::new(state.node(ast::GroupByExpr{
             strategy,
             keys,
@@ -401,6 +402,10 @@ GroupStrategy: ast::GroupingStrategy = {
             None => ast::GroupingStrategy::GroupFull,
         }
     }
+}
+#[inline]
+GroupByKeys: Vec<ast::AstNode<ast::GroupKey>> = {
+    "BY" <CommaSepPlus<GroupKey>>
 }
 #[inline]
 GroupKey: ast::AstNode<ast::GroupKey> = {


### PR DESCRIPTION
Cf. https://github.com/partiql/partiql-tests/blob/066da8fd11c5292245121e2e59a7df5735e58603/partiql-tests-data/eval-equiv/spec-tests.ion#L467

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
