### PR TITLE
Add `LIMIT` and `OFFSET` operators to evaluator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "partiql-conformance-tests/partiql-tests"]
 	path = partiql-conformance-tests/partiql-tests
-	url = https://github.com/partiql/partiql-tests.git
+	url = git@github.com:partiql/partiql-tests.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Added
+- Implements `LIMIT` and `OFFSET` operators in evaluator
 - Adds some benchmarks for parsing, compiling, planning, & evaluation
 - Implements `PIVOT` operator in evaluator
 - `serde` feature to `partiql-value` and `partiql-logical` with `Serialize` and `Deserialize` traits.

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -237,8 +237,7 @@ pub struct Query {
     pub with: Option<AstNode<WithClause>>,
     pub set: AstNode<QuerySet>,
     pub order_by: Option<Box<AstNode<OrderByExpr>>>,
-    pub limit: Option<Box<Expr>>,
-    pub offset: Option<Box<Expr>>,
+    pub limit_offset: Option<Box<AstNode<LimitOffsetClause>>>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]
@@ -805,6 +804,13 @@ pub struct GroupKey {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OrderByExpr {
     pub sort_specs: Vec<AstNode<SortSpec>>,
+}
+
+#[derive(Visit, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct LimitOffsetClause {
+    pub limit: Option<Box<Expr>>,
+    pub offset: Option<Box<Expr>>,
 }
 
 /// <expr> [ASC | DESC] ?

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -212,6 +212,8 @@ pub trait Visitor<'ast> {
     fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) {}
     fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) {}
     fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) {}
+    fn enter_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) {}
+    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) {}
     fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) {}
     fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) {}
     fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) {}

--- a/partiql-ast/tests/test_ast.rs
+++ b/partiql-ast/tests/test_ast.rs
@@ -15,8 +15,7 @@ fn test_ast_init() {
                 node: Lit::Int32Lit(23),
             }))),
         },
-        offset: None,
         order_by: None,
-        limit: None,
+        limit_offset: None,
     });
 }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -3,6 +3,7 @@ use petgraph::prelude::StableGraph;
 use std::collections::HashMap;
 
 use partiql_logical as logical;
+
 use partiql_logical::{
     BinaryOp, BindingsOp, CallName, IsTypeExpr, JoinKind, LogicalPlan, OpId, PathComponent,
     Pattern, PatternMatchExpr, SearchedCase, Type, UnaryOp, ValueExpr,
@@ -133,8 +134,14 @@ impl EvaluatorPlanner {
                 Box::new(eval::evaluable::EvalExprQuery::new(expr))
             }
             BindingsOp::OrderBy => todo!("OrderBy"),
-            BindingsOp::Offset => todo!("Offset"),
-            BindingsOp::Limit => todo!("Limit"),
+            BindingsOp::LimitOffset(logical::LimitOffset { limit, offset }) => {
+                Box::new(eval::evaluable::EvalLimitOffset {
+                    limit: limit.as_ref().map(|e| self.plan_values(e)),
+                    offset: offset.as_ref().map(|e| self.plan_values(e)),
+                    input: None,
+                })
+            }
+
             BindingsOp::SetOp => todo!("SetOp"),
             BindingsOp::GroupBy => todo!("GroupBy"),
         }

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -18,8 +18,7 @@ pub(crate) fn strip_query(q: Box<ast::Expr>) -> Box<ast::Expr> {
                         ..
                     },
                 order_by: None,
-                limit: None,
-                offset: None,
+                limit_offset: None,
             },
         ..
     }) = *q

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -20,10 +20,9 @@ pub(crate) Query: Box<ast::Expr> = {
     <with:WithClause?>
     <set:QuerySet>
     <order_by:OrderByClause?>
-    <limit:LimitClause?>
-    <offset:OffsetByClause?>
+    <limit_offset:LimitOffsetClause>
     <hi:@R> => {
-        Box::new(ast::Expr::Query( state.node(ast::Query { with, set, order_by, limit, offset, }, lo..hi) ) )
+        Box::new(ast::Expr::Query( state.node(ast::Query { with, set, order_by, limit_offset }, lo..hi) ) )
     }
 }
 
@@ -134,7 +133,7 @@ SetQuantifier: ast::SetQuantifier = {
 SingleQuery: ast::AstNode<ast::QuerySet> = {
     <lo:@L> <expr:ExprQuery> <hi:@R> => {
         match *expr {
-           ast::Expr::Query(ast::AstNode{ node: ast::Query{with: None, set, order_by:None, limit:None, offset:None} , .. }) => set,
+           ast::Expr::Query(ast::AstNode{ node: ast::Query{with: None, set, order_by:None, limit_offset:None} , .. }) => set,
            _ => state.node(ast::QuerySet::Expr( expr ), lo..hi),
         }
     },
@@ -479,13 +478,18 @@ ByNullSpec: ast::NullOrderingSpec = {
 }
 
 // ------------------------------------------------------------------------------ //
-//                                     LIMIT                                      //
+//                                LIMIT / OFFSET                                  //
 // ------------------------------------------------------------------------------ //
+LimitOffsetClause: Option<Box<ast::AstNode<ast::LimitOffsetClause>>> = {
+ <lo:@L> <limit:LimitClause?> <offset:OffsetByClause?> <hi:@R> => {
+   if limit.is_none() && offset.is_none() {
+     None
+   } else {
+     Some(Box::new(state.node(ast::LimitOffsetClause { limit, offset }, lo..hi)))
+   }
+ }
+}
 LimitClause: Box<ast::Expr> = { "LIMIT" <ExprQuery> }
-
-// ------------------------------------------------------------------------------ //
-//                                     OFFSET                                     //
-// ------------------------------------------------------------------------------ //
 OffsetByClause: Box<ast::Expr> = { "OFFSET" <ExprQuery> }
 
 // ------------------------------------------------------------------------------ //
@@ -976,7 +980,7 @@ FunctionCallArgs: Vec<ast::AstNode<ast::CallArg>> = {
     // Special case subquery when it is the only sub-expression of a function call (e.g., `SELECT AVG(SELECT VALUE price FROM g AS v))... `)
     <lo:@L> <subq:SfwQuery> <hi:@R> => {
         let qset = state.node(ast::QuerySet::Select(Box::new(subq)), lo..hi);
-        let query = state.node(ast::Query{ with: None, set: qset, order_by: None, limit: None, offset:None }, lo..hi);
+        let query = state.node(ast::Query{ with: None, set: qset, order_by: None, limit_offset:None }, lo..hi);
         vec![state.node(ast::CallArg::Positional(Box::new(ast::Expr::Query(query))), lo..hi)]
     },
 }


### PR DESCRIPTION
- Merges `Limit` and `Offset` into one `LimitOffsetClause` AST node
- Adds `EvalLimitOffset` evaluator operator
- Updates parser and lowering to evaluator
- Updates changelog

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
