### PR TITLE
Parse `TABLE <id>` references

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -265,6 +265,7 @@ pub enum QuerySet {
     Select(Box<AstNode<Select>>),
     Expr(Box<Expr>),
     Values(Vec<Box<Expr>>),
+    Table(QueryTable),
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]
@@ -306,6 +307,13 @@ pub struct Select {
     pub where_clause: Option<Box<AstNode<WhereClause>>>,
     pub group_by: Option<Box<AstNode<GroupByExpr>>>,
     pub having: Option<Box<AstNode<HavingClause>>>,
+}
+
+#[derive(Visit, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct QueryTable {
+    #[visit(skip)]
+    pub table_name: SymbolPrimitive,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -128,6 +128,8 @@ pub trait Visitor<'ast> {
     fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) {}
     fn enter_select(&mut self, _select: &'ast ast::Select) {}
     fn exit_select(&mut self, _select: &'ast ast::Select) {}
+    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) {}
+    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) {}
     fn enter_projection(&mut self, _projection: &'ast ast::Projection) {}
     fn exit_projection(&mut self, _projection: &'ast ast::Projection) {}
     fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) {}

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -532,6 +532,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {}
             QuerySet::Values(_) => todo!("QuerySet::Values"),
+            QuerySet::Table(_) => todo!("QuerySet::Table"),
         }
     }
 
@@ -550,6 +551,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.push_bexpr(id);
             }
             QuerySet::Values(_) => todo!("QuerySet::Values"),
+            QuerySet::Table(_) => todo!("QuerySet::Table"),
         }
     }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -139,6 +139,7 @@ SingleQuery: ast::AstNode<ast::QuerySet> = {
     },
     <lo:@L> <sfw:SfwQuery> <hi:@R> => state.node(ast::QuerySet::Select( Box::new(sfw)), lo..hi),
     <lo:@L> <values:Values> <hi:@R> => values,
+    <lo:@L> <table:ExplicitTable> <hi:@R> => table,
 }
 
 Values: ast::AstNode<ast::QuerySet> = {
@@ -149,6 +150,11 @@ Values: ast::AstNode<ast::QuerySet> = {
 ValueRow: Box<ast::Expr> = {
     "(" <e:ExprQuery> ")" => Box::new(*e),
     <array:ExprTermCollection> => Box::new(array)
+}
+
+#[inline]
+ExplicitTable: ast::AstNode<ast::QuerySet> = {
+    <lo:@L> "TABLE" <table_name:SymbolPrimitive> <hi:@R> => state.node(ast::QuerySet::Table( ast::QueryTable{table_name} ), lo..hi)
 }
 
 // ------------------------------------------------------------------------------ //


### PR DESCRIPTION
Adds parser and AST support for `TABLE <id>` query expressions

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
