### PR TITLE
Add initial sql call aggregation function implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implements `GROUP BY` operator in evaluator
 - Implements `HAVING` operator in evaluator
 - Implements `ORDER BY` operator in evaluator
+- Implements SQL Aggregation functions -- AVG, COUNT, MAX, MIN, SUM
 
 ### Fixes
 - Fixes Tuple value duplicate equality and hashing

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -6,8 +6,8 @@ use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{partiql_bag, partiql_tuple, Bag, List, Tuple, Value};
 use std::borrow::{Borrow, Cow};
 use std::cell::RefCell;
-use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::cmp::{max, min, Ordering};
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -283,13 +283,350 @@ impl Evaluable for EvalJoin {
     }
 }
 
+/// An SQL aggregation function call that has been rewritten to be evaluated with the `GROUP BY`
+/// clause. The `[name]` is the string (generated in lowering step) that replaces the
+/// aggregation call expression. This name will be used as the field in the binding tuple output
+/// by `GROUP BY`. `[expr]` corresponds to the expression within the aggregation function. And
+/// `[func]` corresponds to the aggregation function that's being called (e.g. sum, count, avg).
+///
+/// For example, `SELECT a AS a, SUM(b) AS b FROM t GROUP BY a` is rewritten to the following form
+///              `SELECT a AS a, __agg1 AS b FROM t GROUP BY a`
+/// In the above example, `name` corresponds to '__agg1', expr refers to the variable reference `b`,
+/// and `func` corresponds to the sum aggregation function, `[AggSum]`.
+#[derive(Debug)]
+pub struct AggregateExpression {
+    pub name: String,
+    pub expr: Box<dyn EvalExpr>,
+    pub func: AggFunc,
+}
+
+pub trait AggregateFunction {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple);
+    fn compute(&self, group: &Tuple) -> Value;
+}
+
+#[derive(Debug)]
+pub enum AggFunc {
+    // TODO: modeling COUNT(*)
+    AggAvg(AggAvg),
+    AggCount(AggCount),
+    AggMax(AggMax),
+    AggMin(AggMin),
+    AggSum(AggSum),
+}
+
+impl AggregateFunction for AggFunc {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        match self {
+            AggFunc::AggAvg(v) => v.next_value(input_value, group),
+            AggFunc::AggCount(v) => v.next_value(input_value, group),
+            AggFunc::AggMax(v) => v.next_value(input_value, group),
+            AggFunc::AggMin(v) => v.next_value(input_value, group),
+            AggFunc::AggSum(v) => v.next_value(input_value, group),
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        match self {
+            AggFunc::AggAvg(v) => v.compute(group),
+            AggFunc::AggCount(v) => v.compute(group),
+            AggFunc::AggMax(v) => v.compute(group),
+            AggFunc::AggMin(v) => v.compute(group),
+            AggFunc::AggSum(v) => v.compute(group),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub enum AggFilterFn {
+    Distinct(AggFilterDistinct),
+    #[default]
+    All,
+}
+
+impl AggFilterFn {
+    fn filter_value(&mut self, input_value: Value, group: &Tuple) -> bool {
+        match self {
+            AggFilterFn::Distinct(d) => d.filter_value(input_value, group),
+            AggFilterFn::All => true,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AggFilterDistinct {
+    seen_vals: HashMap<Tuple, HashSet<Value>>,
+}
+
+impl AggFilterDistinct {
+    pub fn new() -> Self {
+        AggFilterDistinct {
+            seen_vals: HashMap::new(),
+        }
+    }
+}
+
+impl Default for AggFilterDistinct {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AggFilterDistinct {
+    fn filter_value(&mut self, input_value: Value, group: &Tuple) -> bool {
+        if let Some(seen_vals_in_group) = self.seen_vals.get_mut(group) {
+            seen_vals_in_group.insert(input_value)
+        } else {
+            let mut new_seen_vals = HashSet::new();
+            new_seen_vals.insert(input_value);
+            self.seen_vals
+                .insert(group.clone(), new_seen_vals)
+                .is_none()
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AggAvg {
+    avgs: HashMap<Tuple, (usize, Value)>,
+    aggregator: AggFilterFn,
+}
+
+impl AggAvg {
+    pub fn new_distinct() -> Self {
+        AggAvg {
+            avgs: HashMap::new(),
+            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
+        }
+    }
+
+    pub fn new_all() -> Self {
+        AggAvg {
+            avgs: HashMap::new(),
+            aggregator: AggFilterFn::default(),
+        }
+    }
+}
+
+impl AggregateFunction for AggAvg {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        if !input_value.is_null_or_missing()
+            && self.aggregator.filter_value(input_value.clone(), group)
+        {
+            match self.avgs.get_mut(group) {
+                None => {
+                    self.avgs.insert(group.clone(), (1, input_value.clone()));
+                }
+                Some((count, sum)) => {
+                    *count += 1;
+                    *sum = &sum.clone() + input_value;
+                }
+            }
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        match self.avgs.get(group).expect("Expect group to exist in avgs") {
+            (0, _) => Null,
+            (c, s) => s / &Value::Decimal(rust_decimal::Decimal::from(*c)),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AggCount {
+    counts: HashMap<Tuple, usize>,
+    aggregator: AggFilterFn,
+}
+
+impl AggCount {
+    pub fn new_distinct() -> Self {
+        AggCount {
+            counts: HashMap::new(),
+            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
+        }
+    }
+
+    pub fn new_all() -> Self {
+        AggCount {
+            counts: HashMap::new(),
+            aggregator: AggFilterFn::default(),
+        }
+    }
+}
+
+impl AggregateFunction for AggCount {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        if !input_value.is_null_or_missing()
+            && self.aggregator.filter_value(input_value.clone(), group)
+        {
+            match self.counts.get_mut(group) {
+                None => {
+                    self.counts.insert(group.clone(), 1);
+                }
+                Some(count) => {
+                    *count += 1;
+                }
+            };
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        Value::from(
+            self.counts
+                .get(group)
+                .expect("Expect group to exist in counts"),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct AggMax {
+    maxes: HashMap<Tuple, Value>,
+    aggregator: AggFilterFn,
+}
+
+impl AggMax {
+    pub fn new_distinct() -> Self {
+        AggMax {
+            maxes: HashMap::new(),
+            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
+        }
+    }
+
+    pub fn new_all() -> Self {
+        AggMax {
+            maxes: HashMap::new(),
+            aggregator: AggFilterFn::default(),
+        }
+    }
+}
+
+impl AggregateFunction for AggMax {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        if !input_value.is_null_or_missing()
+            && self.aggregator.filter_value(input_value.clone(), group)
+        {
+            match self.maxes.get_mut(group) {
+                None => {
+                    self.maxes.insert(group.clone(), input_value.clone());
+                }
+                Some(m) => {
+                    *m = max(m.clone(), input_value.clone());
+                }
+            }
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        self.maxes
+            .get(group)
+            .expect("Expect group to exist in sums")
+            .clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct AggMin {
+    mins: HashMap<Tuple, Value>,
+    aggregator: AggFilterFn,
+}
+
+impl AggMin {
+    pub fn new_distinct() -> Self {
+        AggMin {
+            mins: HashMap::new(),
+            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
+        }
+    }
+
+    pub fn new_all() -> Self {
+        AggMin {
+            mins: HashMap::new(),
+            aggregator: AggFilterFn::default(),
+        }
+    }
+}
+
+impl AggregateFunction for AggMin {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        if !input_value.is_null_or_missing()
+            && self.aggregator.filter_value(input_value.clone(), group)
+        {
+            match self.mins.get_mut(group) {
+                None => {
+                    self.mins.insert(group.clone(), input_value.clone());
+                }
+                Some(m) => {
+                    *m = min(m.clone(), input_value.clone());
+                }
+            }
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        self.mins
+            .get(group)
+            .expect("Expect group to exist in mins")
+            .clone()
+    }
+}
+
+#[derive(Debug)]
+pub struct AggSum {
+    sums: HashMap<Tuple, Value>,
+    aggregator: AggFilterFn,
+}
+
+impl AggSum {
+    pub fn new_distinct() -> Self {
+        AggSum {
+            sums: HashMap::new(),
+            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
+        }
+    }
+
+    pub fn new_all() -> Self {
+        AggSum {
+            sums: HashMap::new(),
+            aggregator: AggFilterFn::default(),
+        }
+    }
+}
+
+impl AggregateFunction for AggSum {
+    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
+        if !input_value.is_null_or_missing()
+            && self.aggregator.filter_value(input_value.clone(), group)
+        {
+            match self.sums.get_mut(group) {
+                None => {
+                    self.sums.insert(group.clone(), input_value.clone());
+                }
+                Some(s) => {
+                    *s = &s.clone() + input_value;
+                }
+            }
+        }
+    }
+
+    fn compute(&self, group: &Tuple) -> Value {
+        self.sums
+            .get(group)
+            .expect("Expect group to exist in sums")
+            .clone()
+    }
+}
+
 /// Represents an evaluation `GROUP BY` operator. For `GROUP BY` operational semantics, see section
 /// `11` of
 /// [PartiQL Specification — August 1, 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
+/// TODO: some docs on `aggregate_exprs`
 #[derive(Debug)]
 pub struct EvalGroupBy {
     pub strategy: EvalGroupingStrategy,
     pub exprs: HashMap<String, Box<dyn EvalExpr>>,
+    pub aggregate_exprs: Vec<AggregateExpression>,
     pub group_as_alias: Option<String>,
     pub input: Option<Value>,
 }
@@ -327,20 +664,37 @@ impl Evaluable for EvalGroupBy {
                 let mut groups: HashMap<Tuple, Vec<Value>> = HashMap::new();
                 for v in input_value.into_iter() {
                     let v_as_tuple = v.coerce_to_tuple();
+                    let group = self.eval_group(&v_as_tuple, ctx);
+                    for aggregate_expr in self.aggregate_exprs.iter_mut() {
+                        let evaluated_val =
+                            aggregate_expr.expr.evaluate(&v_as_tuple, ctx).into_owned();
+                        aggregate_expr.func.next_value(&evaluated_val, &group);
+                    }
                     groups
-                        .entry(self.eval_group(&v_as_tuple, ctx))
+                        .entry(group)
                         .or_insert(vec![])
-                        .push(Value::Tuple(Box::new(v_as_tuple)));
+                        .push(Value::Tuple(Box::new(v_as_tuple.clone())));
                 }
 
                 let bag = groups
                     .into_iter()
-                    .map(|(k, v)| match group_as_alias {
-                        None => Value::from(k), // TODO: removing the values here will be insufficient for when aggregations are added since they may have nothing to aggregate over
-                        Some(alias) => {
-                            let mut tuple_with_group = k;
-                            tuple_with_group.insert(alias, Value::Bag(Box::new(Bag::from(v))));
-                            Value::from(tuple_with_group)
+                    .map(|(mut k, v)| {
+                        let mut agg_results: Vec<(&str, Value)> = vec![];
+                        for aggregate_expr in &self.aggregate_exprs {
+                            let agg_result = aggregate_expr.func.compute(&k);
+                            agg_results.push((aggregate_expr.name.as_str(), agg_result));
+                        }
+                        agg_results
+                            .into_iter()
+                            .for_each(|(agg_name, agg_result)| k.insert(agg_name, agg_result));
+
+                        match group_as_alias {
+                            None => Value::from(k),
+                            Some(alias) => {
+                                let mut tuple_with_group = k;
+                                tuple_with_group.insert(alias, Value::Bag(Box::new(Bag::from(v))));
+                                Value::from(tuple_with_group)
+                            }
                         }
                     })
                     .collect::<Bag>();

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -15,9 +15,9 @@ use partiql_ast::ast::{
 use partiql_ast::visit::{Visit, Visitor};
 use partiql_logical as logical;
 use partiql_logical::{
-    BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch, LikeNonStringNonLiteralMatch,
-    ListExpr, LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SortSpecOrder,
-    TupleExpr, ValueExpr,
+    AggregateExpression, BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch,
+    LikeNonStringNonLiteralMatch, ListExpr, LogicalPlan, OpId, PathComponent, Pattern,
+    PatternMatchExpr, SortSpecOrder, TupleExpr, ValueExpr,
 };
 
 use partiql_value::{BindingsName, Value};
@@ -28,6 +28,7 @@ use crate::call_defs::{CallArgument, FnSymTab, FN_SYM_TAB};
 use crate::name_resolver;
 use itertools::Itertools;
 
+use partiql_logical::AggFunc::{AggAvg, AggCount, AggMax, AggMin, AggSum};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
@@ -108,6 +109,7 @@ pub struct AstToLogical {
     arg_stack: Vec<Vec<CallArgument>>,
     path_stack: Vec<Vec<PathComponent>>,
     sort_stack: Vec<Vec<logical::SortSpec>>,
+    aggregate_exprs: Vec<AggregateExpression>,
 
     from_lets: HashSet<ast::NodeId>,
 
@@ -117,6 +119,7 @@ pub struct AstToLogical {
 
     // generator of 'fresh' ids
     id: IdGenerator,
+    agg_id: IdGenerator,
 
     // output
     plan: LogicalPlan<BindingsOp>,
@@ -171,6 +174,7 @@ impl AstToLogical {
             arg_stack: Default::default(),
             path_stack: Default::default(),
             sort_stack: Default::default(),
+            aggregate_exprs: Default::default(),
 
             from_lets: Default::default(),
 
@@ -180,6 +184,7 @@ impl AstToLogical {
 
             // generator of 'fresh' ids
             id: Default::default(),
+            agg_id: Default::default(),
 
             // output
             plan: Default::default(),
@@ -892,10 +897,84 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
 
     fn enter_call_agg(&mut self, _call_agg: &'ast CallAgg) {
-        todo!("call_agg")
+        self.enter_call();
     }
 
-    fn exit_call_agg(&mut self, _call_agg: &'ast CallAgg) {}
+    fn exit_call_agg(&mut self, call_agg: &'ast CallAgg) {
+        // TODO distinguishing between PartiQL/top-level aggregation function calls and SQL
+        //  aggregation functions. Currently only handles SQL aggregation functions.
+        let env = self.exit_call();
+        let name = call_agg.func_name.value.to_lowercase();
+
+        let new_name = "__agg".to_owned() + &self.agg_id.id();
+        let new_binding_name = BindingsName::CaseSensitive(new_name.clone());
+        let new_expr = ValueExpr::VarRef(new_binding_name);
+        self.push_vexpr(new_expr);
+
+        let mut setq = logical::SetQuantifier::All;
+
+        let arg = match env.last().unwrap() {
+            CallArgument::Positional(ve) => ve.clone(),
+            CallArgument::Named(s, ve) => {
+                if s == "distinct" {
+                    setq = logical::SetQuantifier::Distinct
+                }
+                ve.clone()
+            }
+        };
+
+        let agg_expr = match name.as_str() {
+            "avg" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggAvg,
+                setq,
+            },
+            "count" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggCount,
+                setq,
+            },
+            "max" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggMax,
+                setq,
+            },
+            "min" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggMin,
+                setq,
+            },
+            "sum" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggSum,
+                setq,
+            },
+            _ => panic!("Unsupported aggregation function name."),
+        };
+        self.aggregate_exprs.push(agg_expr);
+        // PartiQL permits SQL aggregations without a GROUP BY (e.g. SELECT SUM(t.a) FROM ...)
+        // What follows adds a GROUP BY clause with the rewrite `... GROUP BY true AS __gk`
+        if self.current_clauses_mut().group_by_clause.is_none() {
+            let mut exprs = HashMap::new();
+            exprs.insert(
+                "__gk".to_string(),
+                ValueExpr::Lit(Box::new(Value::from(true))),
+            );
+            let group_by: BindingsOp = BindingsOp::GroupBy(logical::GroupBy {
+                strategy: logical::GroupingStrategy::GroupFull,
+                exprs,
+                aggregate_exprs: self.aggregate_exprs.clone(),
+                group_as_alias: None,
+            });
+            let id = self.plan.add_operator(group_by);
+            self.current_clauses_mut().group_by_clause.replace(id);
+        }
+    }
 
     fn enter_var_ref(&mut self, _var_ref: &'ast VarRef) {
         let is_from_path = matches!(self.current_ctx(), Some(QueryContext::FromLet));
@@ -1129,6 +1208,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
 
     fn exit_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) {
+        let aggregate_exprs = self.aggregate_exprs.clone();
         let benv = self.exit_benv();
         assert_eq!(benv.len(), 0); // TODO sub-query
         let env = self.exit_env();
@@ -1142,6 +1222,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             GroupingStrategy::GroupFull => logical::GroupingStrategy::GroupFull,
             GroupingStrategy::GroupPartial => logical::GroupingStrategy::GroupPartial,
         };
+
+        let select_clause_op_id = self.current_clauses_mut().select_clause.unwrap();
+        let select_clause = self.plan.operator_as_mut(select_clause_op_id).unwrap();
+        let mut binding = HashMap::new();
+        let select_clause_exprs = match select_clause {
+            BindingsOp::Project(ref mut project) => &mut project.exprs,
+            BindingsOp::ProjectAll => &mut binding,
+            BindingsOp::ProjectValue(_) => &mut binding, // TODO: replacement of SELECT VALUE expressions
+            _ => panic!("Unexpected project type"),
+        };
+        let mut exprs_to_replace: Vec<(String, ValueExpr)> = Vec::new();
+
         let mut exprs = HashMap::with_capacity(env.len() / 2);
         let mut iter = env.into_iter();
         while let Some(value) = iter.next() {
@@ -1153,11 +1245,24 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 },
                 _ => panic!("unexpected alias type"),
             };
+            for (alias, expr) in select_clause_exprs.iter() {
+                if *expr == value {
+                    let new_binding_name = BindingsName::CaseSensitive(alias.clone());
+                    let new_expr = ValueExpr::VarRef(new_binding_name);
+                    exprs_to_replace.push((alias.to_owned(), new_expr));
+                }
+            }
             exprs.insert(alias, value);
         }
+
+        for (k, v) in exprs_to_replace {
+            select_clause_exprs.insert(k, v);
+        }
+
         let group_by: BindingsOp = BindingsOp::GroupBy(logical::GroupBy {
             strategy,
             exprs,
+            aggregate_exprs,
             group_as_alias,
         });
 

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -117,6 +117,7 @@ where
     /// let d = p.add_operator(BindingsOp::GroupBy(GroupBy {
     ///     strategy: GroupingStrategy::GroupFull,
     ///     exprs: Default::default(),
+    ///     aggregate_exprs: vec![],
     ///     group_as_alias: None,
     /// }));
     ///
@@ -148,6 +149,10 @@ where
 
     pub fn operator(&self, id: OpId) -> Option<&T> {
         self.nodes.get(id.0 - 1)
+    }
+
+    pub fn operator_as_mut(&mut self, id: OpId) -> Option<&mut T> {
+        self.nodes.get_mut(id.0 - 1)
     }
 
     // TODO add DAG validation method.
@@ -309,12 +314,33 @@ pub enum JoinKind {
     Cross,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct AggregateExpression {
+    pub name: String,
+    pub expr: ValueExpr,
+    pub func: AggFunc,
+    pub setq: SetQuantifier,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum AggFunc {
+    // TODO: modeling of COUNT(*)
+    AggAvg,
+    AggCount,
+    AggMax,
+    AggMin,
+    AggSum,
+}
+
 /// Represents `GROUP BY` <strategy> <group_key>[, <group_key>] ... \[AS <as_alias>\]
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupBy {
     pub strategy: GroupingStrategy,
     pub exprs: HashMap<String, ValueExpr>,
+    pub aggregate_exprs: Vec<AggregateExpression>,
     pub group_as_alias: Option<String>,
 }
 
@@ -620,6 +646,14 @@ pub enum CallName {
     Cardinality,
 }
 
+/// Indicates if a set should be reduced to its distinct elements or not.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SetQuantifier {
+    All,
+    Distinct,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -636,6 +670,7 @@ mod tests {
         let d = p.add_operator(BindingsOp::GroupBy(GroupBy {
             strategy: GroupingStrategy::GroupFull,
             exprs: Default::default(),
+            aggregate_exprs: vec![],
             group_as_alias: None,
         }));
         p.add_flow(a, b);

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -314,6 +314,7 @@ pub enum JoinKind {
     Cross,
 }
 
+/// An SQL aggregation function call with its arguments
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AggregateExpression {
@@ -323,14 +324,20 @@ pub struct AggregateExpression {
     pub setq: SetQuantifier,
 }
 
+/// SQL aggregate function
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AggFunc {
     // TODO: modeling of COUNT(*)
+    /// Represents SQL's `AVG` aggregation function
     AggAvg,
+    /// Represents SQL's `COUNT` aggregation function
     AggCount,
+    /// Represents SQL's `MAX` aggregation function
     AggMax,
+    /// Represents SQL's `MIN` aggregation function
     AggMin,
+    /// Represents SQL's `SUM` aggregation function
     AggSum,
 }
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -521,6 +521,16 @@ impl Value {
     }
 
     #[inline]
+    pub fn is_number(&self) -> bool {
+        matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
+    }
+
+    #[inline]
+    pub fn is_null_or_missing(&self) -> bool {
+        matches!(self, Value::Missing | Value::Null)
+    }
+
+    #[inline]
     pub fn is_ordered(&self) -> bool {
         self.is_list()
     }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -521,11 +521,13 @@ impl Value {
     }
 
     #[inline]
+    /// Returns true if and only if Value is an integer, real, or decimal
     pub fn is_number(&self) -> bool {
         matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
     }
 
     #[inline]
+    /// Returns true if and only if Value is null or missing
     pub fn is_null_or_missing(&self) -> bool {
         matches!(self, Value::Missing | Value::Null)
     }


### PR DESCRIPTION
Implements SQL aggregation functions (AVG, COUNT, MAX, MIN, SUM) in the evaluator.

Performs some rewrites:
- SQL aggregations without `GROUP BY` are rewritten to include a `GROUP BY true AS $__gk`
- SQL aggregations are rewritten to be computed in the GROUP BY
  - E.g. `SELECT a, SUM(b) FROM t GROUP BY a` -> `SELECT a, $__agg_1 FROM t GROUP BY a`
- GROUP BY expressions usable by other clauses (e.g. SELECT list) for SQL compatibility https://partiql.org/assets/PartiQL-Specification.pdf#subsubsection.11.2.1
  - E.g. `SELECT t.a + 1 AS a FROM t GROUP BY t.a + 1 AS some_group_alias` -> `SELECT some_group_alias AS a FROM t GROUP BY t.a + 1 AS some_group_alias`

---
- Some remaining test failures
  - COUNT(*)
  - ~NULL/MISSING in GROUP BY values https://github.com/partiql/partiql-lang-rust/issues/328~ these conformance tests are incorrect
  - ~Figure out proper lowering of PartiQL/top-level aggregation functions and SQL aggregation functions~ this shouldn't be an issue if we disallow using PartiQL/top-level aggregation functions in SQL aggregation contexts. See https://github.com/partiql/partiql-spec/issues/51#issuecomment-1498352752

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
