### PR TITLE
Add EXTRACT builtin function; update `partiql-tests`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 ### Added
+- Implements built-in function `EXTRACT`
 ### Fixes
+- Fix parsing of `EXTRACT` datetime parts `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`
 
 ## [0.3.0] - 2023-04-11
 ### Changed

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -205,14 +205,16 @@ fn parse_test_value_time(reader: &mut Reader) -> DateTime {
 
 fn parse_test_value_datetime(reader: &mut Reader) -> DateTime {
     let ts = reader.read_timestamp().unwrap();
+    let offset = ts.offset();
     // TODO: fractional seconds Cf. https://github.com/amazon-ion/ion-rust/pull/482#issuecomment-1470615286
-    DateTime::from_ymdhms(
+    DateTime::from_ymdhms_offset_minutes(
         ts.year(),
         NonZeroU8::new(ts.month() as u8).unwrap(),
         ts.day() as u8,
         ts.hour() as u8,
         ts.minute() as u8,
         ts.second() as f64,
+        offset,
     )
 }
 

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -214,7 +214,7 @@ fn parse_test_value_datetime(reader: &mut Reader) -> DateTime {
         ts.hour() as u8,
         ts.minute() as u8,
         ts.second() as u8,
-        ts.nanoseconds() as u32,
+        ts.nanoseconds(),
         offset,
     )
 }

--- a/partiql-conformance-tests/tests/test_value.rs
+++ b/partiql-conformance-tests/tests/test_value.rs
@@ -194,10 +194,11 @@ fn parse_test_value_time(reader: &mut Reader) -> DateTime {
     }
     reader.step_out().expect("step out of struct");
 
-    DateTime::from_hmfs_tz(
+    DateTime::from_hms_nano_tz(
         time.hour.expect("hour"),
         time.minute.expect("minute"),
-        time.second.expect("second"),
+        time.second.expect("second").trunc() as u8,
+        time.second.expect("second").fract() as u32,
         time.tz_hour,
         time.tz_minute,
     )
@@ -206,14 +207,14 @@ fn parse_test_value_time(reader: &mut Reader) -> DateTime {
 fn parse_test_value_datetime(reader: &mut Reader) -> DateTime {
     let ts = reader.read_timestamp().unwrap();
     let offset = ts.offset();
-    // TODO: fractional seconds Cf. https://github.com/amazon-ion/ion-rust/pull/482#issuecomment-1470615286
-    DateTime::from_ymdhms_offset_minutes(
+    DateTime::from_ymdhms_nano_offset_minutes(
         ts.year(),
         NonZeroU8::new(ts.month() as u8).unwrap(),
         ts.day() as u8,
         ts.hour() as u8,
         ts.minute() as u8,
-        ts.second() as f64,
+        ts.second() as u8,
+        ts.nanoseconds() as u32,
         offset,
     )
 }

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -5,7 +5,8 @@ use itertools::Itertools;
 use partiql_logical::Type;
 use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{
-    Bag, BinaryAnd, BinaryOr, BindingsName, List, NullableEq, NullableOrd, Tuple, UnaryPlus, Value,
+    Bag, BinaryAnd, BinaryOr, BindingsName, DateTime, List, NullableEq, NullableOrd, Tuple,
+    UnaryPlus, Value,
 };
 use regex::{Regex, RegexBuilder};
 use std::borrow::{Borrow, Cow};
@@ -930,6 +931,216 @@ impl EvalExpr for EvalFnCardinality {
             Value::List(l) => Value::from(l.len()),
             Value::Bag(b) => Value::from(b.len()),
             Value::Tuple(t) => Value::from(t.len()),
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a year `EXTRACT` function, e.g. `extract(YEAR FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractYear {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractYear {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Date(d) => Value::from(d.year()),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.year()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.year()),
+                DateTime::Time(_) => Missing,
+                DateTime::TimeWithTz(_, _) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a month `EXTRACT` function, e.g. `extract(MONTH FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractMonth {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractMonth {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Date(d) => Value::from(d.month() as u8),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.month() as u8),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.month() as u8),
+                DateTime::Time(_) => Missing,
+                DateTime::TimeWithTz(_, _) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a day `EXTRACT` function, e.g. `extract(DAT FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractDay {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractDay {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Date(d) => Value::from(d.day()),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.day()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.day()),
+                DateTime::Time(_) => Missing,
+                DateTime::TimeWithTz(_, _) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents an hour `EXTRACT` function, e.g. `extract(HOUR FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractHour {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractHour {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Time(t) => Value::from(t.hour()),
+                DateTime::TimeWithTz(t, _) => Value::from(t.hour()),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.hour()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.hour()),
+                DateTime::Date(_) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a minute `EXTRACT` function, e.g. `extract(MINUTE FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractMinute {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractMinute {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Time(t) => Value::from(t.minute()),
+                DateTime::TimeWithTz(t, _) => Value::from(t.minute()),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.minute()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.minute()),
+                DateTime::Date(_) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a second `EXTRACT` function, e.g. `extract(SECOND FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractSecond {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractSecond {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::Time(t) => Value::from(t.second()),
+                DateTime::TimeWithTz(t, _) => Value::from(t.second()),
+                DateTime::Timestamp(tstamp) => Value::from(tstamp.second()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.second()),
+                DateTime::Date(_) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a timezone hour `EXTRACT` function, e.g. `extract(TIMEZONE_HOUR FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractTimezoneHour {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractTimezoneHour {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::TimeWithTz(_, tz) => Value::from(tz.whole_hours()),
+                DateTime::TimestampWithTz(tstamp) => Value::from(tstamp.offset().whole_hours()),
+                DateTime::Date(_) => Missing,
+                DateTime::Time(_) => Missing,
+                DateTime::Timestamp(_) => Missing,
+            },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents a timezone minute `EXTRACT` function, e.g. `extract(TIMEZONE_MINUTE FROM t)`.
+#[derive(Debug)]
+pub struct EvalFnExtractTimezoneMinute {
+    pub value: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnExtractTimezoneMinute {
+    #[inline]
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let value = self.value.evaluate(bindings, ctx);
+        let result = match value.borrow() {
+            Null => Null,
+            Missing => Missing,
+            Value::DateTime(dt) => match dt.as_ref() {
+                DateTime::TimeWithTz(_, tz) => Value::from(tz.minutes_past_hour()),
+                DateTime::TimestampWithTz(tstamp) => {
+                    Value::from(tstamp.offset().minutes_past_hour() % 60)
+                }
+                DateTime::Date(_) => Missing,
+                DateTime::Time(_) => Missing,
+                DateTime::Timestamp(_) => Missing,
+            },
             _ => Missing,
         };
         Cow::Owned(result)

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -1136,7 +1136,7 @@ impl EvalExpr for EvalFnExtractTimezoneMinute {
             Value::DateTime(dt) => match dt.as_ref() {
                 DateTime::TimeWithTz(_, tz) => Value::from(tz.minutes_past_hour()),
                 DateTime::TimestampWithTz(tstamp) => {
-                    Value::from(tstamp.offset().minutes_past_hour() % 60)
+                    Value::from(tstamp.offset().minutes_past_hour())
                 }
                 DateTime::Date(_) => Missing,
                 DateTime::Time(_) => Missing,

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -18,11 +18,13 @@ use crate::eval::evaluable::{
 use crate::eval::expr::pattern_match::like_to_re_pattern;
 use crate::eval::expr::{
     EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalDynamicLookup, EvalExpr, EvalFnAbs,
-    EvalFnBitLength, EvalFnBtrim, EvalFnCardinality, EvalFnCharLength, EvalFnExists, EvalFnLower,
-    EvalFnLtrim, EvalFnModulus, EvalFnOctetLength, EvalFnOverlay, EvalFnPosition, EvalFnRtrim,
-    EvalFnSubstring, EvalFnUpper, EvalIsTypeExpr, EvalLikeMatch, EvalLikeNonStringNonLiteralMatch,
-    EvalListExpr, EvalLitExpr, EvalPath, EvalSearchedCaseExpr, EvalTupleExpr, EvalUnaryOp,
-    EvalUnaryOpExpr, EvalVarRef,
+    EvalFnBitLength, EvalFnBtrim, EvalFnCardinality, EvalFnCharLength, EvalFnExists,
+    EvalFnExtractDay, EvalFnExtractHour, EvalFnExtractMinute, EvalFnExtractMonth,
+    EvalFnExtractSecond, EvalFnExtractTimezoneHour, EvalFnExtractTimezoneMinute, EvalFnExtractYear,
+    EvalFnLower, EvalFnLtrim, EvalFnModulus, EvalFnOctetLength, EvalFnOverlay, EvalFnPosition,
+    EvalFnRtrim, EvalFnSubstring, EvalFnUpper, EvalIsTypeExpr, EvalLikeMatch,
+    EvalLikeNonStringNonLiteralMatch, EvalListExpr, EvalLitExpr, EvalPath, EvalSearchedCaseExpr,
+    EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef,
 };
 use crate::eval::EvalPlan;
 use partiql_value::Value::Null;
@@ -582,6 +584,54 @@ impl EvaluatorPlanner {
                     CallName::Cardinality => {
                         assert_eq!(args.len(), 1);
                         Box::new(EvalFnCardinality {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractYear => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractYear {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractMonth => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractMonth {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractDay => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractDay {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractHour => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractHour {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractMinute => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractMinute {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractSecond => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractSecond {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractTimezoneHour => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractTimezoneHour {
+                            value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ExtractTimezoneMinute => {
+                        assert_eq!(args.len(), 1);
+                        Box::new(EvalFnExtractTimezoneMinute {
                             value: args.pop().unwrap(),
                         })
                     }

--- a/partiql-logical-planner/src/call_defs.rs
+++ b/partiql-logical-planner/src/call_defs.rs
@@ -451,7 +451,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractYear,
                         arguments: args,
@@ -464,7 +464,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractMonth,
                         arguments: args,
@@ -477,7 +477,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractDay,
                         arguments: args,
@@ -490,7 +490,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractHour,
                         arguments: args,
@@ -503,7 +503,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractMinute,
                         arguments: args,
@@ -516,7 +516,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractSecond,
                         arguments: args,
@@ -529,7 +529,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractTimezoneHour,
                         arguments: args,
@@ -542,7 +542,7 @@ fn function_call_def_extract() -> CallDef {
                     CallSpecArg::Named("from".into()),
                 ],
                 output: Box::new(|mut args| {
-                    args.remove(0); // remove first default synthesized argument
+                    args.remove(0); // remove first default synthesized argument from parser preprocessor
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::ExtractTimezoneMinute,
                         arguments: args,

--- a/partiql-logical-planner/src/call_defs.rs
+++ b/partiql-logical-planner/src/call_defs.rs
@@ -441,6 +441,118 @@ fn function_call_def_cardinality() -> CallDef {
     }
 }
 
+fn function_call_def_extract() -> CallDef {
+    CallDef {
+        names: vec!["extract"],
+        overloads: vec![
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("year".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractYear,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("month".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractMonth,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("day".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractDay,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("hour".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractHour,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("minute".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractMinute,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("second".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractSecond,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("timezone_hour".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractTimezoneHour,
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![
+                    CallSpecArg::Named("timezone_minute".into()),
+                    CallSpecArg::Named("from".into()),
+                ],
+                output: Box::new(|mut args| {
+                    args.remove(0); // remove first default synthesized argument
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::ExtractTimezoneMinute,
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
 pub(crate) static FN_SYM_TAB: Lazy<FnSymTab> = Lazy::new(function_call_def);
 
 /// Function symbol table
@@ -478,6 +590,7 @@ pub fn function_call_def() -> FnSymTab {
         function_call_def_abs(),
         function_call_def_mod(),
         function_call_def_cardinality(),
+        function_call_def_extract(),
     ] {
         assert!(!def.names.is_empty());
         let primary = def.names[0];

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -651,6 +651,14 @@ pub enum CallName {
     Abs,
     Mod,
     Cardinality,
+    ExtractYear,
+    ExtractMonth,
+    ExtractDay,
+    ExtractHour,
+    ExtractMinute,
+    ExtractSecond,
+    ExtractTimezoneHour,
+    ExtractTimezoneMinute,
 }
 
 /// Indicates if a set should be reduced to its distinct elements or not.

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -87,7 +87,7 @@ mod built_ins {
     }
 
     const EXTRACT_SPECIFIER: &str =
-        "(?i:second)|(?i:minute)|(?i:hour)|(?i:day)|(?i:month)|(?:year)|(?:timezone_hour)|(?:timezone_minute)";
+        "(?i:second)|(?i:minute)|(?i:hour)|(?i:day)|(?i:month)|(?i:year)|(?i:timezone_hour)|(?i:timezone_minute)";
 
     pub(crate) fn built_in_extract() -> FnExpr<'static> {
         let re = Regex::new(EXTRACT_SPECIFIER).unwrap();

--- a/partiql-value/src/datetime.rs
+++ b/partiql-value/src/datetime.rs
@@ -21,14 +21,15 @@ impl DateTime {
         DateTime::Time(time::Time::from_hms(hour, minute, second).expect("valid time value"))
     }
 
-    pub fn from_hmfs(hour: u8, minute: u8, second: f64) -> Self {
-        Self::from_hmfs_offset(hour, minute, second, None)
+    pub fn from_hms_nano(hour: u8, minute: u8, second: u8, nanosecond: u32) -> Self {
+        Self::from_hms_nano_offset(hour, minute, second, nanosecond, None)
     }
 
-    pub fn from_hmfs_tz(
+    pub fn from_hms_nano_tz(
         hour: u8,
         minute: u8,
-        second: f64,
+        second: u8,
+        nanosecond: u32,
         tz_hours: Option<i8>,
         tz_minutes: Option<i8>,
     ) -> Self {
@@ -39,7 +40,7 @@ impl DateTime {
             _ => None,
         };
 
-        Self::from_hmfs_offset(hour, minute, second, offset)
+        Self::from_hms_nano_offset(hour, minute, second, nanosecond, offset)
     }
 
     pub fn from_ymd(year: i32, month: NonZeroU8, day: u8) -> Self {
@@ -48,18 +49,19 @@ impl DateTime {
         DateTime::Date(date)
     }
 
-    pub fn from_ymdhms_offset_minutes(
+    pub fn from_ymdhms_nano_offset_minutes(
         year: i32,
         month: NonZeroU8,
         day: u8,
         hour: u8,
         minute: u8,
-        second: f64,
+        second: u8,
+        nanosecond: u32,
         offset: Option<i32>,
     ) -> Self {
         let month: time::Month = month.get().try_into().expect("valid month");
         let date = time::Date::from_calendar_date(year, month, day).expect("valid ymd");
-        let time = time_from_hmfs(hour, minute, second);
+        let time = time_from_hms_nano(hour, minute, second, nanosecond);
         match offset {
             None => DateTime::Timestamp(date.with_time(time)),
             Some(o) => {
@@ -70,8 +72,14 @@ impl DateTime {
         }
     }
 
-    fn from_hmfs_offset(hour: u8, minute: u8, second: f64, offset: Option<UtcOffset>) -> Self {
-        let time = time_from_hmfs(hour, minute, second);
+    fn from_hms_nano_offset(
+        hour: u8,
+        minute: u8,
+        second: u8,
+        nanosecond: u32,
+        offset: Option<UtcOffset>,
+    ) -> Self {
+        let time = time_from_hms_nano(hour, minute, second, nanosecond);
         match offset {
             Some(offset) => DateTime::TimeWithTz(time, offset),
             None => DateTime::Time(time),
@@ -79,10 +87,8 @@ impl DateTime {
     }
 }
 
-fn time_from_hmfs(hour: u8, minute: u8, second: f64) -> time::Time {
-    let millis = (second.fract() * 1e9) as u32;
-    let second = second.trunc() as u8;
-    time::Time::from_hms_nano(hour, minute, second, millis).expect("valid time value")
+fn time_from_hms_nano(hour: u8, minute: u8, second: u8, nanosecond: u32) -> time::Time {
+    time::Time::from_hms_nano(hour, minute, second, nanosecond).expect("valid time value")
 }
 
 impl Debug for DateTime {

--- a/partiql-value/src/ion.rs
+++ b/partiql-value/src/ion.rs
@@ -199,14 +199,16 @@ fn parse_time(reader: &mut Reader) -> DateTime {
 
 fn parse_datetime(reader: &mut Reader) -> DateTime {
     let ts = reader.read_timestamp().unwrap();
+    let offset = ts.offset();
     // TODO: fractional seconds Cf. https://github.com/amazon-ion/ion-rust/pull/482#issuecomment-1470615286
-    DateTime::from_ymdhms(
+    DateTime::from_ymdhms_offset_minutes(
         ts.year(),
         NonZeroU8::new(ts.month() as u8).unwrap(),
         ts.day() as u8,
         ts.hour() as u8,
         ts.minute() as u8,
         ts.second() as f64,
+        offset,
     )
 }
 

--- a/partiql-value/src/ion.rs
+++ b/partiql-value/src/ion.rs
@@ -188,10 +188,11 @@ fn parse_time(reader: &mut Reader) -> DateTime {
     }
     reader.step_out().expect("step out of struct");
 
-    DateTime::from_hmfs_tz(
+    DateTime::from_hms_nano_tz(
         time.hour.expect("hour"),
         time.minute.expect("minute"),
-        time.second.expect("second"),
+        time.second.expect("second").trunc() as u8,
+        time.second.expect("second").fract() as u32,
         time.tz_hour,
         time.tz_minute,
     )
@@ -200,14 +201,14 @@ fn parse_time(reader: &mut Reader) -> DateTime {
 fn parse_datetime(reader: &mut Reader) -> DateTime {
     let ts = reader.read_timestamp().unwrap();
     let offset = ts.offset();
-    // TODO: fractional seconds Cf. https://github.com/amazon-ion/ion-rust/pull/482#issuecomment-1470615286
-    DateTime::from_ymdhms_offset_minutes(
+    DateTime::from_ymdhms_nano_offset_minutes(
         ts.year(),
         NonZeroU8::new(ts.month() as u8).unwrap(),
         ts.day() as u8,
         ts.hour() as u8,
         ts.minute() as u8,
-        ts.second() as f64,
+        ts.second() as u8,
+        ts.nanoseconds(),
         offset,
     )
 }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -839,11 +839,32 @@ impl From<i32> for Value {
     }
 }
 
+impl From<i16> for Value {
+    #[inline]
+    fn from(n: i16) -> Self {
+        (n as i64).into()
+    }
+}
+
+impl From<i8> for Value {
+    #[inline]
+    fn from(n: i8) -> Self {
+        (n as i64).into()
+    }
+}
+
 impl From<usize> for Value {
     #[inline]
     fn from(n: usize) -> Self {
         // TODO overflow to bigint/decimal
         Value::Integer(n as i64)
+    }
+}
+
+impl From<u8> for Value {
+    #[inline]
+    fn from(n: u8) -> Self {
+        (n as usize).into()
     }
 }
 


### PR DESCRIPTION
Implements `EXTRACT` builtin function and updates to the latest `partiql-tests`. Also fixes some parsing of the datetime part for `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`. Makes the following assumptions:
- `EXTRACT` with a date component (year, month, day) on a time -> returns missing
- `EXTRACT` with a time component (hour, minute, second) -> returns missing
- a timezone part (timezone_hour, timezone_minute) with a datetime value without a timezone?

All of the above assumptions aren't specified in any SQL spec to my knowledge. The second assumption differs from what `partiql-lang-kotlin` currently does (which defines a default of `0`). Created a spec issue to track: https://github.com/partiql/partiql-spec/issues/53 along with a conformance test issue: https://github.com/partiql/partiql-tests/issues/83.

Another point that may differ from `partiql-lang-kotlin` is the data type returned by the `EXTRACT` function. `partiql-lang-kotlin` always returns a decimal, while this PR returns a decimal for seconds and integer otherwise. The SQL spec says that this is implementation-defined. Add a followup comment in the above spec issue: https://github.com/partiql/partiql-spec/issues/53#issuecomment-1511949884

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
