### PR TITLE
Fix parsing of EXTRACT to allow keywords after the FROM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fix parsing of `EXTRACT` datetime parts `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`
 - Fix logical plan to eval plan conversion for `EvalOrderBySortSpec` with arguments `DESC` and `NULLS LAST`
+- Fix parsing of `EXTRACT` to allow keywords after the `FROM`
 
 ## [0.3.0] - 2023-04-11
 ### Changed


### PR DESCRIPTION
Fixes #343.

`TIME WITH TIME ZONE` literal values can be parsed normally but when within an `EXTRACT` function call, the parser gives an error:

```
parse: ParserError { text: "EXTRACT(HOUR FROM TIME WITH TIME ZONE '01:23:45.678') = 1", offsets: LineOffsetTracker { line_starts: [ByteOffset(0)] }, errors: [UnexpectedToken(Located { inner: UnexpectedTokenData { token: "FROM" }, location: Location { start: BytePosition(ByteOffset(13)), end: BytePosition(ByteOffset(17)) } })] }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
