### PR TITLE
Only construct FnSymTab once, using `OnceCell`

### DIFF
--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -33,6 +33,7 @@ petgraph = "0.6.*"
 num = "0.4"
 fnv = "1"
 assert_matches = "1.5.*"
+once_cell = "1"
 
 [dev-dependencies]
 partiql-eval = { path = "../partiql-eval", version = "0.2.*" }

--- a/partiql-logical-planner/src/call_defs.rs
+++ b/partiql-logical-planner/src/call_defs.rs
@@ -1,9 +1,11 @@
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use partiql_logical as logical;
 use partiql_logical::ValueExpr;
 use partiql_value::Value;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+
 use unicase::UniCase;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -72,7 +74,7 @@ impl CallSpecArg {}
 
 pub struct CallSpec {
     input: Vec<CallSpecArg>,
-    output: Box<dyn Fn(Vec<ValueExpr>) -> logical::ValueExpr>,
+    output: Box<dyn Fn(Vec<ValueExpr>) -> logical::ValueExpr + Send + Sync>,
 }
 
 impl Debug for CallSpec {
@@ -438,6 +440,8 @@ fn function_call_def_cardinality() -> CallDef {
         }],
     }
 }
+
+pub(crate) static FN_SYM_TAB: Lazy<FnSymTab> = Lazy::new(function_call_def);
 
 /// Function symbol table
 #[derive(Debug)]

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -22,7 +22,7 @@ use partiql_value::{BindingsName, Value};
 
 use std::collections::{HashMap, HashSet};
 
-use crate::call_defs::{function_call_def, CallArgument, FnSymTab};
+use crate::call_defs::{CallArgument, FnSymTab, FN_SYM_TAB};
 use crate::name_resolver;
 use itertools::Itertools;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -117,7 +117,7 @@ pub struct AstToLogical {
     plan: LogicalPlan<BindingsOp>,
 
     key_registry: name_resolver::KeyRegistry,
-    fnsym_tab: FnSymTab,
+    fnsym_tab: &'static FnSymTab,
 }
 
 /// Attempt to infer an alias for a simple variable reference expression.
@@ -155,6 +155,7 @@ fn infer_id(expr: &ValueExpr) -> Option<SymbolPrimitive> {
 
 impl AstToLogical {
     pub fn new(registry: name_resolver::KeyRegistry) -> Self {
+        let fnsym_tab: &FnSymTab = &FN_SYM_TAB;
         AstToLogical {
             id_stack: Default::default(),
 
@@ -178,7 +179,7 @@ impl AstToLogical {
             plan: Default::default(),
 
             key_registry: registry,
-            fnsym_tab: function_call_def(),
+            fnsym_tab,
         }
     }
 


### PR DESCRIPTION
fixes #317 

for `cargo bench compile`:

before:
```
compile-1               time:   [26.914 µs 27.030 µs 27.158 µs]
                        change: [-1.4509% -0.1010% +1.2654%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

compile-15              time:   [71.181 µs 71.398 µs 71.624 µs]
                        change: [+0.3953% +1.1365% +1.8644%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

compile-30              time:   [122.76 µs 123.42 µs 124.27 µs]
                        change: [-0.4880% +0.2882% +1.0441%] (p = 0.48 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
```


after:
```
compile-1               time:   [8.4798 µs 8.5462 µs 8.6514 µs]
                        change: [-68.689% -68.281% -67.733%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  8 (8.00%) high mild
  2 (2.00%) high severe

compile-15              time:   [52.131 µs 52.400 µs 52.715 µs]
                        change: [-26.885% -26.134% -25.429%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe

compile-30              time:   [102.97 µs 103.48 µs 104.08 µs]
                        change: [-16.501% -15.725% -14.863%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe  
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
