### PR TITLE
Add parsing of `WITH` clause (`SEARCH` & `CYCLE` still TODO)

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -234,10 +234,29 @@ pub enum ConflictAction {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Query {
+    pub with: Option<AstNode<WithClause>>,
     pub set: AstNode<QuerySet>,
     pub order_by: Option<Box<AstNode<OrderByExpr>>>,
     pub limit: Option<Box<Expr>>,
     pub offset: Option<Box<Expr>>,
+}
+
+#[derive(Visit, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct WithClause {
+    #[visit(skip)]
+    pub recursive: bool,
+    pub withs: Vec<AstNode<WithElement>>,
+}
+
+#[derive(Visit, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct WithElement {
+    #[visit(skip)]
+    pub query_name: SymbolPrimitive,
+    #[visit(skip)]
+    pub columns: Option<Vec<SymbolPrimitive>>,
+    pub subquery: AstNode<Expr>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -118,6 +118,10 @@ pub trait Visitor<'ast> {
 
     fn enter_query(&mut self, _query: &'ast ast::Query) {}
     fn exit_query(&mut self, _query: &'ast ast::Query) {}
+    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) {}
+    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) {}
+    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) {}
+    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) {}
     fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) {}
     fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) {}
     fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) {}

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -7,6 +7,7 @@ fn test_ast_init() {
     common::setup();
 
     let _i = Item::Query(Query {
+        with: None,
         set: AstNode {
             id: NodeId(2),
             node: QuerySet::Expr(Box::new(Expr::Lit(AstNode {

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -528,6 +528,8 @@ pub enum Token<'input> {
     Case,
     #[regex("(?i:Cross)")]
     Cross,
+    #[regex("(?i:Cycle)")]
+    Cycle,
     #[regex("(?i:Date)")]
     Date,
     #[regex("(?i:Desc)")]
@@ -604,8 +606,12 @@ pub enum Token<'input> {
     Preserve,
     #[regex("(?i:Right)")]
     Right,
+    #[regex("(?i:Recursive)")]
+    Recursive,
     #[regex("(?i:Select)")]
     Select,
+    #[regex("(?i:Search)")]
+    Search,
     #[regex("(?i:Table)")]
     Table,
     #[regex("(?i:Time)")]
@@ -649,7 +655,9 @@ impl<'input> Token<'input> {
                 | Token::At
                 | Token::Between
                 | Token::By
+                | Token::Case
                 | Token::Cross
+                | Token::Cycle
                 | Token::Date
                 | Token::Desc
                 | Token::Distinct
@@ -685,6 +693,8 @@ impl<'input> Token<'input> {
                 | Token::Pivot
                 | Token::Preserve
                 | Token::Right
+                | Token::Recursive
+                | Token::Search
                 | Token::Select
                 | Token::Table
                 | Token::Time
@@ -757,6 +767,7 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::By
             | Token::Case
             | Token::Cross
+            | Token::Cycle
             | Token::Date
             | Token::Desc
             | Token::Distinct
@@ -795,6 +806,8 @@ impl<'input> fmt::Display for Token<'input> {
             | Token::Pivot
             | Token::Preserve
             | Token::Right
+            | Token::Recursive
+            | Token::Search
             | Token::Select
             | Token::Table
             | Token::Time

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -23,6 +23,7 @@ use partiql_source_map::metadata::LocationMap;
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::ptr_arg)]
 #[allow(clippy::vec_box)]
+#[allow(clippy::let_unit_value)]
 #[allow(unused_variables)]
 #[allow(dead_code)]
 mod grammar {

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -11,6 +11,7 @@ pub(crate) fn strip_query(q: Box<ast::Expr>) -> Box<ast::Expr> {
     if let ast::Expr::Query(ast::AstNode {
         node:
             ast::Query {
+                with: None,
                 set:
                     ast::AstNode {
                         node: ast::QuerySet::Expr(e),

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -15,6 +15,69 @@ use crate::parse::parser_state::{ParserState, IdGenerator};
 grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'input, Id>) where Id: IdGenerator;
 
 
+pub(crate) Query: Box<ast::Expr> = {
+    <lo:@L>
+    <with:WithClause?>
+    <set:QuerySet>
+    <order_by:OrderByClause?>
+    <limit:LimitClause?>
+    <offset:OffsetByClause?>
+    <hi:@R> => {
+        Box::new(ast::Expr::Query( state.node(ast::Query { with, set, order_by, limit, offset, }, lo..hi) ) )
+    }
+}
+
+
+// ------------------------------------------------------------------------------ //
+//                                     WITH                                       //
+// ------------------------------------------------------------------------------ //
+WithClause: ast::AstNode<ast::WithClause> = {
+    <lo:@L> "WITH" <rec:"RECURSIVE"?> <withs:WithList> <hi:@R> => {
+        let recursive = matches!(rec, Some(_));
+        state.node(ast::WithClause {
+             recursive,
+             withs
+        }, lo..hi)
+    }
+}
+
+#[inline]
+WithList: Vec<ast::AstNode<ast::WithElement>> = {
+    <CommaSepPlus<WithListElement>>
+}
+
+#[inline]
+WithListElement: ast::AstNode<ast::WithElement> = {
+    <lo:@L> <query_name: SymbolPrimitive> <columns:WithColList?> "AS" <subquery:SubQueryAst> <how:WithSearchOrCycle?> <hi:@R> => {
+        state.node(ast::WithElement {
+             query_name,
+             columns,
+             subquery,
+        }, lo..hi)
+    }
+}
+
+#[inline]
+WithColList: Vec<ast::SymbolPrimitive> = {
+    "(" <CommaSepPlus<SymbolPrimitive>> ")"
+}
+
+// TODO
+#[inline]
+WithSearchOrCycle: () = {
+    <WithSearchClause>,
+    <WithCycleClause>,
+    <WithSearchClause> <WithCycleClause>,
+}
+// TODO
+WithSearchClause : () = {
+    "SEARCH"
+}
+// TODO
+WithCycleClause : () = {
+    "CYCLE"
+}
+
 // ------------------------------------------------------------------------------ //
 //                                                                                //
 //                            UNION/INTERSECT/EXCEPT                              //
@@ -30,17 +93,6 @@ grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'
 //      (i.e., `UNION` & `EXCEPT`) are at the top of the recursion tree, and the highest
 //      precedence are at the bottom (i.e., `INTERSECT`)
 //    - all set operations are left-associative and are thus expressed as left-self-recursive rules
-
-pub(crate) Query: Box<ast::Expr> = {
-    <lo:@L>
-    <set:QuerySet>
-    <order_by:OrderByClause?>
-    <limit:LimitClause?>
-    <offset:OffsetByClause?>
-    <hi:@R> => {
-        Box::new(ast::Expr::Query( state.node(ast::Query { set, order_by, limit, offset, }, lo..hi) ) )
-    }
-}
 
 QuerySet: ast::AstNode<ast::QuerySet> = {
     <lo:@L> <lhs:QuerySet> <setop:SetOp> <setq:SetQuantifier> <rhs:SingleQuery> <hi:@R> => {
@@ -82,7 +134,7 @@ SetQuantifier: ast::SetQuantifier = {
 SingleQuery: ast::AstNode<ast::QuerySet> = {
     <lo:@L> <expr:ExprQuery> <hi:@R> => {
         match *expr {
-           ast::Expr::Query(ast::AstNode{ node: ast::Query{set, order_by:None, limit:None, offset:None} , .. }) => set,
+           ast::Expr::Query(ast::AstNode{ node: ast::Query{with: None, set, order_by:None, limit:None, offset:None} , .. }) => set,
            _ => state.node(ast::QuerySet::Expr( expr ), lo..hi),
         }
     },
@@ -113,7 +165,6 @@ SfwQuery: ast::AstNode<ast::Select> = {
 // SQL-style where `Select` precedes `From`
 SfwClauses: ast::AstNode<ast::Select> = {
     <lo:@L>
-    <with:WithClause?>
     <project:SelectClause>
     <from:FromClause?>
     <where_clause:WhereClause?>
@@ -134,7 +185,6 @@ SfwClauses: ast::AstNode<ast::Select> = {
 // PartiQL-style where `Select` is last
 FwsClauses: ast::AstNode<ast::Select> = {
     <lo:@L>
-    <with:WithClause?>
     <from:FromClause>
     <where_clause:WhereClause?>
     <group_by:GroupClause?>
@@ -151,12 +201,6 @@ FwsClauses: ast::AstNode<ast::Select> = {
         }, lo..hi)
     }
 }
-
-// ------------------------------------------------------------------------------ //
-//                                     WITH                                       //
-// ------------------------------------------------------------------------------ //
-// TODO
-WithClause: () = {}
 
 // ------------------------------------------------------------------------------ //
 //                                    SELECT                                      //
@@ -249,15 +293,6 @@ TableNonJoin: ast::FromSource = {
 
 #[inline]
 TableBaseReference: ast::AstNode<ast::FromLet> = {
-    <lo:@L> <e:ExprQuery> <as_alias:SymbolPrimitive> <hi:@R> => {
-        state.node(ast::FromLet {
-            expr: e,
-            kind: ast::FromLetKind::Scan,
-            as_alias: Some(as_alias),
-            at_alias: None,
-            by_alias: None
-        }, lo..hi)
-    },
     <lo:@L> <e:ExprQuery> <as_alias:AsIdent?> <at_alias:AtIdent?> <by_alias:ByIdent?> <hi:@R> => {
         state.node(ast::FromLet {
             expr: e,
@@ -826,12 +861,20 @@ ExprPrecedence01: ast::Expr = {
 }
 
 ExprTerm: ast::Expr = {
-    "(" <q:Query> ")" =>  *strip_query(q),
+    <SubQuery>,
     <lo:@L> <lit:Literal> <hi:@R> => ast::Expr::Lit( state.node(lit, lo..hi) ),
     <VarRefExpr>,
     <ExprTermCollection>,
     <ExprTermTuple>,
     ! => { state.errors.push(<>); ast::Expr::Error},
+}
+
+SubQuery: ast::Expr = {
+    "(" <q:Query> ")" =>  *strip_query(q),
+}
+
+SubQueryAst: ast::AstNode<ast::Expr> = {
+    <lo:@L> <subq:SubQuery> <hi:@R> => state.node(subq, lo..hi),
 }
 
 // ------------------------------------------------------------------------------ //
@@ -933,7 +976,7 @@ FunctionCallArgs: Vec<ast::AstNode<ast::CallArg>> = {
     // Special case subquery when it is the only sub-expression of a function call (e.g., `SELECT AVG(SELECT VALUE price FROM g AS v))... `)
     <lo:@L> <subq:SfwQuery> <hi:@R> => {
         let qset = state.node(ast::QuerySet::Select(Box::new(subq)), lo..hi);
-        let query = state.node(ast::Query{ set: qset, order_by: None, limit: None, offset:None }, lo..hi);
+        let query = state.node(ast::Query{ with: None, set: qset, order_by: None, limit: None, offset:None }, lo..hi);
         vec![state.node(ast::CallArg::Positional(Box::new(ast::Expr::Query(query))), lo..hi)]
     },
 }
@@ -1231,7 +1274,7 @@ SymbolPrimitive: ast::SymbolPrimitive = {
 }
 
 AsIdent: ast::SymbolPrimitive = {
-    "AS" <SymbolPrimitive>
+    "AS"? <SymbolPrimitive>
 }
 
 AtIdent: ast::SymbolPrimitive = {
@@ -1312,6 +1355,7 @@ extern {
         "BY" => lexer::Token::By,
         "CASE" => lexer::Token::Case,
         "CROSS" => lexer::Token::Cross,
+        "CYCLE" => lexer::Token::Cycle,
         "DATE" => lexer::Token::Date,
         "DESC" => lexer::Token::Desc,
         "DISTINCT" => lexer::Token::Distinct,
@@ -1350,7 +1394,9 @@ extern {
         "PIVOT" => lexer::Token::Pivot,
         "PRESERVE" => lexer::Token::Preserve,
         "RIGHT" => lexer::Token::Right,
+        "RECURSIVE" => lexer::Token::Recursive,
         "SELECT" => lexer::Token::Select,
+        "SEARCH" => lexer::Token::Search,
         "TABLE" => lexer::Token::Table,
         "TIME" => lexer::Token::Time,
         "TIMESTAMP" => lexer::Token::Timestamp,


### PR DESCRIPTION
Cf. https://github.com/partiql/partiql-tests/blob/4ab01b3ffa8c0ebf3bae0697111b42714f22a544/partiql-tests-data/eval/spec-tests.ion#L744

Cf. https://jakewheat.github.io/sql-overview/sql-2016-foundation-grammar.html#with-clause

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
