### PR TITLE
Implements `ORDER BY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose `partiql_value::parse_ion` as a public API.
 - Implements `GROUP BY` operator in evaluator
 - Implements `HAVING` operator in evaluator
+- Implements `ORDER BY` operator in evaluator
 
 ### Fixes
 - Fixes Tuple value duplicate equality and hashing


### PR DESCRIPTION
Implements lowering & evaluation of `ORDER BY` clause.

Some `ORDER BY` conformance tests still fail due to a lack of proper name resolution and data flow analysis, which will be addressed separately.

---



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
