### PR TITLE
Adds the COLL_* functions (COLL_AVG, COLL_COUNT, COLL_MAX, COLL_MIN, COLL_SUM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `partiql-extension-ion` extension for encoding/decoding `Value` to/from Ion data
 - Add `partiql-extension-ion-functions` extension which contains an extension function for reading from an Ion file
 - Add `partiql-catalog` including an experimental `Catalog` interface and implementation
+- Implements the `COLL_*` functions -- `COLL_AVG`, `COLL_COUNT`, `COLL_MAX`, `COLL_MIN`, `COLL_SUM`
 ### Fixes
 - Fix parsing of `EXTRACT` datetime parts `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`
 - Fix logical plan to eval plan conversion for `EvalOrderBySortSpec` with arguments `DESC` and `NULLS LAST`

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -1282,3 +1282,10 @@ impl EvalExpr for EvalSubQueryExpr {
         Cow::Owned(value)
     }
 }
+
+/// Indicates if a set should be reduced to its distinct elements or not.
+#[derive(Debug)]
+pub(crate) enum SetQuantifier {
+    All,
+    Distinct,
+}

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -1,4 +1,5 @@
 use crate::env::Bindings;
+use crate::eval::evaluable::SetQuantifier;
 use crate::eval::expr::pattern_match::like_to_re_pattern;
 use crate::eval::EvalContext;
 use itertools::Itertools;
