### PR TITLE
Change `lower` to return `Result` rather than `panic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *BREAKING:* partiql-eval: modifies visibility of types implementing `EvalExpr` and `Evaluable`
 - *BREAKING:* removed `from_ion` method on `Value`
+- *BREAKING:* partiql-ast: `visit` fn returns a `partiql-ast::Recurse` type to indicate if visitation of children nodes should continue
+- *BREAKING:* partiql-logical-planner: modifies `lower(parsed: &Parsed)` to return a Result type of `Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError>` rather than a `logical::LogicalPlan<logical::BindingsOp>`
+  - This is part of an effort to replace `panic`s with `Result`s
 ### Added
 - Implements built-in function `EXTRACT`
 - Add `partiql-extension-ion` extension for encoding/decoding `Value` to/from Ion data

--- a/partiql-ast/partiql-ast-macros/src/lib.rs
+++ b/partiql-ast/partiql-ast-macros/src/lib.rs
@@ -63,12 +63,12 @@ fn impl_visit(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
     let ast_name = &ast.ident;
     quote! {
         impl crate::visit::Visit for #ast_name {
-            fn visit<'v, V>(&'v self, v: &mut V) -> crate::visit::Recurse
+            fn visit<'v, V>(&'v self, v: &mut V) -> crate::visit::Traverse
             where
                 V: crate::visit::Visitor<'v>,
             {
-                if v.#enter_fn_name(self) == crate::visit::Recurse::Stop {
-                    return crate::visit::Recurse::Stop
+                if v.#enter_fn_name(self) == crate::visit::Traverse::Stop {
+                    return crate::visit::Traverse::Stop
                 }
                 #visit_children
                 v.#exit_fn_name(self)
@@ -91,7 +91,7 @@ fn impl_visit_children(ast: &&DeriveInput) -> TokenStream {
             let non_exhaustive = variants.len() < e.variants.len();
             let else_clause = non_exhaustive.then(|| {
                 quote! {
-                    _ => crate::visit::Recurse::Continue
+                    _ => crate::visit::Traverse::Continue
                 }
             });
 
@@ -99,8 +99,8 @@ fn impl_visit_children(ast: &&DeriveInput) -> TokenStream {
                 if match &self {
                     #(#enum_name::#variants(child) => child.visit(v),)*
                     #else_clause
-                } == crate::visit::Recurse::Stop {
-                    return crate::visit::Recurse::Stop
+                } == crate::visit::Traverse::Stop {
+                    return crate::visit::Traverse::Stop
                 }
             }
         }
@@ -132,8 +132,8 @@ fn impl_visit_children(ast: &&DeriveInput) -> TokenStream {
                 Fields::Unit => vec![],
             };
             quote! {
-                #(if self.#fields.visit(v) == crate::visit::Recurse::Stop {
-                    return crate::visit::Recurse::Stop
+                #(if self.#fields.visit(v) == crate::visit::Traverse::Stop {
+                    return crate::visit::Traverse::Stop
                 })*
             }
         }

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -29,7 +29,7 @@ pub struct AstNode<T> {
     pub node: T,
 }
 
-#[derive(Visit, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Item {
     // Data Definition Language statements

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -29,7 +29,7 @@ pub struct AstNode<T> {
     pub node: T,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Item {
     // Data Definition Language statements

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -688,7 +688,7 @@ mod tests {
         let mut acc = Accum::default();
 
         use super::Visit;
-        ast.visit(&mut acc);
+        ast.visit(&mut acc).expect("Expect no error to occur");
 
         let val = acc.val;
         assert!(matches!(val, Some(2989)));

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -2,7 +2,7 @@ use crate::ast;
 use crate::ast::NodeId;
 
 pub trait Visit {
-    fn visit<'ast, V>(&'ast self, _: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
         V: Visitor<'ast>;
 }
@@ -11,13 +11,13 @@ impl<T> Visit for ast::AstNode<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
-        V: Visitor<'ast>,
+        V: Visitor<'ast>
     {
-        v.enter_ast_node(self.id);
-        self.node.visit(v);
-        v.exit_ast_node(self.id);
+        v.enter_ast_node(self.id)?;
+        self.node.visit(v)?;
+        v.exit_ast_node(self.id)
     }
 }
 
@@ -25,7 +25,7 @@ impl<T> Visit for &T
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
         V: Visitor<'ast>,
     {
@@ -37,7 +37,7 @@ impl<T> Visit for Box<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
         V: Visitor<'ast>,
     {
@@ -49,13 +49,14 @@ impl<T> Visit for Option<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
         V: Visitor<'ast>,
     {
         if let Some(inner) = self {
-            inner.visit(v)
+            inner.visit(v)?
         }
+        Ok(())
     }
 }
 
@@ -63,163 +64,162 @@ impl<T> Visit for Vec<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V)
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
         V: Visitor<'ast>,
     {
         for i in self {
-            i.visit(v)
+            i.visit(v)?
         }
+        Ok(())
     }
 }
 
 pub trait Visitor<'ast> {
-    fn enter_ast_node(&mut self, _id: NodeId) {}
-    fn exit_ast_node(&mut self, _id: NodeId) {}
+    type Error;
 
-    fn enter_item(&mut self, _item: &'ast ast::Item) {}
-    fn exit_item(&mut self, _item: &'ast ast::Item) {}
-
-    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) {}
-    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) {}
-    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) {}
-    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) {}
-    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) {}
-    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) {}
-    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) {}
-    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) {}
-    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) {}
-    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) {}
-    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) {}
-    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) {}
-
-    fn enter_dml(&mut self, _dml: &'ast ast::Dml) {}
-    fn exit_dml(&mut self, _dml: &'ast ast::Dml) {}
-    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) {}
-    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) {}
-    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) {}
-    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) {}
-    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) {}
-    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) {}
-    fn enter_insert(&mut self, _insert: &'ast ast::Insert) {}
-    fn exit_insert(&mut self, _insert: &'ast ast::Insert) {}
-    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) {}
-    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) {}
-    fn enter_set(&mut self, _set: &'ast ast::Set) {}
-    fn exit_set(&mut self, _set: &'ast ast::Set) {}
-    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) {}
-    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) {}
-    fn enter_remove(&mut self, _remove: &'ast ast::Remove) {}
-    fn exit_remove(&mut self, _remove: &'ast ast::Remove) {}
-    fn enter_delete(&mut self, _delete: &'ast ast::Delete) {}
-    fn exit_delete(&mut self, _delete: &'ast ast::Delete) {}
-    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) {}
-    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) {}
-
-    fn enter_query(&mut self, _query: &'ast ast::Query) {}
-    fn exit_query(&mut self, _query: &'ast ast::Query) {}
-    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) {}
-    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) {}
-    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) {}
-    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) {}
-    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) {}
-    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) {}
-    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) {}
-    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) {}
-    fn enter_select(&mut self, _select: &'ast ast::Select) {}
-    fn exit_select(&mut self, _select: &'ast ast::Select) {}
-    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) {}
-    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) {}
-    fn enter_projection(&mut self, _projection: &'ast ast::Projection) {}
-    fn exit_projection(&mut self, _projection: &'ast ast::Projection) {}
-    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) {}
-    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) {}
-    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) {}
-    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) {}
-    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) {}
-    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) {}
-    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) {}
-    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) {}
-    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) {}
-    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) {}
-    fn enter_expr(&mut self, _expr: &'ast ast::Expr) {}
-    fn exit_expr(&mut self, _expr: &'ast ast::Expr) {}
-    fn enter_lit(&mut self, _lit: &'ast ast::Lit) {}
-    fn exit_lit(&mut self, _lit: &'ast ast::Lit) {}
-    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) {}
-    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) {}
-    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) {}
-    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) {}
-    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) {}
-    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) {}
-    fn enter_like(&mut self, _like: &'ast ast::Like) {}
-    fn exit_like(&mut self, _like: &'ast ast::Like) {}
-    fn enter_between(&mut self, _between: &'ast ast::Between) {}
-    fn exit_between(&mut self, _between: &'ast ast::Between) {}
-    fn enter_in(&mut self, _in: &'ast ast::In) {}
-    fn exit_in(&mut self, _in: &'ast ast::In) {}
-    fn enter_case(&mut self, _case: &'ast ast::Case) {}
-    fn exit_case(&mut self, _case: &'ast ast::Case) {}
-    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) {}
-    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) {}
-    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) {}
-    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) {}
-    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) {}
-    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) {}
-    fn enter_struct(&mut self, _struct: &'ast ast::Struct) {}
-    fn exit_struct(&mut self, _struct: &'ast ast::Struct) {}
-    fn enter_bag(&mut self, _bag: &'ast ast::Bag) {}
-    fn exit_bag(&mut self, _bag: &'ast ast::Bag) {}
-    fn enter_list(&mut self, _list: &'ast ast::List) {}
-    fn exit_list(&mut self, _list: &'ast ast::List) {}
-    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) {}
-    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) {}
-    fn enter_call(&mut self, _call: &'ast ast::Call) {}
-    fn exit_call(&mut self, _call: &'ast ast::Call) {}
-    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) {}
-    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) {}
-    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) {}
-    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) {}
-    fn enter_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) {}
-    fn exit_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) {}
-    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) {}
-    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) {}
-    fn enter_path(&mut self, _path: &'ast ast::Path) {}
-    fn exit_path(&mut self, _path: &'ast ast::Path) {}
-    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) {}
-    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) {}
-    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) {}
-    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) {}
-    fn enter_let(&mut self, _let: &'ast ast::Let) {}
-    fn exit_let(&mut self, _let: &'ast ast::Let) {}
-    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) {}
-    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) {}
-    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) {}
-    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) {}
-    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) {}
-    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) {}
-    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) {}
-    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) {}
-    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) {}
-    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) {}
-    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) {}
-    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) {}
-    fn enter_join(&mut self, _join: &'ast ast::Join) {}
-    fn exit_join(&mut self, _join: &'ast ast::Join) {}
-    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) {}
-    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) {}
-    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) {}
-    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) {}
-    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) {}
-    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) {}
-    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) {}
-    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) {}
-    fn enter_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) {}
-    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) {}
-    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) {}
-    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) {}
-    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) {}
-    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) {}
+    fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> { Ok(()) }
+    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> { Ok(()) }
 }
 
 #[cfg(test)]
@@ -237,6 +237,12 @@ mod tests {
         }
 
         impl<'ast> Visitor<'ast> for Accum {
+            type Error = ();
+
+            fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
+                todo!()
+            }
+
             fn enter_lit(&mut self, literal: &'ast Lit) {
                 match literal {
                     Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -1,17 +1,17 @@
 use crate::ast;
 use crate::ast::NodeId;
 
-/// Indicates if children nodes should be visited
+/// Indicates if tree traversal of the entire tree should continue or not.
 #[derive(PartialEq, Debug)]
-pub enum Recurse {
-    /// Signals visiting children nodes should continue
+pub enum Traverse {
+    /// Signals tree traversal of entire tree should continue.
     Continue,
-    /// Signals visiting children nodes should stop
+    /// Signals tree traversal of entire tree should stop.
     Stop,
 }
 
 pub trait Visit {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>;
 }
@@ -20,15 +20,15 @@ impl<T> Visit for ast::AstNode<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>,
     {
-        if v.enter_ast_node(self.id) == Recurse::Stop {
-            return Recurse::Stop;
+        if v.enter_ast_node(self.id) == Traverse::Stop {
+            return Traverse::Stop;
         }
-        if self.node.visit(v) == Recurse::Stop {
-            return Recurse::Stop;
+        if self.node.visit(v) == Traverse::Stop {
+            return Traverse::Stop;
         }
         v.exit_ast_node(self.id)
     }
@@ -38,7 +38,7 @@ impl<T> Visit for &T
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>,
     {
@@ -50,7 +50,7 @@ impl<T> Visit for Box<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>,
     {
@@ -62,16 +62,16 @@ impl<T> Visit for Option<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>,
     {
         if let Some(inner) = self {
-            if inner.visit(v) == Recurse::Stop {
-                return Recurse::Stop;
+            if inner.visit(v) == Traverse::Stop {
+                return Traverse::Stop;
             }
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 }
 
@@ -79,461 +79,464 @@ impl<T> Visit for Vec<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Traverse
     where
         V: Visitor<'ast>,
     {
         for i in self {
-            if i.visit(v) == Recurse::Stop {
-                return Recurse::Stop;
+            if i.visit(v) == Traverse::Stop {
+                return Traverse::Stop;
             }
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 }
 
 pub trait Visitor<'ast> {
-    fn enter_ast_node(&mut self, _id: NodeId) -> Recurse {
-        Recurse::Continue
+    fn enter_ast_node(&mut self, _id: NodeId) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_ast_node(&mut self, _id: NodeId) -> Recurse {
-        Recurse::Continue
+    fn exit_ast_node(&mut self, _id: NodeId) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_item(&mut self, _item: &'ast ast::Item) -> Recurse {
-        Recurse::Continue
+    fn enter_item(&mut self, _item: &'ast ast::Item) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_item(&mut self, _item: &'ast ast::Item) -> Recurse {
-        Recurse::Continue
+    fn exit_item(&mut self, _item: &'ast ast::Item) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Recurse {
-        Recurse::Continue
+    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Recurse {
-        Recurse::Continue
+    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Recurse {
-        Recurse::Continue
+    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Recurse {
-        Recurse::Continue
+    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Recurse {
-        Recurse::Continue
+    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Recurse {
-        Recurse::Continue
+    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Recurse {
-        Recurse::Continue
+    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Recurse {
-        Recurse::Continue
+    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Recurse {
-        Recurse::Continue
+    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Recurse {
-        Recurse::Continue
+    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Recurse {
-        Recurse::Continue
+    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Recurse {
-        Recurse::Continue
+    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Recurse {
-        Recurse::Continue
+    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Recurse {
-        Recurse::Continue
+    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Recurse {
-        Recurse::Continue
+    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Recurse {
-        Recurse::Continue
+    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Recurse {
-        Recurse::Continue
+    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Recurse {
-        Recurse::Continue
+    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Recurse {
-        Recurse::Continue
+    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Recurse {
-        Recurse::Continue
+    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Recurse {
-        Recurse::Continue
+    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Recurse {
-        Recurse::Continue
+    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_set(&mut self, _set: &'ast ast::Set) -> Recurse {
-        Recurse::Continue
+    fn enter_set(&mut self, _set: &'ast ast::Set) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_set(&mut self, _set: &'ast ast::Set) -> Recurse {
-        Recurse::Continue
+    fn exit_set(&mut self, _set: &'ast ast::Set) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Recurse {
-        Recurse::Continue
+    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Recurse {
-        Recurse::Continue
+    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Recurse {
-        Recurse::Continue
+    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Recurse {
-        Recurse::Continue
+    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Recurse {
-        Recurse::Continue
+    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Recurse {
-        Recurse::Continue
+    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Recurse {
-        Recurse::Continue
+    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Recurse {
-        Recurse::Continue
+    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_query(&mut self, _query: &'ast ast::Query) -> Recurse {
-        Recurse::Continue
+    fn enter_query(&mut self, _query: &'ast ast::Query) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_query(&mut self, _query: &'ast ast::Query) -> Recurse {
-        Recurse::Continue
+    fn exit_query(&mut self, _query: &'ast ast::Query) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Recurse {
-        Recurse::Continue
+    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Recurse {
-        Recurse::Continue
+    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Recurse {
-        Recurse::Continue
+    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Recurse {
-        Recurse::Continue
+    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Recurse {
-        Recurse::Continue
+    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Recurse {
-        Recurse::Continue
+    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_select(&mut self, _select: &'ast ast::Select) -> Recurse {
-        Recurse::Continue
+    fn enter_select(&mut self, _select: &'ast ast::Select) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_select(&mut self, _select: &'ast ast::Select) -> Recurse {
-        Recurse::Continue
+    fn exit_select(&mut self, _select: &'ast ast::Select) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Recurse {
-        Recurse::Continue
+    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Recurse {
-        Recurse::Continue
+    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Recurse {
-        Recurse::Continue
+    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Recurse {
-        Recurse::Continue
+    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Recurse {
-        Recurse::Continue
+    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Recurse {
-        Recurse::Continue
+    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Recurse {
-        Recurse::Continue
+    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Recurse {
-        Recurse::Continue
+    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Recurse {
-        Recurse::Continue
+    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Recurse {
-        Recurse::Continue
+    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Recurse {
-        Recurse::Continue
+    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Recurse {
-        Recurse::Continue
+    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Recurse {
-        Recurse::Continue
+    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Recurse {
-        Recurse::Continue
+    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Recurse {
-        Recurse::Continue
+    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Recurse {
-        Recurse::Continue
+    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Recurse {
-        Recurse::Continue
+    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Recurse {
-        Recurse::Continue
+    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Recurse {
-        Recurse::Continue
+    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Recurse {
-        Recurse::Continue
+    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Recurse {
-        Recurse::Continue
+    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Recurse {
-        Recurse::Continue
+    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_like(&mut self, _like: &'ast ast::Like) -> Recurse {
-        Recurse::Continue
+    fn enter_like(&mut self, _like: &'ast ast::Like) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_like(&mut self, _like: &'ast ast::Like) -> Recurse {
-        Recurse::Continue
+    fn exit_like(&mut self, _like: &'ast ast::Like) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_between(&mut self, _between: &'ast ast::Between) -> Recurse {
-        Recurse::Continue
+    fn enter_between(&mut self, _between: &'ast ast::Between) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_between(&mut self, _between: &'ast ast::Between) -> Recurse {
-        Recurse::Continue
+    fn exit_between(&mut self, _between: &'ast ast::Between) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_in(&mut self, _in: &'ast ast::In) -> Recurse {
-        Recurse::Continue
+    fn enter_in(&mut self, _in: &'ast ast::In) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_in(&mut self, _in: &'ast ast::In) -> Recurse {
-        Recurse::Continue
+    fn exit_in(&mut self, _in: &'ast ast::In) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_case(&mut self, _case: &'ast ast::Case) -> Recurse {
-        Recurse::Continue
+    fn enter_case(&mut self, _case: &'ast ast::Case) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_case(&mut self, _case: &'ast ast::Case) -> Recurse {
-        Recurse::Continue
+    fn exit_case(&mut self, _case: &'ast ast::Case) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Recurse {
-        Recurse::Continue
+    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Recurse {
-        Recurse::Continue
+    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Recurse {
-        Recurse::Continue
+    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Recurse {
-        Recurse::Continue
+    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Recurse {
-        Recurse::Continue
+    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Recurse {
-        Recurse::Continue
+    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Recurse {
-        Recurse::Continue
+    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Recurse {
-        Recurse::Continue
+    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Recurse {
-        Recurse::Continue
+    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Recurse {
-        Recurse::Continue
+    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_list(&mut self, _list: &'ast ast::List) -> Recurse {
-        Recurse::Continue
+    fn enter_list(&mut self, _list: &'ast ast::List) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_list(&mut self, _list: &'ast ast::List) -> Recurse {
-        Recurse::Continue
+    fn exit_list(&mut self, _list: &'ast ast::List) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Recurse {
-        Recurse::Continue
+    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Recurse {
-        Recurse::Continue
+    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_call(&mut self, _call: &'ast ast::Call) -> Recurse {
-        Recurse::Continue
+    fn enter_call(&mut self, _call: &'ast ast::Call) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_call(&mut self, _call: &'ast ast::Call) -> Recurse {
-        Recurse::Continue
+    fn exit_call(&mut self, _call: &'ast ast::Call) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Recurse {
-        Recurse::Continue
+    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Recurse {
-        Recurse::Continue
+    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Recurse {
-        Recurse::Continue
+    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Recurse {
-        Recurse::Continue
+    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Traverse {
+        Traverse::Continue
     }
     fn enter_call_arg_named_type(
         &mut self,
         _call_arg_named_type: &'ast ast::CallArgNamedType,
-    ) -> Recurse {
-        Recurse::Continue
+    ) -> Traverse {
+        Traverse::Continue
     }
     fn exit_call_arg_named_type(
         &mut self,
         _call_arg_named_type: &'ast ast::CallArgNamedType,
-    ) -> Recurse {
-        Recurse::Continue
+    ) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Recurse {
-        Recurse::Continue
+    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Recurse {
-        Recurse::Continue
+    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_path(&mut self, _path: &'ast ast::Path) -> Recurse {
-        Recurse::Continue
+    fn enter_path(&mut self, _path: &'ast ast::Path) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_path(&mut self, _path: &'ast ast::Path) -> Recurse {
-        Recurse::Continue
+    fn exit_path(&mut self, _path: &'ast ast::Path) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Recurse {
-        Recurse::Continue
+    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Recurse {
-        Recurse::Continue
+    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_let(&mut self, _let: &'ast ast::Let) -> Recurse {
-        Recurse::Continue
+    fn enter_let(&mut self, _let: &'ast ast::Let) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_let(&mut self, _let: &'ast ast::Let) -> Recurse {
-        Recurse::Continue
+    fn exit_let(&mut self, _let: &'ast ast::Let) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Recurse {
-        Recurse::Continue
+    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Recurse {
-        Recurse::Continue
+    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Recurse {
-        Recurse::Continue
+    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Recurse {
-        Recurse::Continue
+    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Recurse {
-        Recurse::Continue
+    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Recurse {
-        Recurse::Continue
+    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
-        Recurse::Continue
+    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
-        Recurse::Continue
+    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
-        Recurse::Continue
+    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
-        Recurse::Continue
+    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Recurse {
-        Recurse::Continue
+    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Recurse {
-        Recurse::Continue
+    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_join(&mut self, _join: &'ast ast::Join) -> Recurse {
-        Recurse::Continue
+    fn enter_join(&mut self, _join: &'ast ast::Join) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_join(&mut self, _join: &'ast ast::Join) -> Recurse {
-        Recurse::Continue
+    fn exit_join(&mut self, _join: &'ast ast::Join) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Recurse {
-        Recurse::Continue
+    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Recurse {
-        Recurse::Continue
+    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Recurse {
-        Recurse::Continue
+    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Recurse {
-        Recurse::Continue
+    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Traverse {
+        Traverse::Continue
     }
     fn enter_limit_offset_clause(
         &mut self,
         _limit_offset: &'ast ast::LimitOffsetClause,
-    ) -> Recurse {
-        Recurse::Continue
+    ) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Recurse {
-        Recurse::Continue
+    fn exit_limit_offset_clause(
+        &mut self,
+        _limit_offset: &'ast ast::LimitOffsetClause,
+    ) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Recurse {
-        Recurse::Continue
+    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Recurse {
-        Recurse::Continue
+    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Traverse {
+        Traverse::Continue
     }
-    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Recurse {
-        Recurse::Continue
+    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Traverse {
+        Traverse::Continue
     }
-    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Recurse {
-        Recurse::Continue
+    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Traverse {
+        Traverse::Continue
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::ast;
-    use crate::visit::{Recurse, Visitor};
+    use crate::visit::{Traverse, Visitor};
     use ast::{AstNode, BinOp, BinOpKind, Expr, Lit, NodeId};
     use std::ops::AddAssign;
 
@@ -545,7 +548,7 @@ mod tests {
         }
 
         impl<'ast> Visitor<'ast> for Accum {
-            fn enter_lit(&mut self, literal: &'ast Lit) -> Recurse {
+            fn enter_lit(&mut self, literal: &'ast Lit) -> Traverse {
                 match literal {
                     Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
                     Lit::Int16Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
@@ -553,7 +556,7 @@ mod tests {
                     Lit::Int64Lit(l) => self.val.get_or_insert(0i64).add_assign(l),
                     _ => {}
                 }
-                Recurse::Continue
+                Traverse::Continue
             }
         }
 
@@ -587,7 +590,7 @@ mod tests {
         let mut acc = Accum::default();
 
         use super::Visit;
-        assert_eq!(Recurse::Continue, ast.visit(&mut acc));
+        assert_eq!(Traverse::Continue, ast.visit(&mut acc));
 
         let val = acc.val;
         assert!(matches!(val, Some(2989)));

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -1,8 +1,14 @@
 use crate::ast;
 use crate::ast::NodeId;
 
+#[derive(PartialEq)]
+pub enum Recurse {
+    Continue,
+    Stop,
+}
+
 pub trait Visit {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>;
 }
@@ -11,12 +17,16 @@ impl<T> Visit for ast::AstNode<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>,
     {
-        v.enter_ast_node(self.id)?;
-        self.node.visit(v)?;
+        if v.enter_ast_node(self.id) == Recurse::Stop {
+            return Recurse::Stop;
+        }
+        if self.node.visit(v) == Recurse::Stop {
+            return Recurse::Stop;
+        }
         v.exit_ast_node(self.id)
     }
 }
@@ -25,7 +35,7 @@ impl<T> Visit for &T
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>,
     {
@@ -37,7 +47,7 @@ impl<T> Visit for Box<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>,
     {
@@ -49,14 +59,16 @@ impl<T> Visit for Option<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>,
     {
         if let Some(inner) = self {
-            inner.visit(v)?
+            if inner.visit(v) == Recurse::Stop {
+                return Recurse::Stop;
+            }
         }
-        Ok(())
+        Recurse::Continue
     }
 }
 
@@ -64,575 +76,461 @@ impl<T> Visit for Vec<T>
 where
     T: Visit,
 {
-    fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
+    fn visit<'ast, V>(&'ast self, v: &mut V) -> Recurse
     where
         V: Visitor<'ast>,
     {
         for i in self {
-            i.visit(v)?
+            if i.visit(v) == Recurse::Stop {
+                return Recurse::Stop;
+            }
         }
-        Ok(())
+        Recurse::Continue
     }
 }
 
 pub trait Visitor<'ast> {
-    type Error;
-
-    fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_ast_node(&mut self, _id: NodeId) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn enter_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn exit_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> {
-        Ok(())
-    }
-    fn enter_create_table(
-        &mut self,
-        _create_table: &'ast ast::CreateTable,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_ast_node(&mut self, _id: NodeId) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_create_table(
-        &mut self,
-        _create_table: &'ast ast::CreateTable,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_item(&mut self, _item: &'ast ast::Item) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_item(&mut self, _item: &'ast ast::Item) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_create_index(
-        &mut self,
-        _create_index: &'ast ast::CreateIndex,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_create_index(
-        &mut self,
-        _create_index: &'ast ast::CreateIndex,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_returning_expr(
-        &mut self,
-        _returning_expr: &'ast ast::ReturningExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_returning_expr(
-        &mut self,
-        _returning_expr: &'ast ast::ReturningExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_returning_elem(
-        &mut self,
-        _returning_elem: &'ast ast::ReturningElem,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_returning_elem(
-        &mut self,
-        _returning_elem: &'ast ast::ReturningElem,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_insert_value(
-        &mut self,
-        _insert_value: &'ast ast::InsertValue,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_insert_value(
-        &mut self,
-        _insert_value: &'ast ast::InsertValue,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_set(&mut self, _set: &'ast ast::Set) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_on_conflict(
-        &mut self,
-        _on_conflict: &'ast ast::OnConflict,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_set(&mut self, _set: &'ast ast::Set) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_query(&mut self, _query: &'ast ast::Query) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_query(&mut self, _query: &'ast ast::Query) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_projection_kind(
-        &mut self,
-        _projection_kind: &'ast ast::ProjectionKind,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_projection_kind(
-        &mut self,
-        _projection_kind: &'ast ast::ProjectionKind,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_select(&mut self, _select: &'ast ast::Select) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_project_item(
-        &mut self,
-        _project_item: &'ast ast::ProjectItem,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_select(&mut self, _select: &'ast ast::Select) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_project_item(
-        &mut self,
-        _project_item: &'ast ast::ProjectItem,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_project_pivot(
-        &mut self,
-        _project_pivot: &'ast ast::ProjectPivot,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_project_pivot(
-        &mut self,
-        _project_pivot: &'ast ast::ProjectPivot,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_project_all(
-        &mut self,
-        _project_all: &'ast ast::ProjectAll,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_project_expr(
-        &mut self,
-        _project_expr: &'ast ast::ProjectExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_project_expr(
-        &mut self,
-        _project_expr: &'ast ast::ProjectExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_like(&mut self, _like: &'ast ast::Like) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_simple_case(
-        &mut self,
-        _simple_case: &'ast ast::SimpleCase,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_like(&mut self, _like: &'ast ast::Like) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_between(&mut self, _between: &'ast ast::Between) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_searched_case(
-        &mut self,
-        _searched_case: &'ast ast::SearchedCase,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_between(&mut self, _between: &'ast ast::Between) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_searched_case(
-        &mut self,
-        _searched_case: &'ast ast::SearchedCase,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_in(&mut self, _in: &'ast ast::In) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_in(&mut self, _in: &'ast ast::In) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_case(&mut self, _case: &'ast ast::Case) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_case(&mut self, _case: &'ast ast::Case) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_list(&mut self, _list: &'ast ast::List) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_call_arg_named(
-        &mut self,
-        _call_arg_named: &'ast ast::CallArgNamed,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_list(&mut self, _list: &'ast ast::List) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_call_arg_named(
-        &mut self,
-        _call_arg_named: &'ast ast::CallArgNamed,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Recurse {
+        Recurse::Continue
+    }
+    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Recurse {
+        Recurse::Continue
+    }
+    fn enter_call(&mut self, _call: &'ast ast::Call) -> Recurse {
+        Recurse::Continue
+    }
+    fn exit_call(&mut self, _call: &'ast ast::Call) -> Recurse {
+        Recurse::Continue
+    }
+    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Recurse {
+        Recurse::Continue
+    }
+    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Recurse {
+        Recurse::Continue
+    }
+    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Recurse {
+        Recurse::Continue
+    }
+    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Recurse {
+        Recurse::Continue
     }
     fn enter_call_arg_named_type(
         &mut self,
         _call_arg_named_type: &'ast ast::CallArgNamedType,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    ) -> Recurse {
+        Recurse::Continue
     }
     fn exit_call_arg_named_type(
         &mut self,
         _call_arg_named_type: &'ast ast::CallArgNamedType,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    ) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_path(&mut self, _path: &'ast ast::Path) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_path(&mut self, _path: &'ast ast::Path) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_let(&mut self, _let: &'ast ast::Let) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_let(&mut self, _let: &'ast ast::Let) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_let_binding(
-        &mut self,
-        _let_binding: &'ast ast::LetBinding,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_from_clause(
-        &mut self,
-        _from_clause: &'ast ast::FromClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_from_source(
-        &mut self,
-        _from_clause: &'ast ast::FromSource,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_where_clause(
-        &mut self,
-        _where_clause: &'ast ast::WhereClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_where_clause(
-        &mut self,
-        _where_clause: &'ast ast::WhereClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_having_clause(
-        &mut self,
-        _having_clause: &'ast ast::HavingClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_having_clause(
-        &mut self,
-        _having_clause: &'ast ast::HavingClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_join(&mut self, _join: &'ast ast::Join) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_join(&mut self, _join: &'ast ast::Join) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_group_by_expr(
-        &mut self,
-        _group_by_expr: &'ast ast::GroupByExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_group_by_expr(
-        &mut self,
-        _group_by_expr: &'ast ast::GroupByExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_order_by_expr(
-        &mut self,
-        _order_by_expr: &'ast ast::OrderByExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_order_by_expr(
-        &mut self,
-        _order_by_expr: &'ast ast::OrderByExpr,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Recurse {
+        Recurse::Continue
     }
     fn enter_limit_offset_clause(
         &mut self,
         _limit_offset: &'ast ast::LimitOffsetClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    ) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_limit_offset_clause(
-        &mut self,
-        _limit_offset: &'ast ast::LimitOffsetClause,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Recurse {
+        Recurse::Continue
     }
-    fn enter_custom_type(
-        &mut self,
-        _custom_type: &'ast ast::CustomType,
-    ) -> Result<(), Self::Error> {
-        Ok(())
+    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Recurse {
+        Recurse::Continue
     }
-    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> {
-        Ok(())
+    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Recurse {
+        Recurse::Continue
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::ast;
-    use crate::visit::Visitor;
+    use crate::visit::{Recurse, Visitor};
     use ast::{AstNode, BinOp, BinOpKind, Expr, Lit, NodeId};
     use std::ops::AddAssign;
 
@@ -644,9 +542,7 @@ mod tests {
         }
 
         impl<'ast> Visitor<'ast> for Accum {
-            type Error = ();
-
-            fn enter_lit(&mut self, literal: &'ast Lit) -> Result<(), Self::Error> {
+            fn enter_lit(&mut self, literal: &'ast Lit) -> Recurse {
                 match literal {
                     Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
                     Lit::Int16Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
@@ -654,7 +550,7 @@ mod tests {
                     Lit::Int64Lit(l) => self.val.get_or_insert(0i64).add_assign(l),
                     _ => {}
                 }
-                Ok(())
+                Recurse::Continue
             }
         }
 
@@ -688,7 +584,8 @@ mod tests {
         let mut acc = Accum::default();
 
         use super::Visit;
-        ast.visit(&mut acc).expect("Expect no error to occur");
+        ast.visit(&mut acc);
+        // todo error handling
 
         let val = acc.val;
         assert!(matches!(val, Some(2989)));

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -13,7 +13,7 @@ where
 {
     fn visit<'ast, V>(&'ast self, v: &mut V) -> Result<(), V::Error>
     where
-        V: Visitor<'ast>
+        V: Visitor<'ast>,
     {
         v.enter_ast_node(self.id)?;
         self.node.visit(v)?;
@@ -78,148 +78,555 @@ where
 pub trait Visitor<'ast> {
     type Error;
 
-    fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_create_table(&mut self, _create_table: &'ast ast::CreateTable) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_create_index(&mut self, _create_index: &'ast ast::CreateIndex) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_returning_expr(&mut self, _returning_expr: &'ast ast::ReturningExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_returning_elem(&mut self, _returning_elem: &'ast ast::ReturningElem) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_insert_value(&mut self, _insert_value: &'ast ast::InsertValue) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_projection_kind(&mut self, _projection_kind: &'ast ast::ProjectionKind) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_project_item(&mut self, _project_item: &'ast ast::ProjectItem) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_project_pivot(&mut self, _project_pivot: &'ast ast::ProjectPivot) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_project_expr(&mut self, _project_expr: &'ast ast::ProjectExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_searched_case(&mut self, _searched_case: &'ast ast::SearchedCase) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_call_arg_named(&mut self, _call_arg_named: &'ast ast::CallArgNamed) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_call_arg_named_type(&mut self, _call_arg_named_type: &'ast ast::CallArgNamedType) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast ast::GroupByExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast ast::OrderByExpr) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_limit_offset_clause(&mut self, _limit_offset: &'ast ast::LimitOffsetClause) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> { Ok(()) }
-    fn enter_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> { Ok(()) }
-    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> { Ok(()) }
+    fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_item(&mut self, _item: &'ast ast::Item) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_create_table(
+        &mut self,
+        _create_table: &'ast ast::CreateTable,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_create_table(
+        &mut self,
+        _create_table: &'ast ast::CreateTable,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_drop_table(&mut self, _drop_table: &'ast ast::DropTable) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_create_index(
+        &mut self,
+        _create_index: &'ast ast::CreateIndex,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_create_index(
+        &mut self,
+        _create_index: &'ast ast::CreateIndex,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_drop_index(&mut self, _drop_index: &'ast ast::DropIndex) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_dml(&mut self, _dml: &'ast ast::Dml) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_dml_op(&mut self, _dml_op: &'ast ast::DmlOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_returning_expr(
+        &mut self,
+        _returning_expr: &'ast ast::ReturningExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_returning_expr(
+        &mut self,
+        _returning_expr: &'ast ast::ReturningExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_returning_elem(
+        &mut self,
+        _returning_elem: &'ast ast::ReturningElem,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_returning_elem(
+        &mut self,
+        _returning_elem: &'ast ast::ReturningElem,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_insert(&mut self, _insert: &'ast ast::Insert) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_insert_value(
+        &mut self,
+        _insert_value: &'ast ast::InsertValue,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_insert_value(
+        &mut self,
+        _insert_value: &'ast ast::InsertValue,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_set(&mut self, _set: &'ast ast::Set) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_assignment(&mut self, _assignment: &'ast ast::Assignment) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_remove(&mut self, _remove: &'ast ast::Remove) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_delete(&mut self, _delete: &'ast ast::Delete) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_on_conflict(
+        &mut self,
+        _on_conflict: &'ast ast::OnConflict,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_on_conflict(&mut self, _on_conflict: &'ast ast::OnConflict) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_query(&mut self, _query: &'ast ast::Query) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_with_clause(&mut self, _query: &'ast ast::WithClause) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_with_element(&mut self, _query: &'ast ast::WithElement) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_select(&mut self, _select: &'ast ast::Select) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_query_table(&mut self, _table: &'ast ast::QueryTable) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_projection(&mut self, _projection: &'ast ast::Projection) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_projection_kind(
+        &mut self,
+        _projection_kind: &'ast ast::ProjectionKind,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_projection_kind(
+        &mut self,
+        _projection_kind: &'ast ast::ProjectionKind,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_project_item(
+        &mut self,
+        _project_item: &'ast ast::ProjectItem,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_project_item(
+        &mut self,
+        _project_item: &'ast ast::ProjectItem,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_project_pivot(
+        &mut self,
+        _project_pivot: &'ast ast::ProjectPivot,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_project_pivot(
+        &mut self,
+        _project_pivot: &'ast ast::ProjectPivot,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_project_all(
+        &mut self,
+        _project_all: &'ast ast::ProjectAll,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_project_all(&mut self, _project_all: &'ast ast::ProjectAll) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_project_expr(
+        &mut self,
+        _project_expr: &'ast ast::ProjectExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_project_expr(
+        &mut self,
+        _project_expr: &'ast ast::ProjectExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_expr(&mut self, _expr: &'ast ast::Expr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_lit(&mut self, _lit: &'ast ast::Lit) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_var_ref(&mut self, _var_ref: &'ast ast::VarRef) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_bin_op(&mut self, _bin_op: &'ast ast::BinOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_uni_op(&mut self, _uni_op: &'ast ast::UniOp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_like(&mut self, _like: &'ast ast::Like) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_between(&mut self, _between: &'ast ast::Between) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_in(&mut self, _in: &'ast ast::In) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_case(&mut self, _case: &'ast ast::Case) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_simple_case(
+        &mut self,
+        _simple_case: &'ast ast::SimpleCase,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_simple_case(&mut self, _simple_case: &'ast ast::SimpleCase) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_searched_case(
+        &mut self,
+        _searched_case: &'ast ast::SearchedCase,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_searched_case(
+        &mut self,
+        _searched_case: &'ast ast::SearchedCase,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_expr_pair(&mut self, _expr_pair: &'ast ast::ExprPair) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_struct(&mut self, _struct: &'ast ast::Struct) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_bag(&mut self, _bag: &'ast ast::Bag) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_list(&mut self, _list: &'ast ast::List) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_call(&mut self, _call: &'ast ast::Call) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_call_arg(&mut self, _call_arg: &'ast ast::CallArg) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_call_arg_named(
+        &mut self,
+        _call_arg_named: &'ast ast::CallArgNamed,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_call_arg_named(
+        &mut self,
+        _call_arg_named: &'ast ast::CallArgNamed,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_call_arg_named_type(
+        &mut self,
+        _call_arg_named_type: &'ast ast::CallArgNamedType,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_call_arg_named_type(
+        &mut self,
+        _call_arg_named_type: &'ast ast::CallArgNamedType,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_call_agg(&mut self, _call_agg: &'ast ast::CallAgg) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_path(&mut self, _path: &'ast ast::Path) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_path_step(&mut self, _path_step: &'ast ast::PathStep) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_path_expr(&mut self, _path_expr: &'ast ast::PathExpr) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_let(&mut self, _let: &'ast ast::Let) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_let_binding(
+        &mut self,
+        _let_binding: &'ast ast::LetBinding,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_let_binding(&mut self, _let_binding: &'ast ast::LetBinding) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_from_clause(
+        &mut self,
+        _from_clause: &'ast ast::FromClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_from_clause(&mut self, _from_clause: &'ast ast::FromClause) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_from_source(
+        &mut self,
+        _from_clause: &'ast ast::FromSource,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_from_source(&mut self, _from_clause: &'ast ast::FromSource) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_where_clause(
+        &mut self,
+        _where_clause: &'ast ast::WhereClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_where_clause(
+        &mut self,
+        _where_clause: &'ast ast::WhereClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_having_clause(
+        &mut self,
+        _having_clause: &'ast ast::HavingClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_having_clause(
+        &mut self,
+        _having_clause: &'ast ast::HavingClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_from_let(&mut self, _from_let: &'ast ast::FromLet) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_join(&mut self, _join: &'ast ast::Join) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_join_spec(&mut self, _join_spec: &'ast ast::JoinSpec) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_group_by_expr(
+        &mut self,
+        _group_by_expr: &'ast ast::GroupByExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_group_by_expr(
+        &mut self,
+        _group_by_expr: &'ast ast::GroupByExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_group_key(&mut self, _group_key: &'ast ast::GroupKey) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_order_by_expr(
+        &mut self,
+        _order_by_expr: &'ast ast::OrderByExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_order_by_expr(
+        &mut self,
+        _order_by_expr: &'ast ast::OrderByExpr,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_limit_offset_clause(
+        &mut self,
+        _limit_offset: &'ast ast::LimitOffsetClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_limit_offset_clause(
+        &mut self,
+        _limit_offset: &'ast ast::LimitOffsetClause,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_sort_spec(&mut self, _sort_spec: &'ast ast::SortSpec) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn enter_custom_type(
+        &mut self,
+        _custom_type: &'ast ast::CustomType,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    fn exit_custom_type(&mut self, _custom_type: &'ast ast::CustomType) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -239,11 +646,7 @@ mod tests {
         impl<'ast> Visitor<'ast> for Accum {
             type Error = ();
 
-            fn enter_ast_node(&mut self, _id: NodeId) -> Result<(), Self::Error> {
-                todo!()
-            }
-
-            fn enter_lit(&mut self, literal: &'ast Lit) {
+            fn enter_lit(&mut self, literal: &'ast Lit) -> Result<(), Self::Error> {
                 match literal {
                     Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
                     Lit::Int16Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
@@ -251,6 +654,7 @@ mod tests {
                     Lit::Int64Lit(l) => self.val.get_or_insert(0i64).add_assign(l),
                     _ => {}
                 }
+                Ok(())
             }
         }
 

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -1,9 +1,12 @@
 use crate::ast;
 use crate::ast::NodeId;
 
-#[derive(PartialEq)]
+/// Indicates if children nodes should be visited
+#[derive(PartialEq, Debug)]
 pub enum Recurse {
+    /// Signals visiting children nodes should continue
     Continue,
+    /// Signals visiting children nodes should stop
     Stop,
 }
 
@@ -584,8 +587,7 @@ mod tests {
         let mut acc = Accum::default();
 
         use super::Visit;
-        ast.visit(&mut acc);
-        // todo error handling
+        assert_eq!(Recurse::Continue, ast.visit(&mut acc));
 
         let val = acc.val;
         assert!(matches!(val, Some(2989)));

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -1,6 +1,7 @@
 use partiql_eval as eval;
 use partiql_eval::env::basic::MapBindings;
 use partiql_logical as logical;
+use partiql_logical_planner::error::LowerError;
 use partiql_parser::{Parsed, ParserResult};
 use partiql_value::Value;
 
@@ -22,7 +23,9 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 
 #[track_caller]
 #[inline]
-pub(crate) fn lower(parsed: &Parsed) -> logical::LogicalPlan<logical::BindingsOp> {
+pub(crate) fn lower(
+    parsed: &Parsed,
+) -> Result<logical::LogicalPlan<logical::BindingsOp>, LowerError> {
     partiql_logical_planner::lower(parsed)
 }
 
@@ -96,7 +99,8 @@ pub(crate) fn fail_eval(statement: &str, mode: EvaluationMode, env: &Option<Test
     }
 
     let parsed = parse(statement);
-    let lowered = lower(&parsed.expect("parse"));
+    let lowered_result = lower(&parsed.expect("parse"));
+    let lowered = lowered_result.expect("lower");
     let bindings = env
         .as_ref()
         .map(|e| (&e.value).into())
@@ -122,7 +126,8 @@ pub(crate) fn pass_eval(
     }
 
     let parsed = parse(statement);
-    let lowered = lower(&parsed.expect("parse"));
+    let lowered_result = lower(&parsed.expect("parse"));
+    let lowered = lowered_result.expect("lower");
     let bindings = env
         .as_ref()
         .map(|e| (&e.value).into())

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -1,7 +1,7 @@
 use partiql_eval as eval;
 use partiql_eval::env::basic::MapBindings;
 use partiql_logical as logical;
-use partiql_logical_planner::error::LowerError;
+use partiql_logical_planner::error::LoweringError;
 use partiql_parser::{Parsed, ParserResult};
 use partiql_value::Value;
 
@@ -25,7 +25,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[inline]
 pub(crate) fn lower(
     parsed: &Parsed,
-) -> Result<logical::LogicalPlan<logical::BindingsOp>, LowerError> {
+) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
     partiql_logical_planner::lower(parsed)
 }
 

--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -36,6 +36,7 @@ num = "0.4"
 fnv = "1"
 assert_matches = "1.5.*"
 once_cell = "1"
+thiserror = "1.0"
 
 [dev-dependencies]
 partiql-eval = { path = "../partiql-eval", version = "0.3.*" }

--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -1,7 +1,13 @@
 use thiserror::Error;
 
+/// Contains the errors that occur during AST to logical plan conversion
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LoweringError {
+    pub errors: Vec<LowerError>,
+}
+
+/// An error that can happen during the AST to logical plan conversion
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum LowerError {
     /// Indicates that AST lowering has not yet been implemented for this feature.

--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -10,4 +10,10 @@ pub enum LowerError {
     /// Indicates that there is an internal error that was not due to user input or API violation.
     #[error("Illegal State: {0}")]
     IllegalState(String),
+    /// Indicates that this function is not supported.
+    #[error("Unsupported function: {0}")]
+    UnsupportedFunction(String),
+    /// Indicates that this aggregation function is not supported.
+    #[error("Unsupported aggregation function: {0}")]
+    UnsupportedAggregationFunction(String),
 }

--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum LowerError {
+    /// Indicates that AST lowering has not yet been implemented for this feature.
+    #[error("Not yet implemented: {0}")]
+    NotYetImplemented(String),
+    /// Indicates that there is an internal error that was not due to user input or API violation.
+    #[error("Illegal State: {0}")]
+    IllegalState(String),
+}

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -7,6 +7,7 @@ use partiql_parser::Parsed;
 mod call_defs;
 mod lower;
 mod name_resolver;
+pub mod error;
 
 // TODO better encapsulate and add error types.
 pub fn lower(parsed: &Parsed) -> logical::LogicalPlan<logical::BindingsOp> {

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -5,9 +5,9 @@ use partiql_logical as logical;
 use partiql_parser::Parsed;
 
 mod call_defs;
+pub mod error;
 mod lower;
 mod name_resolver;
-pub mod error;
 
 // TODO better encapsulate and add error types.
 pub fn lower(parsed: &Parsed) -> logical::LogicalPlan<logical::BindingsOp> {

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -10,18 +10,14 @@ pub mod error;
 mod lower;
 mod name_resolver;
 
-// TODO better encapsulate and add error types.
+// TODO better encapsulate.
 pub fn lower(parsed: &Parsed) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
     if let ast::Expr::Query(q) = parsed.ast.as_ref() {
         let mut resolver = NameResolver::default();
-        let key_resolver = resolver.resolve(q);
-        match key_resolver {
-            Ok(kr) => {
-                let planner = AstToLogical::new(kr);
-                planner.lower_query(q)
-            }
-            Err(e) => Err(e),
-        }
+        let mut resolver = NameResolver::default();
+        let registry = resolver.resolve(q)?;
+        let planner = AstToLogical::new(registry);
+        planner.lower_query(q)
     } else {
         Err(LoweringError {
             errors: vec![LowerError::NotYetImplemented(

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -14,7 +14,6 @@ mod name_resolver;
 pub fn lower(parsed: &Parsed) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
     if let ast::Expr::Query(q) = parsed.ast.as_ref() {
         let mut resolver = NameResolver::default();
-        let mut resolver = NameResolver::default();
         let registry = resolver.resolve(q)?;
         let planner = AstToLogical::new(registry);
         planner.lower_query(q)

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -32,6 +32,7 @@ use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
 use partiql_extension_ion::Encoding;
 use partiql_logical::AggFunc::{AggAvg, AggCount, AggMax, AggMin, AggSum};
 use std::sync::atomic::{AtomicU32, Ordering};
+use crate::error::LowerError;
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
@@ -452,8 +453,11 @@ impl AstToLogical {
 // By convention, processing for them is done in the `enter_<x>` calls here.
 //
 impl<'ast> Visitor<'ast> for AstToLogical {
-    fn enter_ast_node(&mut self, id: NodeId) {
+    type Error = LowerError;
+
+    fn enter_ast_node(&mut self, id: NodeId) -> Result<(), LowerError> {
         self.id_stack.push(id);
+        Ok(())
     }
     fn exit_ast_node(&mut self, id: NodeId) {
         assert_eq!(self.id_stack.pop(), Some(id))

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -12,7 +12,7 @@ use partiql_ast::ast::{
     Query, QuerySet, Remove, SearchedCase, Select, Set, SetExpr, SetQuantifier, Sexp, SimpleCase,
     SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
 };
-use partiql_ast::visit::{Recurse, Visit, Visitor};
+use partiql_ast::visit::{Traverse, Visit, Visitor};
 use partiql_logical as logical;
 use partiql_logical::{
     AggregateExpression, BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch,
@@ -447,24 +447,24 @@ impl AstToLogical {
         self.sort_stack.last_mut().unwrap().push(spec);
     }
 
-    fn eq_or_error<V>(&mut self, l: V, r: V, msg: &str) -> Recurse
+    fn eq_or_error<V>(&mut self, l: V, r: V, msg: &str) -> Traverse
     where
         V: PartialEq,
     {
         if l != r {
             self.errors.push(LowerError::IllegalState(msg.to_string()));
-            Recurse::Stop
+            Traverse::Stop
         } else {
-            Recurse::Continue
+            Traverse::Continue
         }
     }
 
-    fn true_or_error(&mut self, b: bool, msg: &str) -> Recurse {
+    fn true_or_error(&mut self, b: bool, msg: &str) -> Traverse {
         if !b {
             self.errors.push(LowerError::IllegalState(msg.to_string()));
-            Recurse::Stop
+            Traverse::Stop
         } else {
-            Recurse::Continue
+            Traverse::Continue
         }
     }
 }
@@ -484,122 +484,122 @@ impl AstToLogical {
 // By convention, processing for them is done in the `enter_<x>` calls here.
 //
 impl<'ast> Visitor<'ast> for AstToLogical {
-    fn enter_ast_node(&mut self, id: NodeId) -> Recurse {
+    fn enter_ast_node(&mut self, id: NodeId) -> Traverse {
         self.id_stack.push(id);
-        Recurse::Continue
+        Traverse::Continue
     }
-    fn exit_ast_node(&mut self, id: NodeId) -> Recurse {
+    fn exit_ast_node(&mut self, id: NodeId) -> Traverse {
         let cur_node = self.id_stack.pop();
-        if self.eq_or_error(cur_node, Some(id), "id_stack node id != id") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(cur_node, Some(id), "id_stack node id != id") == Traverse::Stop {
+            return Traverse::Stop;
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_item(&mut self, _item: &'ast Item) -> Recurse {
+    fn enter_item(&mut self, _item: &'ast Item) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Item".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_ddl(&mut self, _ddl: &'ast Ddl) -> Recurse {
+    fn enter_ddl(&mut self, _ddl: &'ast Ddl) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Ddl".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_ddl_op(&mut self, _ddl_op: &'ast DdlOp) -> Recurse {
+    fn enter_ddl_op(&mut self, _ddl_op: &'ast DdlOp) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("DdlOp".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_create_table(&mut self, _create_table: &'ast CreateTable) -> Recurse {
+    fn enter_create_table(&mut self, _create_table: &'ast CreateTable) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("CreateTable".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_drop_table(&mut self, _drop_table: &'ast DropTable) -> Recurse {
+    fn enter_drop_table(&mut self, _drop_table: &'ast DropTable) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("DropTable".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_create_index(&mut self, _create_index: &'ast CreateIndex) -> Recurse {
+    fn enter_create_index(&mut self, _create_index: &'ast CreateIndex) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("CreateIndex".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_drop_index(&mut self, _drop_index: &'ast DropIndex) -> Recurse {
+    fn enter_drop_index(&mut self, _drop_index: &'ast DropIndex) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("DropIndex".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_dml(&mut self, _dml: &'ast Dml) -> Recurse {
+    fn enter_dml(&mut self, _dml: &'ast Dml) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Dml".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_dml_op(&mut self, _dml_op: &'ast DmlOp) -> Recurse {
+    fn enter_dml_op(&mut self, _dml_op: &'ast DmlOp) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("DmlOp".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_insert(&mut self, _insert: &'ast Insert) -> Recurse {
+    fn enter_insert(&mut self, _insert: &'ast Insert) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Insert".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_insert_value(&mut self, _insert_value: &'ast InsertValue) -> Recurse {
+    fn enter_insert_value(&mut self, _insert_value: &'ast InsertValue) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("InsertValue".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_set(&mut self, _set: &'ast Set) -> Recurse {
+    fn enter_set(&mut self, _set: &'ast Set) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Set".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_assignment(&mut self, _assignment: &'ast Assignment) -> Recurse {
+    fn enter_assignment(&mut self, _assignment: &'ast Assignment) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Assignment".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_remove(&mut self, _remove: &'ast Remove) -> Recurse {
+    fn enter_remove(&mut self, _remove: &'ast Remove) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Remove".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_delete(&mut self, _delete: &'ast Delete) -> Recurse {
+    fn enter_delete(&mut self, _delete: &'ast Delete) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Delete".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_on_conflict(&mut self, _on_conflict: &'ast OnConflict) -> Recurse {
+    fn enter_on_conflict(&mut self, _on_conflict: &'ast OnConflict) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("OnConflict".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_query(&mut self, _query: &'ast Query) -> Recurse {
+    fn enter_query(&mut self, _query: &'ast Query) -> Traverse {
         self.enter_benv();
         self.siblings.push(vec![]);
         self.enter_q();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_query(&mut self, _query: &'ast Query) -> Recurse {
+    fn exit_query(&mut self, _query: &'ast Query) -> Traverse {
         let clauses = self.exit_q();
 
         let mut clauses = clauses.evaluation_order().into_iter();
@@ -615,25 +615,25 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         self.siblings.pop();
 
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 1, "Expect benv.len() == 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(benv.len(), 1, "Expect benv.len() == 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let out = benv.pop().unwrap();
 
         let sink_id = self.plan.add_operator(BindingsOp::Sink);
         self.plan.add_flow(out, sink_id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_query_set(&mut self, _query_set: &'ast QuerySet) -> Recurse {
+    fn enter_query_set(&mut self, _query_set: &'ast QuerySet) -> Traverse {
         self.enter_env();
 
         match _query_set {
             QuerySet::SetOp(_) => {
                 self.errors
                     .push(LowerError::NotYetImplemented("QuerySet::SetOp".to_string()));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {}
@@ -641,30 +641,30 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::NotYetImplemented(
                     "QuerySet::Values".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             QuerySet::Table(_) => {
                 self.errors
                     .push(LowerError::NotYetImplemented("QuerySet::Table".to_string()));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_query_set(&mut self, _query_set: &'ast QuerySet) -> Recurse {
+    fn exit_query_set(&mut self, _query_set: &'ast QuerySet) -> Traverse {
         let env = self.exit_env();
 
         match _query_set {
             QuerySet::SetOp(_) => {
                 self.errors
                     .push(LowerError::NotYetImplemented("QuerySet::SetOp".to_string()));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
                 let expr = env.into_iter().next().unwrap();
                 let op = BindingsOp::ExprQuery(logical::ExprQuery { expr });
@@ -675,79 +675,80 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::NotYetImplemented(
                     "QuerySet::Values".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             QuerySet::Table(_) => {
                 self.errors
                     .push(LowerError::NotYetImplemented("QuerySet::Table".to_string()));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Recurse {
-        Recurse::Continue
+    fn enter_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Traverse {
+        Traverse::Continue
     }
 
-    fn exit_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Recurse {
-        Recurse::Continue
+    fn exit_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Traverse {
+        Traverse::Continue
     }
 
-    fn enter_select(&mut self, _select: &'ast Select) -> Recurse {
-        Recurse::Continue
+    fn enter_select(&mut self, _select: &'ast Select) -> Traverse {
+        Traverse::Continue
     }
 
-    fn exit_select(&mut self, _select: &'ast Select) -> Recurse {
-        Recurse::Continue
+    fn exit_select(&mut self, _select: &'ast Select) -> Traverse {
+        Traverse::Continue
     }
 
-    fn enter_projection(&mut self, _projection: &'ast Projection) -> Recurse {
+    fn enter_projection(&mut self, _projection: &'ast Projection) -> Traverse {
         self.enter_benv();
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_projection(&mut self, _projection: &'ast Projection) -> Recurse {
+    fn exit_projection(&mut self, _projection: &'ast Projection) -> Traverse {
         let benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 0, "benv.len() != 0") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(benv.len(), 0, "benv.len() != 0") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let env = self.exit_env();
-        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         if let Some(SetQuantifier::Distinct) = _projection.setq {
             let id = self.plan.add_operator(BindingsOp::Distinct);
             self.current_clauses_mut().distinct.replace(id);
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_projection_kind(&mut self, _projection_kind: &'ast ProjectionKind) -> Recurse {
+    fn enter_projection_kind(&mut self, _projection_kind: &'ast ProjectionKind) -> Traverse {
         self.enter_benv();
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_projection_kind(&mut self, _projection_kind: &'ast ProjectionKind) -> Recurse {
+    fn exit_projection_kind(&mut self, _projection_kind: &'ast ProjectionKind) -> Traverse {
         let benv = self.exit_benv();
         if !benv.is_empty() {
             self.errors.push(LowerError::NotYetImplemented(
                 "Subquery within project".to_string(),
             ));
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
         let env = self.exit_env();
 
         let select: BindingsOp = match _projection_kind {
             ProjectionKind::ProjectStar => logical::BindingsOp::ProjectAll,
             ProjectionKind::ProjectList(_) => {
-                if self.true_or_error(env.len().is_even(), "env.len() is not even") == Recurse::Stop
+                if self.true_or_error(env.len().is_even(), "env.len() is not even")
+                    == Traverse::Stop
                 {
-                    return Recurse::Stop;
+                    return Traverse::Stop;
                 }
                 let mut exprs = HashMap::with_capacity(env.len() / 2);
                 let mut iter = env.into_iter();
@@ -777,8 +778,8 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 logical::BindingsOp::Project(logical::Project { exprs })
             }
             ProjectionKind::ProjectPivot(_) => {
-                if self.eq_or_error(env.len(), 2, "env.len() != 2") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 2, "env.len() != 2") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
 
                 let mut iter = env.into_iter();
@@ -787,8 +788,8 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 logical::BindingsOp::Pivot(logical::Pivot { key, value })
             }
             ProjectionKind::ProjectValue(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
 
                 let expr = env.into_iter().next().unwrap();
@@ -797,10 +798,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         };
         let id = self.plan.add_operator(select);
         self.current_clauses_mut().select_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_project_expr(&mut self, _project_expr: &'ast ProjectExpr) -> Recurse {
+    fn exit_project_expr(&mut self, _project_expr: &'ast ProjectExpr) -> Traverse {
         let as_key: &name_resolver::Symbol = self
             .key_registry
             .aliases
@@ -812,18 +813,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             name_resolver::Symbol::Unknown(id) => format!("_{id}"),
         };
         self.push_value(as_key.into());
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_bin_op(&mut self, _bin_op: &'ast BinOp) -> Recurse {
+    fn enter_bin_op(&mut self, _bin_op: &'ast BinOp) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_bin_op(&mut self, _bin_op: &'ast BinOp) -> Recurse {
+    fn exit_bin_op(&mut self, _bin_op: &'ast BinOp) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 2, "env.len() != 2") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 2, "env.len() != 2") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let rhs = env.pop().unwrap();
@@ -837,14 +838,14 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                         self.errors.push(LowerError::NotYetImplemented(
                             "Unsupported rhs literal for `IS`".to_string(),
                         ));
-                        return Recurse::Stop;
+                        return Traverse::Stop;
                     }
                 },
                 _ => {
                     self.errors.push(LowerError::NotYetImplemented(
                         "Unsupported rhs for `IS`".to_string(),
                     ));
-                    return Recurse::Stop;
+                    return Traverse::Stop;
                 }
             };
             self.push_vexpr(ValueExpr::IsTypeExpr(IsTypeExpr {
@@ -873,18 +874,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             };
             self.push_vexpr(ValueExpr::BinaryExpr(op, Box::new(lhs), Box::new(rhs)));
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_uni_op(&mut self, _uni_op: &'ast UniOp) -> Recurse {
+    fn enter_uni_op(&mut self, _uni_op: &'ast UniOp) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_uni_op(&mut self, _uni_op: &'ast UniOp) -> Recurse {
+    fn exit_uni_op(&mut self, _uni_op: &'ast UniOp) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let expr = env.pop().unwrap();
@@ -894,40 +895,40 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             UniOpKind::Not => logical::UnaryOp::Not,
         };
         self.push_vexpr(ValueExpr::UnExpr(op, Box::new(expr)));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_between(&mut self, _between: &'ast Between) -> Recurse {
+    fn enter_between(&mut self, _between: &'ast Between) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_between(&mut self, _between: &'ast Between) -> Recurse {
+    fn exit_between(&mut self, _between: &'ast Between) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 3, "env.len() != 3") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 3, "env.len() != 3") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let to = Box::new(env.pop().unwrap());
         let from = Box::new(env.pop().unwrap());
         let value = Box::new(env.pop().unwrap());
         self.push_vexpr(ValueExpr::BetweenExpr(BetweenExpr { value, from, to }));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_like(&mut self, _like: &'ast Like) -> Recurse {
+    fn enter_like(&mut self, _like: &'ast Like) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_like(&mut self, _like: &'ast Like) -> Recurse {
+    fn exit_like(&mut self, _like: &'ast Like) -> Traverse {
         let mut env = self.exit_env();
         if self.true_or_error(
             (2..=3).contains(&env.len()),
             "env.len() is not between 2 and 3",
-        ) == Recurse::Stop
+        ) == Traverse::Stop
         {
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
         let escape_ve = if env.len() == 3 {
             env.pop().unwrap()
@@ -958,15 +959,15 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
         let pattern = ValueExpr::PatternMatchExpr(PatternMatchExpr { value, pattern });
         self.push_vexpr(pattern);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_call(&mut self, _call: &'ast Call) -> Recurse {
+    fn enter_call(&mut self, _call: &'ast Call) -> Traverse {
         self.enter_call();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_call(&mut self, _call: &'ast Call) -> Recurse {
+    fn exit_call(&mut self, _call: &'ast Call) -> Traverse {
         // TODO better argument validation/error messaging
         let env = self.exit_call();
         let name = _call.func_name.value.to_lowercase();
@@ -977,33 +978,33 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             // Include as an error but allow lowering to proceed for multiple error reporting
             self.errors.push(LowerError::UnsupportedFunction(name));
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_call_arg(&mut self, _call_arg: &'ast CallArg) -> Recurse {
+    fn enter_call_arg(&mut self, _call_arg: &'ast CallArg) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_call_arg(&mut self, _call_arg: &'ast CallArg) -> Recurse {
+    fn exit_call_arg(&mut self, _call_arg: &'ast CallArg) -> Traverse {
         let mut env = self.exit_env();
         match _call_arg {
             CallArg::Star() => {
                 self.errors.push(LowerError::NotYetImplemented(
                     "* as a call argument".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             CallArg::Positional(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
 
                 self.push_call_arg(CallArgument::Positional(env.pop().unwrap()));
             }
             CallArg::Named(CallArgNamed { name, .. }) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
 
                 let name = name.value.to_lowercase();
@@ -1013,21 +1014,21 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::NotYetImplemented(
                     "PositionalType call argument".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             CallArg::NamedType(_) => {
                 self.errors.push(LowerError::NotYetImplemented(
                     "PositionalType call argument".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
     // Values & Value Constructors
 
-    fn enter_lit(&mut self, _lit: &'ast Lit) -> Recurse {
+    fn enter_lit(&mut self, _lit: &'ast Lit) -> Traverse {
         let val = match _lit {
             Lit::Null => Value::Null,
             Lit::Missing => Value::Missing,
@@ -1073,18 +1074,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             }
         };
         self.push_value(val);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_struct(&mut self, _struct: &'ast Struct) -> Recurse {
+    fn enter_struct(&mut self, _struct: &'ast Struct) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_struct(&mut self, _struct: &'ast Struct) -> Recurse {
+    fn exit_struct(&mut self, _struct: &'ast Struct) -> Traverse {
         let env = self.exit_env();
-        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let len = env.len() / 2;
@@ -1099,48 +1100,48 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         }
 
         self.push_vexpr(ValueExpr::TupleExpr(TupleExpr { attrs, values }));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_bag(&mut self, _bag: &'ast Bag) -> Recurse {
+    fn enter_bag(&mut self, _bag: &'ast Bag) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_bag(&mut self, _bag: &'ast Bag) -> Recurse {
+    fn exit_bag(&mut self, _bag: &'ast Bag) -> Traverse {
         let elements = self.exit_env();
         self.push_vexpr(ValueExpr::BagExpr(BagExpr { elements }));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_list(&mut self, _list: &'ast List) -> Recurse {
+    fn enter_list(&mut self, _list: &'ast List) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_list(&mut self, _list: &'ast List) -> Recurse {
+    fn exit_list(&mut self, _list: &'ast List) -> Traverse {
         let elements = self.exit_env();
         self.push_vexpr(ValueExpr::ListExpr(ListExpr { elements }));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_sexp(&mut self, _sexp: &'ast Sexp) -> Recurse {
+    fn enter_sexp(&mut self, _sexp: &'ast Sexp) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_sexp(&mut self, _sexp: &'ast Sexp) -> Recurse {
+    fn exit_sexp(&mut self, _sexp: &'ast Sexp) -> Traverse {
         self.errors
             .push(LowerError::NotYetImplemented("Sexp".to_string()));
-        Recurse::Stop
+        Traverse::Stop
     }
 
-    fn enter_call_agg(&mut self, _call_agg: &'ast CallAgg) -> Recurse {
+    fn enter_call_agg(&mut self, _call_agg: &'ast CallAgg) -> Traverse {
         self.enter_call();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_call_agg(&mut self, call_agg: &'ast CallAgg) -> Recurse {
+    fn exit_call_agg(&mut self, call_agg: &'ast CallAgg) -> Traverse {
         // Relates to the SQL aggregation functions (e.g. AVG, COUNT, SUM) -- not the `COLL_`
         // functions
         let mut env = self.exit_call();
@@ -1155,8 +1156,8 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let new_expr = ValueExpr::VarRef(new_binding_name);
         self.push_vexpr(new_expr);
 
-        if self.true_or_error(!env.is_empty(), "env is empty") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.true_or_error(!env.is_empty(), "env is empty") == Traverse::Stop {
+            return Traverse::Stop;
         }
         // Default set quantifier if the set quantifier keyword is omitted will be `ALL`
         let (setq, arg) = match env.pop().unwrap() {
@@ -1168,7 +1169,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                     self.errors.push(LowerError::IllegalState(
                         "Invalid set quantifier".to_string(),
                     ));
-                    return Recurse::Stop;
+                    return Traverse::Stop;
                 }
             },
         };
@@ -1233,10 +1234,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             let id = self.plan.add_operator(group_by);
             self.current_clauses_mut().group_by_clause.replace(id);
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_var_ref(&mut self, _var_ref: &'ast VarRef) -> Recurse {
+    fn enter_var_ref(&mut self, _var_ref: &'ast VarRef) -> Traverse {
         let is_from_path = matches!(self.current_ctx(), Some(QueryContext::FromLet));
         let is_path = matches!(self.current_ctx(), Some(QueryContext::Path));
         let should_resolve = !is_from_path && !is_path;
@@ -1256,45 +1257,45 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             };
             self.push_vexpr(ValueExpr::VarRef(name));
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_var_ref(&mut self, _var_ref: &'ast VarRef) -> Recurse {
-        Recurse::Continue
+    fn exit_var_ref(&mut self, _var_ref: &'ast VarRef) -> Traverse {
+        Traverse::Continue
     }
 
-    fn enter_path(&mut self, _path: &'ast Path) -> Recurse {
+    fn enter_path(&mut self, _path: &'ast Path) -> Traverse {
         self.enter_env();
         self.enter_path();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_path(&mut self, _path: &'ast Path) -> Recurse {
+    fn exit_path(&mut self, _path: &'ast Path) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let steps = self.exit_path();
         let root = env.pop().unwrap();
 
         self.push_vexpr(ValueExpr::Path(Box::new(root), steps));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_path_step(&mut self, _path_step: &'ast PathStep) -> Recurse {
+    fn enter_path_step(&mut self, _path_step: &'ast PathStep) -> Traverse {
         if let PathStep::PathExpr(_) = _path_step {
             self.enter_env();
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_path_step(&mut self, _path_step: &'ast PathStep) -> Recurse {
+    fn exit_path_step(&mut self, _path_step: &'ast PathStep) -> Traverse {
         let step = match _path_step {
             PathStep::PathExpr(_s) => {
                 let mut env = self.exit_env();
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-                    return Recurse::Stop;
+                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+                    return Traverse::Stop;
                 }
 
                 let path = env.pop().unwrap();
@@ -1319,52 +1320,52 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::NotYetImplemented(
                     "PathStep::PathWildCard".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             PathStep::PathUnpivot => {
                 self.errors.push(LowerError::NotYetImplemented(
                     "PathStep::PathUnpivot".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         };
 
         self.push_path_step(step);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_from_clause(&mut self, _from_clause: &'ast FromClause) -> Recurse {
+    fn enter_from_clause(&mut self, _from_clause: &'ast FromClause) -> Traverse {
         self.enter_benv();
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_from_clause(&mut self, _from_clause: &'ast FromClause) -> Recurse {
+    fn exit_from_clause(&mut self, _from_clause: &'ast FromClause) -> Traverse {
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 1, "benv.len() != 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(benv.len(), 1, "benv.len() != 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let env = self.exit_env();
-        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         self.current_clauses_mut()
             .from_clause
             .replace(benv.pop().unwrap());
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_from_let(&mut self, from_let: &'ast FromLet) -> Recurse {
+    fn enter_from_let(&mut self, from_let: &'ast FromLet) -> Traverse {
         self.from_lets.insert(*self.current_node());
         *self.current_ctx_mut() = QueryContext::FromLet;
         self.enter_env();
 
         let id = *self.current_node();
-        if self.true_or_error(!self.siblings.is_empty(), "self.siblings is empty") == Recurse::Stop
+        if self.true_or_error(!self.siblings.is_empty(), "self.siblings is empty") == Traverse::Stop
         {
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
         self.siblings.last_mut().unwrap().push(id);
 
@@ -1374,14 +1375,14 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         {
             self.aliases.insert(id, sym.clone());
         }
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_from_let(&mut self, from_let: &'ast FromLet) -> Recurse {
+    fn exit_from_let(&mut self, from_let: &'ast FromLet) -> Traverse {
         *self.current_ctx_mut() = QueryContext::Query;
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let expr = env.pop().unwrap();
@@ -1411,28 +1412,28 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         };
         let id = self.plan.add_operator(bexpr);
         self.push_bexpr(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_join(&mut self, _join: &'ast Join) -> Recurse {
+    fn enter_join(&mut self, _join: &'ast Join) -> Traverse {
         self.enter_benv();
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_join(&mut self, join: &'ast Join) -> Recurse {
+    fn exit_join(&mut self, join: &'ast Join) -> Traverse {
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 2, "benv.len() != 2") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(benv.len(), 2, "benv.len() != 2") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let mut env = self.exit_env();
         if self.true_or_error(
             (0..=1).contains(&env.len()),
             "env.len() is not between 0 and 1",
-        ) == Recurse::Stop
+        ) == Traverse::Stop
         {
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
 
         let Join { kind, .. } = join;
@@ -1459,10 +1460,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         });
         let join = self.plan.add_operator(join);
         self.push_bexpr(join);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_join_spec(&mut self, join_spec: &'ast JoinSpec) -> Recurse {
+    fn enter_join_spec(&mut self, join_spec: &'ast JoinSpec) -> Traverse {
         match join_spec {
             JoinSpec::On(_) => {
                 // visitor recurse into expr will put the condition in the current env
@@ -1470,27 +1471,27 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             JoinSpec::Using(_) => {
                 self.errors
                     .push(LowerError::NotYetImplemented("JoinSpec::Using".to_string()));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
             JoinSpec::Natural => {
                 self.errors.push(LowerError::NotYetImplemented(
                     "JoinSpec::Natural".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         };
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
+    fn enter_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Recurse {
+    fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let filter = logical::BindingsOp::Filter(logical::Filter {
@@ -1499,18 +1500,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let id = self.plan.add_operator(filter);
 
         self.current_clauses_mut().where_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
+    fn enter_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Recurse {
+    fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let having = BindingsOp::Having(logical::Having {
@@ -1519,16 +1520,16 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let id = self.plan.add_operator(having);
 
         self.current_clauses_mut().having_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) -> Recurse {
+    fn enter_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) -> Traverse {
         self.enter_benv();
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) -> Recurse {
+    fn exit_group_by_expr(&mut self, _group_by_expr: &'ast GroupByExpr) -> Traverse {
         let aggregate_exprs = self.aggregate_exprs.clone();
         let benv = self.exit_benv();
         if !benv.is_empty() {
@@ -1536,12 +1537,12 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::NotYetImplemented(
                     "Subquery in group by".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         }
         let env = self.exit_env();
-        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let group_as_alias = _group_by_expr
@@ -1568,7 +1569,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             self.errors.push(LowerError::IllegalState(
                 "select_clause_op_id is None".to_string(),
             ));
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
         let select_clause = self
             .plan
@@ -1583,7 +1584,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 self.errors.push(LowerError::IllegalState(
                     "Unexpected project type".to_string(),
                 ));
-                return Recurse::Stop;
+                return Traverse::Stop;
             }
         };
         let mut exprs_to_replace: Vec<(String, ValueExpr)> = Vec::new();
@@ -1608,7 +1609,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                     self.errors.push(LowerError::IllegalState(
                         "Unexpected alias type".to_string(),
                     ));
-                    return Recurse::Stop;
+                    return Traverse::Stop;
                 }
             };
             for (alias, expr) in select_clause_exprs.iter() {
@@ -1634,10 +1635,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
         let id = self.plan.add_operator(group_by);
         self.current_clauses_mut().group_by_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_group_key(&mut self, _group_key: &'ast GroupKey) -> Recurse {
+    fn exit_group_key(&mut self, _group_key: &'ast GroupKey) -> Traverse {
         let as_key: &name_resolver::Symbol = self
             .key_registry
             .aliases
@@ -1649,31 +1650,31 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             name_resolver::Symbol::Unknown(id) => format!("_{id}"),
         };
         self.push_value(as_key.into());
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast OrderByExpr) -> Recurse {
+    fn enter_order_by_expr(&mut self, _order_by_expr: &'ast OrderByExpr) -> Traverse {
         self.enter_sort();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast OrderByExpr) -> Recurse {
+    fn exit_order_by_expr(&mut self, _order_by_expr: &'ast OrderByExpr) -> Traverse {
         let specs = self.exit_sort();
         let order_by = logical::BindingsOp::OrderBy(logical::OrderBy { specs });
         let id = self.plan.add_operator(order_by);
         self.current_clauses_mut().order_by_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_sort_spec(&mut self, _sort_spec: &'ast SortSpec) -> Recurse {
+    fn enter_sort_spec(&mut self, _sort_spec: &'ast SortSpec) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_sort_spec(&mut self, sort_spec: &'ast SortSpec) -> Recurse {
+    fn exit_sort_spec(&mut self, sort_spec: &'ast SortSpec) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let expr = env.pop().unwrap();
@@ -1700,25 +1701,25 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             order,
             null_order,
         });
-        Recurse::Continue
+        Traverse::Continue
     }
 
     fn enter_limit_offset_clause(
         &mut self,
         _limit_offset: &'ast ast::LimitOffsetClause,
-    ) -> Recurse {
+    ) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_limit_offset_clause(&mut self, limit_offset: &'ast ast::LimitOffsetClause) -> Recurse {
+    fn exit_limit_offset_clause(&mut self, limit_offset: &'ast ast::LimitOffsetClause) -> Traverse {
         let mut env = self.exit_env();
         if self.true_or_error(
             (1..=2).contains(&env.len()),
             "env.len() is  not between 1 and 2",
-        ) == Recurse::Stop
+        ) == Traverse::Stop
         {
-            return Recurse::Stop;
+            return Traverse::Stop;
         }
 
         let offset = if limit_offset.offset.is_some() {
@@ -1735,18 +1736,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let limit_offset = logical::BindingsOp::LimitOffset(logical::LimitOffset { limit, offset });
         let id = self.plan.add_operator(limit_offset);
         self.current_clauses_mut().limit_offset_clause.replace(id);
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_simple_case(&mut self, _simple_case: &'ast SimpleCase) -> Recurse {
+    fn enter_simple_case(&mut self, _simple_case: &'ast SimpleCase) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_simple_case(&mut self, _simple_case: &'ast SimpleCase) -> Recurse {
+    fn exit_simple_case(&mut self, _simple_case: &'ast SimpleCase) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(env.len() >= 2, "env.len < 2") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.true_or_error(env.len() >= 2, "env.len < 2") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let default = if env.len().is_even() {
@@ -1774,18 +1775,18 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             cases,
             default,
         }));
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn enter_searched_case(&mut self, _searched_case: &'ast SearchedCase) -> Recurse {
+    fn enter_searched_case(&mut self, _searched_case: &'ast SearchedCase) -> Traverse {
         self.enter_env();
-        Recurse::Continue
+        Traverse::Continue
     }
 
-    fn exit_searched_case(&mut self, _searched_case: &'ast SearchedCase) -> Recurse {
+    fn exit_searched_case(&mut self, _searched_case: &'ast SearchedCase) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(!env.is_empty(), "env is empty") == Recurse::Stop {
-            return Recurse::Stop;
+        if self.true_or_error(!env.is_empty(), "env is empty") == Traverse::Stop {
+            return Traverse::Stop;
         }
 
         let default = if env.len().is_odd() {
@@ -1809,7 +1810,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             cases,
             default,
         }));
-        Recurse::Continue
+        Traverse::Continue
     }
 }
 

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -36,6 +36,47 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 type FnvIndexMap<K, V> = IndexMap<K, V, FnvBuildHasher>;
 
+#[macro_export]
+macro_rules! eq_or_fault {
+    ($self:ident, $lhs:expr, $rhs:expr, $msg:expr) => {
+        if $lhs != $rhs {
+            $self
+                .errors
+                .push(LowerError::IllegalState($msg.to_string()));
+            return partiql_ast::visit::Traverse::Stop;
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! true_or_fault {
+    ($self:ident, $expr:expr, $msg:expr) => {
+        if !$expr {
+            $self
+                .errors
+                .push(LowerError::IllegalState($msg.to_string()));
+            return partiql_ast::visit::Traverse::Stop;
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! not_yet_implemented_fault {
+    ($self:ident, $msg:expr) => {
+        not_yet_implemented_err!($self, $msg);
+        return partiql_ast::visit::Traverse::Stop;
+    };
+}
+
+#[macro_export]
+macro_rules! not_yet_implemented_err {
+    ($self:ident, $msg:expr) => {
+        $self
+            .errors
+            .push(LowerError::NotYetImplemented($msg.to_string()));
+    };
+}
+
 #[derive(Copy, Clone, Debug)]
 enum QueryContext {
     FromLet,
@@ -446,27 +487,6 @@ impl AstToLogical {
     fn push_sort_spec(&mut self, spec: logical::SortSpec) {
         self.sort_stack.last_mut().unwrap().push(spec);
     }
-
-    fn eq_or_error<V>(&mut self, l: V, r: V, msg: &str) -> Traverse
-    where
-        V: PartialEq,
-    {
-        if l != r {
-            self.errors.push(LowerError::IllegalState(msg.to_string()));
-            Traverse::Stop
-        } else {
-            Traverse::Continue
-        }
-    }
-
-    fn true_or_error(&mut self, b: bool, msg: &str) -> Traverse {
-        if !b {
-            self.errors.push(LowerError::IllegalState(msg.to_string()));
-            Traverse::Stop
-        } else {
-            Traverse::Continue
-        }
-    }
 }
 
 // SQL (and therefore PartiQL) text (and therefore AST) is not lexically-scoped as is the
@@ -490,106 +510,72 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
     fn exit_ast_node(&mut self, id: NodeId) -> Traverse {
         let cur_node = self.id_stack.pop();
-        if self.eq_or_error(cur_node, Some(id), "id_stack node id != id") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, cur_node, Some(id), "id_stack node id != id");
         Traverse::Continue
     }
 
     fn enter_item(&mut self, _item: &'ast Item) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Item".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Item");
     }
 
     fn enter_ddl(&mut self, _ddl: &'ast Ddl) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Ddl".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Ddl".to_string());
     }
 
     fn enter_ddl_op(&mut self, _ddl_op: &'ast DdlOp) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("DdlOp".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "DdlOp".to_string());
     }
 
     fn enter_create_table(&mut self, _create_table: &'ast CreateTable) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("CreateTable".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "CreateTable".to_string());
     }
 
     fn enter_drop_table(&mut self, _drop_table: &'ast DropTable) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("DropTable".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "DropTable".to_string());
     }
 
     fn enter_create_index(&mut self, _create_index: &'ast CreateIndex) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("CreateIndex".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "CreateIndex".to_string());
     }
 
     fn enter_drop_index(&mut self, _drop_index: &'ast DropIndex) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("DropIndex".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "DropIndex".to_string());
     }
 
     fn enter_dml(&mut self, _dml: &'ast Dml) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Dml".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Dml".to_string());
     }
 
     fn enter_dml_op(&mut self, _dml_op: &'ast DmlOp) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("DmlOp".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "DmlOp".to_string());
     }
 
     fn enter_insert(&mut self, _insert: &'ast Insert) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Insert".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Insert".to_string());
     }
 
     fn enter_insert_value(&mut self, _insert_value: &'ast InsertValue) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("InsertValue".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "InsertValue".to_string());
     }
 
     fn enter_set(&mut self, _set: &'ast Set) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Set".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Set".to_string());
     }
 
     fn enter_assignment(&mut self, _assignment: &'ast Assignment) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Assignment".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Assignment".to_string());
     }
 
     fn enter_remove(&mut self, _remove: &'ast Remove) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Remove".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Remove".to_string());
     }
 
     fn enter_delete(&mut self, _delete: &'ast Delete) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Delete".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Delete".to_string());
     }
 
     fn enter_on_conflict(&mut self, _on_conflict: &'ast OnConflict) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("OnConflict".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "OnConflict".to_string());
     }
 
     fn enter_query(&mut self, _query: &'ast Query) -> Traverse {
@@ -615,9 +601,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         self.siblings.pop();
 
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 1, "Expect benv.len() == 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, benv.len(), 1, "Expect benv.len() == 1");
 
         let out = benv.pop().unwrap();
 
@@ -631,22 +615,15 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
         match _query_set {
             QuerySet::SetOp(_) => {
-                self.errors
-                    .push(LowerError::NotYetImplemented("QuerySet::SetOp".to_string()));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::SetOp".to_string());
             }
             QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {}
             QuerySet::Values(_) => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "QuerySet::Values".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::Values".to_string());
             }
             QuerySet::Table(_) => {
-                self.errors
-                    .push(LowerError::NotYetImplemented("QuerySet::Table".to_string()));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::Table".to_string());
             }
         }
         Traverse::Continue
@@ -657,30 +634,21 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
         match _query_set {
             QuerySet::SetOp(_) => {
-                self.errors
-                    .push(LowerError::NotYetImplemented("QuerySet::SetOp".to_string()));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::SetOp".to_string());
             }
             QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 1, "env.len() != 1");
                 let expr = env.into_iter().next().unwrap();
                 let op = BindingsOp::ExprQuery(logical::ExprQuery { expr });
                 let id = self.plan.add_operator(op);
                 self.push_bexpr(id);
             }
             QuerySet::Values(_) => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "QuerySet::Values".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::Values".to_string());
             }
             QuerySet::Table(_) => {
-                self.errors
-                    .push(LowerError::NotYetImplemented("QuerySet::Table".to_string()));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "QuerySet::Table".to_string());
             }
         }
         Traverse::Continue
@@ -710,14 +678,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_projection(&mut self, _projection: &'ast Projection) -> Traverse {
         let benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 0, "benv.len() != 0") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, benv.len(), 0, "benv.len() != 0");
 
         let env = self.exit_env();
-        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 0, "env.len() != 0");
 
         if let Some(SetQuantifier::Distinct) = _projection.setq {
             let id = self.plan.add_operator(BindingsOp::Distinct);
@@ -735,21 +699,14 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     fn exit_projection_kind(&mut self, _projection_kind: &'ast ProjectionKind) -> Traverse {
         let benv = self.exit_benv();
         if !benv.is_empty() {
-            self.errors.push(LowerError::NotYetImplemented(
-                "Subquery within project".to_string(),
-            ));
-            return Traverse::Stop;
+            not_yet_implemented_fault!(self, "Subquery within project".to_string());
         }
         let env = self.exit_env();
 
         let select: BindingsOp = match _projection_kind {
             ProjectionKind::ProjectStar => logical::BindingsOp::ProjectAll,
             ProjectionKind::ProjectList(_) => {
-                if self.true_or_error(env.len().is_even(), "env.len() is not even")
-                    == Traverse::Stop
-                {
-                    return Traverse::Stop;
-                }
+                true_or_fault!(self, env.len().is_even(), "env.len() is not even");
                 let mut exprs = HashMap::with_capacity(env.len() / 2);
                 let mut iter = env.into_iter();
                 while let Some(value) = iter.next() {
@@ -778,9 +735,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 logical::BindingsOp::Project(logical::Project { exprs })
             }
             ProjectionKind::ProjectPivot(_) => {
-                if self.eq_or_error(env.len(), 2, "env.len() != 2") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 2, "env.len() != 2");
 
                 let mut iter = env.into_iter();
                 let key = iter.next().unwrap();
@@ -788,9 +743,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 logical::BindingsOp::Pivot(logical::Pivot { key, value })
             }
             ProjectionKind::ProjectValue(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
                 let expr = env.into_iter().next().unwrap();
                 logical::BindingsOp::ProjectValue(logical::ProjectValue { expr })
@@ -823,9 +776,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_bin_op(&mut self, _bin_op: &'ast BinOp) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 2, "env.len() != 2") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 2, "env.len() != 2");
 
         let rhs = env.pop().unwrap();
         let lhs = env.pop().unwrap();
@@ -835,17 +786,14 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                     Value::Null => logical::Type::NullType,
                     Value::Missing => logical::Type::MissingType,
                     _ => {
-                        self.errors.push(LowerError::NotYetImplemented(
-                            "Unsupported rhs literal for `IS`".to_string(),
-                        ));
-                        return Traverse::Stop;
+                        not_yet_implemented_fault!(
+                            self,
+                            "Unsupported rhs literal for `IS`".to_string()
+                        );
                     }
                 },
                 _ => {
-                    self.errors.push(LowerError::NotYetImplemented(
-                        "Unsupported rhs for `IS`".to_string(),
-                    ));
-                    return Traverse::Stop;
+                    not_yet_implemented_fault!(self, "Unsupported rhs for `IS`".to_string());
                 }
             };
             self.push_vexpr(ValueExpr::IsTypeExpr(IsTypeExpr {
@@ -884,9 +832,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_uni_op(&mut self, _uni_op: &'ast UniOp) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
         let expr = env.pop().unwrap();
         let op = match _uni_op.kind {
@@ -905,9 +851,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_between(&mut self, _between: &'ast Between) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 3, "env.len() != 3") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 3, "env.len() != 3");
 
         let to = Box::new(env.pop().unwrap());
         let from = Box::new(env.pop().unwrap());
@@ -923,13 +867,11 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_like(&mut self, _like: &'ast Like) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(
+        true_or_fault!(
+            self,
             (2..=3).contains(&env.len()),
-            "env.len() is not between 2 and 3",
-        ) == Traverse::Stop
-        {
-            return Traverse::Stop;
-        }
+            "env.len() is not between 2 and 3"
+        );
         let escape_ve = if env.len() == 3 {
             env.pop().unwrap()
         } else {
@@ -990,37 +932,24 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let mut env = self.exit_env();
         match _call_arg {
             CallArg::Star() => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "* as a call argument".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "* as a call argument".to_string());
             }
             CallArg::Positional(_) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
                 self.push_call_arg(CallArgument::Positional(env.pop().unwrap()));
             }
             CallArg::Named(CallArgNamed { name, .. }) => {
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
                 let name = name.value.to_lowercase();
                 self.push_call_arg(CallArgument::Named(name, env.pop().unwrap()));
             }
             CallArg::PositionalType(_) => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "PositionalType call argument".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "PositionalType call argument".to_string());
             }
             CallArg::NamedType(_) => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "PositionalType call argument".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "PositionalType call argument".to_string());
             }
         }
         Traverse::Continue
@@ -1047,29 +976,22 @@ impl<'ast> Visitor<'ast> for AstToLogical {
             Lit::NationalCharStringLit(s) => Value::String(Box::new(s.clone())),
             Lit::BitStringLit(_) => {
                 // Report error but allow visitor to continue
-                self.errors.push(LowerError::NotYetImplemented(
-                    "Lit::BitStringLit".to_string(),
-                ));
+                not_yet_implemented_err!(self, "Lit::BitStringLit".to_string());
                 Value::Missing
             }
             Lit::HexStringLit(_) => {
                 // Report error but allow visitor to continue
-                self.errors.push(LowerError::NotYetImplemented(
-                    "Lit::HexStringLit".to_string(),
-                ));
+                not_yet_implemented_err!(self, "Lit::HexStringLit".to_string());
                 Value::Missing
             }
             Lit::CollectionLit(_) => {
                 // Report error but allow visitor to continue
-                self.errors.push(LowerError::NotYetImplemented(
-                    "Lit::CollectionLit".to_string(),
-                ));
+                not_yet_implemented_err!(self, "Lit::CollectionLit".to_string());
                 Value::Missing
             }
             Lit::TypedLit(_, _) => {
                 // Report error but allow visitor to continue
-                self.errors
-                    .push(LowerError::NotYetImplemented("Lit::TypedLit".to_string()));
+                not_yet_implemented_err!(self, "Lit::TypedLit".to_string());
                 Value::Missing
             }
         };
@@ -1084,9 +1006,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_struct(&mut self, _struct: &'ast Struct) -> Traverse {
         let env = self.exit_env();
-        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, env.len().is_even(), "env.len() is not even");
 
         let len = env.len() / 2;
         let mut attrs = Vec::with_capacity(len);
@@ -1131,9 +1051,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     }
 
     fn exit_sexp(&mut self, _sexp: &'ast Sexp) -> Traverse {
-        self.errors
-            .push(LowerError::NotYetImplemented("Sexp".to_string()));
-        Traverse::Stop
+        not_yet_implemented_fault!(self, "Sexp".to_string());
     }
 
     fn enter_call_agg(&mut self, _call_agg: &'ast CallAgg) -> Traverse {
@@ -1156,9 +1074,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let new_expr = ValueExpr::VarRef(new_binding_name);
         self.push_vexpr(new_expr);
 
-        if self.true_or_error(!env.is_empty(), "env is empty") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, !env.is_empty(), "env is empty");
         // Default set quantifier if the set quantifier keyword is omitted will be `ALL`
         let (setq, arg) = match env.pop().unwrap() {
             CallArgument::Positional(ve) => (logical::SetQuantifier::All, ve),
@@ -1272,9 +1188,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_path(&mut self, _path: &'ast Path) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
         let steps = self.exit_path();
         let root = env.pop().unwrap();
@@ -1294,9 +1208,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let step = match _path_step {
             PathStep::PathExpr(_s) => {
                 let mut env = self.exit_env();
-                if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-                    return Traverse::Stop;
-                }
+                eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
                 let path = env.pop().unwrap();
                 match path {
@@ -1317,16 +1229,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 }
             }
             PathStep::PathWildCard => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "PathStep::PathWildCard".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "PathStep::PathWildCard".to_string());
             }
             PathStep::PathUnpivot => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "PathStep::PathUnpivot".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "PathStep::PathUnpivot".to_string());
             }
         };
 
@@ -1342,14 +1248,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_from_clause(&mut self, _from_clause: &'ast FromClause) -> Traverse {
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 1, "benv.len() != 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, benv.len(), 1, "benv.len() != 1");
 
         let env = self.exit_env();
-        if self.eq_or_error(env.len(), 0, "env.len() != 0") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 0, "env.len() != 0");
 
         self.current_clauses_mut()
             .from_clause
@@ -1363,10 +1265,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         self.enter_env();
 
         let id = *self.current_node();
-        if self.true_or_error(!self.siblings.is_empty(), "self.siblings is empty") == Traverse::Stop
-        {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, !self.siblings.is_empty(), "self.siblings is empty");
         self.siblings.last_mut().unwrap().push(id);
 
         for sym in [&from_let.as_alias, &from_let.at_alias, &from_let.by_alias]
@@ -1381,9 +1280,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
     fn exit_from_let(&mut self, from_let: &'ast FromLet) -> Traverse {
         *self.current_ctx_mut() = QueryContext::Query;
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
         let expr = env.pop().unwrap();
 
@@ -1423,18 +1320,14 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_join(&mut self, join: &'ast Join) -> Traverse {
         let mut benv = self.exit_benv();
-        if self.eq_or_error(benv.len(), 2, "benv.len() != 2") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, benv.len(), 2, "benv.len() != 2");
 
         let mut env = self.exit_env();
-        if self.true_or_error(
+        true_or_fault!(
+            self,
             (0..=1).contains(&env.len()),
-            "env.len() is not between 0 and 1",
-        ) == Traverse::Stop
-        {
-            return Traverse::Stop;
-        }
+            "env.len() is not between 0 and 1"
+        );
 
         let Join { kind, .. } = join;
 
@@ -1469,15 +1362,10 @@ impl<'ast> Visitor<'ast> for AstToLogical {
                 // visitor recurse into expr will put the condition in the current env
             }
             JoinSpec::Using(_) => {
-                self.errors
-                    .push(LowerError::NotYetImplemented("JoinSpec::Using".to_string()));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "JoinSpec::Using".to_string());
             }
             JoinSpec::Natural => {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "JoinSpec::Natural".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "JoinSpec::Natural".to_string());
             }
         };
         Traverse::Continue
@@ -1490,9 +1378,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_where_clause(&mut self, _where_clause: &'ast ast::WhereClause) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() != 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() != 1");
 
         let filter = logical::BindingsOp::Filter(logical::Filter {
             expr: env.pop().unwrap(),
@@ -1510,9 +1396,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_having_clause(&mut self, _having_clause: &'ast ast::HavingClause) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() is 1");
 
         let having = BindingsOp::Having(logical::Having {
             expr: env.pop().unwrap(),
@@ -1534,16 +1418,11 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let benv = self.exit_benv();
         if !benv.is_empty() {
             {
-                self.errors.push(LowerError::NotYetImplemented(
-                    "Subquery in group by".to_string(),
-                ));
-                return Traverse::Stop;
+                not_yet_implemented_fault!(self, "Subquery in group by".to_string());
             }
         }
         let env = self.exit_env();
-        if self.true_or_error(env.len().is_even(), "env.len() is not even") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, env.len().is_even(), "env.len() is not even");
 
         let group_as_alias = _group_by_expr
             .group_as_alias
@@ -1673,9 +1552,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_sort_spec(&mut self, sort_spec: &'ast SortSpec) -> Traverse {
         let mut env = self.exit_env();
-        if self.eq_or_error(env.len(), 1, "env.len() is 1") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        eq_or_fault!(self, env.len(), 1, "env.len() is 1");
 
         let expr = env.pop().unwrap();
         let order = match sort_spec
@@ -1714,13 +1591,11 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_limit_offset_clause(&mut self, limit_offset: &'ast ast::LimitOffsetClause) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(
+        true_or_fault!(
+            self,
             (1..=2).contains(&env.len()),
-            "env.len() is  not between 1 and 2",
-        ) == Traverse::Stop
-        {
-            return Traverse::Stop;
-        }
+            "env.len() is  not between 1 and 2"
+        );
 
         let offset = if limit_offset.offset.is_some() {
             env.pop()
@@ -1746,9 +1621,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_simple_case(&mut self, _simple_case: &'ast SimpleCase) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(env.len() >= 2, "env.len < 2") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, env.len() >= 2, "env.len < 2");
 
         let default = if env.len().is_even() {
             Some(Box::new(env.pop().unwrap()))
@@ -1785,9 +1658,7 @@ impl<'ast> Visitor<'ast> for AstToLogical {
 
     fn exit_searched_case(&mut self, _searched_case: &'ast SearchedCase) -> Traverse {
         let mut env = self.exit_env();
-        if self.true_or_error(!env.is_empty(), "env is empty") == Traverse::Stop {
-            return Traverse::Stop;
-        }
+        true_or_fault!(self, !env.is_empty(), "env is empty");
 
         let default = if env.len().is_odd() {
             Some(Box::new(env.pop().unwrap()))

--- a/partiql-logical-planner/src/name_resolver.rs
+++ b/partiql-logical-planner/src/name_resolver.rs
@@ -109,7 +109,7 @@ impl NameResolver {
         query.visit(self);
         if !self.errors.is_empty() {
             return Err(LoweringError {
-                errors: self.errors.clone(),
+                errors: std::mem::take(&mut self.errors),
             });
         }
 

--- a/partiql/benches/bench_eval_multi_like.rs
+++ b/partiql/benches/bench_eval_multi_like.rs
@@ -337,7 +337,7 @@ fn parse(text: &str) -> ParserResult {
 }
 #[inline]
 fn compile(parsed: &partiql_parser::Parsed) -> LogicalPlan<BindingsOp> {
-    partiql_logical_planner::lower(parsed)
+    partiql_logical_planner::lower(parsed).expect("Expect no lower error")
 }
 #[inline]
 fn plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {


### PR DESCRIPTION
Partially addresses #349.

Changes the AST to logical plan `lower` function to return a `Result` type. This is part of an effort to reduce the `panic`s within the APIs. Also changes the `Visitor` API provided by `partiql-ast` to return a `Recurse` enum indicating whether visitation into the child nodes should continue or stop.

Conformance test changes are due to updating the `partiql-tests` commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
