### PR TITLE
Add SQL aggregates ANY, SOME, EVERY and their COLL_ versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
 - partiql-parser set quantifier for bag operators fixed to `DISTINCT`
 - partiql-parser set quantifier for bag operators fixed to be `DISTINCT` when unspecified
+- partiql-logical-planner add error for when a `HAVING` is included without `GROUP BY`
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `partiql_ast_passes::static_typer` for type annotating the AST.
 - Add ability to parse `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
 - Add `OUTER` bag operator (`OUTER UNION`, `OUTER INTERSECT`, `OUTER EXCEPT`) implementation
+- Implements the aggregation functions `ANY`, `SOME`, `EVERY` and their `COLL_` versions
 
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.

--- a/partiql-ast-passes/src/error.rs
+++ b/partiql-ast-passes/src/error.rs
@@ -38,6 +38,10 @@ pub enum AstTransformError {
     /// Any other lowering error.
     #[error("Lowering error: {0}")]
     Unknown(String),
+
+    /// Indicates that a `HAVING` clause was provided without a `GROUP BY`
+    #[error("HAVING clause provided without GROUP BY")]
+    HavingWithoutGroupBy,
 }
 
 impl From<CallLookupError> for AstTransformError {

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -24,8 +24,6 @@ pub(crate) fn subsumes(typ: &PartiqlType, value: &Value) -> bool {
         (_, Value::Missing) => true,
         (TypeKind::Any, _) => true,
         (TypeKind::AnyOf(anyof), val) => anyof.types().any(|typ| subsumes(typ, val)),
-        (TypeKind::Null, Value::Null) => true,
-        (TypeKind::Missing, Value::Missing) => true,
         (
             TypeKind::Int | TypeKind::Int8 | TypeKind::Int16 | TypeKind::Int32 | TypeKind::Int64,
             Value::Integer(_),
@@ -41,11 +39,7 @@ pub(crate) fn subsumes(typ: &PartiqlType, value: &Value) -> bool {
         (TypeKind::Bag(b_type), Value::Bag(b_values)) => {
             let bag_element_type = b_type.element_type.as_ref();
             let mut b_values = b_values.iter();
-            b_values.all(|b_value| {
-                println!("b_value: {:?}", b_value);
-                println!("bag_element_type: {:?}", bag_element_type);
-                subsumes(bag_element_type, b_value)
-            })
+            b_values.all(|b_value| subsumes(bag_element_type, b_value))
         }
         (TypeKind::DateTime, Value::DateTime(_)) => true,
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -13,9 +13,9 @@ use partiql_logical::{
 use crate::error::{ErrorNode, PlanErr, PlanningError};
 use crate::eval;
 use crate::eval::evaluable::{
-    Avg, Count, EvalGroupingStrategy, EvalJoinKind, EvalOrderBy, EvalOrderBySortCondition,
+    Any, Avg, Count, EvalGroupingStrategy, EvalJoinKind, EvalOrderBy, EvalOrderBySortCondition,
     EvalOrderBySortSpec, EvalOuterExcept, EvalOuterIntersect, EvalOuterUnion, EvalSubQueryExpr,
-    Evaluable, Max, Min, Sum,
+    Evaluable, Every, Max, Min, Sum,
 };
 use crate::eval::expr::{
     BindError, BindEvalExpr, EvalBagExpr, EvalBetweenExpr, EvalCollFn, EvalDynamicLookup, EvalExpr,
@@ -259,6 +259,12 @@ impl<'c> EvaluatorPlanner<'c> {
                             (AggFunc::AggSum, logical::SetQuantifier::All) => {
                                 eval::evaluable::AggFunc::Sum(Sum::new_all())
                             }
+                            (AggFunc::AggAny, logical::SetQuantifier::All) => {
+                                eval::evaluable::AggFunc::Any(Any::new_all())
+                            }
+                            (AggFunc::AggEvery, logical::SetQuantifier::All) => {
+                                eval::evaluable::AggFunc::Every(Every::new_all())
+                            }
                             (AggFunc::AggAvg, logical::SetQuantifier::Distinct) => {
                                 eval::evaluable::AggFunc::Avg(Avg::new_distinct())
                             }
@@ -273,6 +279,12 @@ impl<'c> EvaluatorPlanner<'c> {
                             }
                             (AggFunc::AggSum, logical::SetQuantifier::Distinct) => {
                                 eval::evaluable::AggFunc::Sum(Sum::new_distinct())
+                            }
+                            (AggFunc::AggAny, logical::SetQuantifier::Distinct) => {
+                                eval::evaluable::AggFunc::Any(Any::new_distinct())
+                            }
+                            (AggFunc::AggEvery, logical::SetQuantifier::Distinct) => {
+                                eval::evaluable::AggFunc::Every(Every::new_distinct())
                             }
                         };
                         eval::evaluable::AggregateExpression {
@@ -714,6 +726,14 @@ impl<'c> EvaluatorPlanner<'c> {
                     CallName::CollSum(setq) => (
                         "coll_sum",
                         EvalCollFn::Sum(setq.into()).bind::<{ STRICT }>(args),
+                    ),
+                    CallName::CollAny(setq) => (
+                        "coll_any",
+                        EvalCollFn::Any(setq.into()).bind::<{ STRICT }>(args),
+                    ),
+                    CallName::CollEvery(setq) => (
+                        "coll_every",
+                        EvalCollFn::Every(setq.into()).bind::<{ STRICT }>(args),
                     ),
                     CallName::ByName(name) => match self.catalog.get_function(name) {
                         None => {

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -655,6 +655,76 @@ fn function_call_def_coll_sum() -> CallDef {
     }
 }
 
+fn function_call_def_coll_any() -> CallDef {
+    CallDef {
+        names: vec!["coll_any", "coll_some"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAny(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAny(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollAny(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
+fn function_call_def_coll_every() -> CallDef {
+    CallDef {
+        names: vec!["coll_every"],
+        overloads: vec![
+            CallSpec {
+                input: vec![CallSpecArg::Positional],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollEvery(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("all".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollEvery(SetQuantifier::All),
+                        arguments: args,
+                    })
+                }),
+            },
+            CallSpec {
+                input: vec![CallSpecArg::Named("distinct".into())],
+                output: Box::new(|args| {
+                    logical::ValueExpr::Call(logical::CallExpr {
+                        name: logical::CallName::CollEvery(SetQuantifier::Distinct),
+                        arguments: args,
+                    })
+                }),
+            },
+        ],
+    }
+}
+
 pub(crate) static FN_SYM_TAB: Lazy<FnSymTab> = Lazy::new(function_call_def);
 
 /// Function symbol table
@@ -698,6 +768,8 @@ pub fn function_call_def() -> FnSymTab {
         function_call_def_coll_max(),
         function_call_def_coll_min(),
         function_call_def_coll_sum(),
+        function_call_def_coll_any(),
+        function_call_def_coll_every(),
     ] {
         assert!(!def.names.is_empty());
         let primary = def.names[0];

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -707,8 +707,13 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         Traverse::Continue
     }
 
-    fn enter_select(&mut self, _select: &'ast Select) -> Traverse {
-        Traverse::Continue
+    fn enter_select(&mut self, select: &'ast Select) -> Traverse {
+        if select.having.is_some() && select.group_by.is_none() {
+            self.errors.push(AstTransformError::HavingWithoutGroupBy);
+            Traverse::Stop
+        } else {
+            Traverse::Continue
+        }
     }
 
     fn exit_select(&mut self, _select: &'ast Select) -> Traverse {

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -34,7 +34,7 @@ use partiql_ast_passes::error::{AstTransformError, AstTransformationError};
 use partiql_catalog::Catalog;
 use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
 use partiql_extension_ion::Encoding;
-use partiql_logical::AggFunc::{AggAvg, AggCount, AggMax, AggMin, AggSum};
+use partiql_logical::AggFunc::{AggAny, AggAvg, AggCount, AggEvery, AggMax, AggMin, AggSum};
 use std::sync::atomic::{AtomicU32, Ordering};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
@@ -1170,6 +1170,18 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                 name: new_name,
                 expr: arg,
                 func: AggSum,
+                setq,
+            },
+            "any" | "some" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggAny,
+                setq,
+            },
+            "every" => AggregateExpression {
+                name: new_name,
+                expr: arg,
+                func: AggEvery,
                 setq,
             },
             _ => {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -359,6 +359,10 @@ pub enum AggFunc {
     AggMin,
     /// Represents SQL's `SUM` aggregation function
     AggSum,
+    /// Represents SQL's `ANY`/`SOME` aggregation function
+    AggAny,
+    /// Represents SQL's `EVERY` aggregation function
+    AggEvery,
 }
 
 /// Represents `GROUP BY` <strategy> <group_key>[, <group_key>] ... \[AS <as_alias>\]
@@ -684,6 +688,8 @@ pub enum CallName {
     CollMax(SetQuantifier),
     CollMin(SetQuantifier),
     CollSum(SetQuantifier),
+    CollAny(SetQuantifier),
+    CollEvery(SetQuantifier),
     ByName(String),
 }
 

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -69,7 +69,8 @@ impl<'input> Default for ParserState<'input, NodeIdGenerator> {
 
 // TODO: currently needs to be manually kept in-sync with preprocessor's `built_in_aggs`
 // TODO: make extensible
-const KNOWN_AGGREGATES: &str = "(?i:^count$)|(?i:^avg$)|(?i:^min$)|(?i:^max$)|(?i:^sum$)";
+const KNOWN_AGGREGATES: &str =
+    "(?i:^count$)|(?i:^avg$)|(?i:^min$)|(?i:^max$)|(?i:^sum$)|(?i:^any$)|(?i:^some$)|(?i:^every$)";
 static KNOWN_AGGREGATE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(KNOWN_AGGREGATES).unwrap());
 
 impl<'input, I> ParserState<'input, I>

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -132,7 +132,7 @@ mod built_ins {
     pub(crate) fn built_in_aggs() -> FnExpr<'static> {
         FnExpr {
             // TODO: currently needs to be manually kept in-sync with parsers's `KNOWN_AGGREGATES`
-            fn_names: vec!["count", "avg", "min", "max", "sum"],
+            fn_names: vec!["count", "avg", "min", "max", "sum", "any", "some", "every"],
             #[rustfmt::skip]
             patterns: vec![
                 // e.g., count(all x) => count("all": x)

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -363,7 +363,7 @@ pub enum StructConstraint {
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 #[allow(dead_code)]
 pub struct BagType {
-    element_type: Box<PartiqlType>,
+    pub element_type: Box<PartiqlType>,
     constraints: Vec<CollectionConstraint>,
 }
 
@@ -385,7 +385,7 @@ impl BagType {
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 #[allow(dead_code)]
 pub struct ArrayType {
-    element_type: Box<PartiqlType>,
+    pub element_type: Box<PartiqlType>,
     constraints: Vec<CollectionConstraint>,
 }
 


### PR DESCRIPTION
Adds the SQL aggregate functions `ANY`, `SOME`, and `EVERY` along with their `COLL_` versions (i.e. `COLL_ANY`, `COLL_SOME`, `COLL_EVERY`). 

This PR also
- fixes a slight bug related to the previously implemented SQL aggregates when an aggregation result is `NULL` or `MISSING`.
- closes #419 with some fixes to the strict mode type checking behavior of the `COLL_` functions.
- adds a check to logical plan lowering for `HAVING` without `GROUP BY`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