@@ -1143,6 +1144,255 @@ impl EvalExpr for EvalFnExtractTimezoneMinute {
                 DateTime::Time(_) => Missing,
                 DateTime::Timestamp(_) => Missing,
             },
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents the `COLL_AVG` function, e.g. `COLL_AVG(DISTINCT [1, 2, 2, 3])`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCollAvg {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) elems: Box<dyn EvalExpr>,
+}
+
+#[inline]
+#[track_caller]
+fn coll_avg(elems: Vec<&Value>) -> Value {
+    if elems.is_empty() {
+        Null
+    } else {
+        let count = elems.len();
+        let mut sum = Value::from(0);
+        for e in elems {
+            if e.is_number() {
+                sum = &sum + e
+            } else {
+                return Missing;
+            }
+        }
+        &sum / &Value::Decimal(rust_decimal::Decimal::from(count))
+    }
+}
+
+impl EvalExpr for EvalFnCollAvg {
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let elems = self.elems.evaluate(bindings, ctx);
+        let result = match elems.borrow() {
+            Null => Null,
+            Value::List(l) => {
+                let l_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => l.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => l
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_avg(l_nums)
+            }
+            Value::Bag(b) => {
+                let b_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => b.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => b
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_avg(b_nums)
+            }
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents the `COLL_COUNT` function, e.g. `COLL_COUNT(DISTINCT [1, 2, 2, 3])`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCollCount {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) elems: Box<dyn EvalExpr>,
+}
+
+impl EvalExpr for EvalFnCollCount {
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let elems = self.elems.evaluate(bindings, ctx);
+        let result = match elems.borrow() {
+            Null => Null,
+            Value::List(l) => {
+                let l_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => l.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => l
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                Value::from(l_nums.len())
+            }
+            Value::Bag(b) => {
+                let b_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => b.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => b
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                Value::from(b_nums.len())
+            }
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents the `COLL_MAX` function, e.g. `COLL_MAX(DISTINCT [1, 2, 2, 3])`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCollMax {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) elems: Box<dyn EvalExpr>,
+}
+
+#[inline]
+#[track_caller]
+fn coll_max(elems: Vec<&Value>) -> Value {
+    elems.into_iter().max().unwrap_or(&Null).to_owned()
+}
+
+impl EvalExpr for EvalFnCollMax {
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let elems = self.elems.evaluate(bindings, ctx);
+        let result = match elems.borrow() {
+            Null => Null,
+            Value::List(l) => {
+                let l_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => l.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => l
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_max(l_nums)
+            }
+            Value::Bag(b) => {
+                let b_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => b.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => b
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_max(b_nums)
+            }
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents the `COLL_MIN` function, e.g. `COLL_MIN(DISTINCT [1, 2, 2, 3])`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCollMin {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) elems: Box<dyn EvalExpr>,
+}
+
+#[inline]
+#[track_caller]
+fn coll_min(elems: Vec<&Value>) -> Value {
+    elems.into_iter().min().unwrap_or(&Null).to_owned()
+}
+
+impl EvalExpr for EvalFnCollMin {
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let elems = self.elems.evaluate(bindings, ctx);
+        let result = match elems.borrow() {
+            Null => Null,
+            Value::List(l) => {
+                let l_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => l.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => l
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_min(l_nums)
+            }
+            Value::Bag(b) => {
+                let b_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => b.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => b
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_min(b_nums)
+            }
+            _ => Missing,
+        };
+        Cow::Owned(result)
+    }
+}
+
+/// Represents the `COLL_SUM` function, e.g. `COLL_SUM(DISTINCT [1, 2, 2, 3])`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCollSum {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) elems: Box<dyn EvalExpr>,
+}
+
+#[inline]
+#[track_caller]
+fn coll_sum(elems: Vec<&Value>) -> Value {
+    if elems.is_empty() {
+        Null
+    } else {
+        let mut sum = Value::from(0);
+        for e in elems {
+            if e.is_number() {
+                sum = &sum + e
+            } else {
+                return Missing;
+            }
+        }
+        sum
+    }
+}
+
+impl EvalExpr for EvalFnCollSum {
+    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        let elems = self.elems.evaluate(bindings, ctx);
+        let result = match elems.borrow() {
+            Null => Null,
+            Value::List(l) => {
+                let l_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => l.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => l
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_sum(l_nums)
+            }
+            Value::Bag(b) => {
+                let b_nums: Vec<&Value> = match self.setq {
+                    SetQuantifier::All => b.iter().filter(|&e| !e.is_null_or_missing()).collect(),
+                    SetQuantifier::Distinct => b
+                        .iter()
+                        .filter(|&e| !e.is_null_or_missing())
+                        .unique()
+                        .collect(),
+                };
+                coll_sum(b_nums)
+            }
             _ => Missing,
         };
         Cow::Owned(result)

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use partiql_logical as logical;
-use partiql_logical::ValueExpr;
+use partiql_logical::{SetQuantifier, ValueExpr};
 use partiql_value::Value;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -479,6 +479,182 @@ fn function_call_def_extract() -> CallDef {
     }
 }
 
+// ------------------------ COLL_AGG Functions ------------------------
+fn function_call_def_coll_avg() -> CallDef {
+    CallDef {
+        names: vec!["coll_avg"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAvg(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAvg(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAvg(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
+fn function_call_def_coll_count() -> CallDef {
+    CallDef {
+        names: vec!["coll_count"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollCount(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollCount(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollCount(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
+fn function_call_def_coll_max() -> CallDef {
+    CallDef {
+        names: vec!["coll_max"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMax(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMax(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMax(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
+fn function_call_def_coll_min() -> CallDef {
+    CallDef {
+        names: vec!["coll_min"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMin(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMin(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollMin(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
+fn function_call_def_coll_sum() -> CallDef {
+    CallDef {
+        names: vec!["coll_sum"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollSum(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollSum(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollSum(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
 pub(crate) static FN_SYM_TAB: Lazy<FnSymTab> = Lazy::new(function_call_def);
 
 /// Function symbol table
@@ -517,6 +693,11 @@ pub fn function_call_def() -> FnSymTab {
         function_call_def_mod(),
         function_call_def_cardinality(),
         function_call_def_extract(),
+        function_call_def_coll_avg(),
+        function_call_def_coll_count(),
+        function_call_def_coll_max(),
+        function_call_def_coll_min(),
+        function_call_def_coll_sum(),
     ] {
         assert!(!def.names.is_empty());
         let primary = def.names[0];

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -659,6 +659,11 @@ pub enum CallName {
     ExtractSecond,
     ExtractTimezoneHour,
     ExtractTimezoneMinute,
+    CollAvg(SetQuantifier),
+    CollCount(SetQuantifier),
+    CollMax(SetQuantifier),
+    CollMin(SetQuantifier),
+    CollSum(SetQuantifier),
     ByName(String),
 }
 

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -69,7 +69,7 @@ impl<'input> Default for ParserState<'input, NodeIdGenerator> {
 
 // TODO: currently needs to be manually kept in-sync with preprocessor's `built_in_aggs`
 // TODO: make extensible
-const KNOWN_AGGREGATES: &str = "(?i:count)|(?i:avg)|(?i:min)|(?i:max)|(?i:sum)";
+const KNOWN_AGGREGATES: &str = "(?i:^count$)|(?i:^avg$)|(?i:^min$)|(?i:^max$)|(?i:^sum$)";
 static KNOWN_AGGREGATE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(KNOWN_AGGREGATES).unwrap());
 
 impl<'input, I> ParserState<'input, I>


### PR DESCRIPTION
Implements the `COLL_` functions (`COLL_AVG`, `COLL_COUNT`, `COLL_MAX`, `COLL_MIN`, `COLL_SUM`). Also
- Fixes slight bug in the aggregation function regex
- Upgrades lalrpop to latest version to get rid of warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
