### PR TITLE
Fix Tuple value duplicate equality and hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `partiql_value::parse_ion` as a public API.
 
 ### Fixes
+- Fixes Tuple value duplicate equality and hashing
 
 ## [0.2.0] - 2023-01-10
 ### Changed

--- a/partiql-value/src/tuple.rs
+++ b/partiql-value/src/tuple.rs
@@ -2,7 +2,6 @@ use itertools::Itertools;
 
 use std::cmp::Ordering;
 
-use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter::zip;
@@ -171,9 +170,7 @@ impl Iterator for Tuple {
 
 impl PartialEq for Tuple {
     fn eq(&self, other: &Self) -> bool {
-        let s1: HashSet<(&str, &Value)> = self.pairs().collect();
-        let s2: HashSet<(&str, &Value)> = other.pairs().collect();
-        s1.eq(&s2)
+        self.pairs().sorted().eq(other.pairs().sorted())
     }
 }
 
@@ -185,7 +182,7 @@ impl PartialOrd for Tuple {
 
 impl Hash for Tuple {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for (k, v) in self.pairs() {
+        for (k, v) in self.pairs().sorted() {
             k.hash(state);
             v.hash(state);
         }


### PR DESCRIPTION
Tuple value equality was wrong in the case of duplicates and different tuple orders. Tuple value hashing was also wrong for unordered nested values.

Test cases in this PR show the correct behavior but were all previously failing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
