### PR TITLE
Changes logical plan to eval plan API to return `Result` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING:* removed `from_ion` method on `Value`
 - *BREAKING:* partiql-ast: `visit` fn returns a `partiql-ast::Recurse` type to indicate if visitation of children nodes should continue
 - *BREAKING:* partiql-logical-planner: modifies `lower(parsed: &Parsed)` to return a Result type of `Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError>` rather than a `logical::LogicalPlan<logical::BindingsOp>`
-- *BREAKING:* partiql-eval: modifies `compile(&mut self, plan: &LogicalPlan<BindingsOp>)` to return a Result type of `Result<EvalPlan, EvalErr>` rather than an `EvalPlan`
+- *BREAKING:* partiql-eval: modifies `compile(&mut self, plan: &LogicalPlan<BindingsOp>)` to return a Result type of `Result<EvalPlan, PlanErr>` rather than an `EvalPlan`
 
 ### Added
 - Implements built-in function `EXTRACT`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING:* removed `from_ion` method on `Value`
 - *BREAKING:* partiql-ast: `visit` fn returns a `partiql-ast::Recurse` type to indicate if visitation of children nodes should continue
 - *BREAKING:* partiql-logical-planner: modifies `lower(parsed: &Parsed)` to return a Result type of `Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError>` rather than a `logical::LogicalPlan<logical::BindingsOp>`
-  - This is part of an effort to replace `panic`s with `Result`s
+- *BREAKING:* partiql-eval: modifies `compile(&mut self, plan: &LogicalPlan<BindingsOp>)` to return a Result type of `Result<EvalPlan, EvalErr>` rather than an `EvalPlan`
+
 ### Added
 - Implements built-in function `EXTRACT`
 - Add `partiql-extension-ion` extension for encoding/decoding `Value` to/from Ion data

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -120,9 +120,8 @@ fn logical_plan() -> LogicalPlan<BindingsOp> {
 }
 
 fn eval_plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
-    let planner = plan::EvaluatorPlanner;
-
-    planner.compile(logical)
+    let mut planner = plan::EvaluatorPlanner::new();
+    planner.compile(logical).expect("Expect no plan error")
 }
 
 fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> Value {

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -1,0 +1,61 @@
+use crate::eval::evaluable::Evaluable;
+use crate::eval::expr::EvalExpr;
+use crate::eval::EvalContext;
+use partiql_value::{Tuple, Value};
+use std::borrow::Cow;
+use thiserror::Error;
+
+/// All errors that occur during evaluation.
+#[derive(Debug)]
+pub struct EvalErr {
+    pub errors: Vec<EvaluationError>,
+}
+
+/// An error that can happen during evaluation.
+/// TODO: decide on splitting out logical to eval plan to separate error enum
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum EvaluationError {
+    /// Malformed evaluation plan with graph containing cycle.
+    #[error("Evaluation Error: invalid evaluation plan detected `{0}`")]
+    InvalidEvaluationPlan(String),
+    /// Feature has not yet been implemented.
+    #[error("Not yet implemented: {0}")]
+    NotYetImplemented(String),
+    /// Internal error that was not due to user input or API violation.
+    #[error("Illegal State: {0}")]
+    IllegalState(String),
+    /// Invalid number of arguments to the function call.
+    #[error("Invalid number of arguments: {0}")]
+    InvalidNumberOfArguments(String),
+    /// Invalid escape pattern.
+    #[error("Invalid LIKE expression pattern: {0}")]
+    InvalidLikeEscape(String),
+}
+
+/// Used when an error occurs during the the logical to eval plan conversion. Allows the conversion
+/// to continue in order to report multiple errors.
+#[derive(Debug)]
+pub(crate) struct ErrorNode {}
+
+impl ErrorNode {
+    pub(crate) fn new() -> ErrorNode {
+        ErrorNode {}
+    }
+}
+
+impl Evaluable for ErrorNode {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
+        panic!("ErrorNode will not be evaluated")
+    }
+
+    fn update_input(&mut self, _input: Value, _branch_num: u8) {
+        panic!("ErrorNode will not be evaluated")
+    }
+}
+
+impl EvalExpr for ErrorNode {
+    fn evaluate<'a>(&'a self, _bindings: &'a Tuple, _ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+        panic!("ErrorNode will not be evaluated")
+    }
+}

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -25,9 +25,6 @@ pub enum EvaluationError {
     /// Internal error that was not due to user input or API violation.
     #[error("Illegal State: {0}")]
     IllegalState(String),
-    /// Invalid number of arguments to the function call.
-    #[error("Invalid number of arguments: {0}")]
-    InvalidNumberOfArguments(String),
     /// Invalid escape pattern.
     #[error("Invalid LIKE expression pattern: {0}")]
     InvalidLikeEscape(String),

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -5,29 +5,37 @@ use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use thiserror::Error;
 
-/// All errors that occur during evaluation.
+/// All errors that occurred during [`partiql_logical::LogicalPlan`] to [`eval::EvalPlan`] creation.
 #[derive(Debug)]
-pub struct EvalErr {
-    pub errors: Vec<EvaluationError>,
+pub struct PlanErr {
+    pub errors: Vec<PlanningError>,
 }
 
-/// An error that can happen during evaluation.
-/// TODO: decide on splitting out logical to eval plan to separate error enum
+/// An error that can happen during [`partiql_logical::LogicalPlan`] to [`eval::EvalPlan`] creation.
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum EvaluationError {
-    /// Malformed evaluation plan with graph containing cycle.
-    #[error("Evaluation Error: invalid evaluation plan detected `{0}`")]
-    InvalidEvaluationPlan(String),
+pub enum PlanningError {
     /// Feature has not yet been implemented.
     #[error("Not yet implemented: {0}")]
     NotYetImplemented(String),
     /// Internal error that was not due to user input or API violation.
     #[error("Illegal State: {0}")]
     IllegalState(String),
-    /// Invalid escape pattern.
-    #[error("Invalid LIKE expression pattern: {0}")]
-    InvalidLikeEscape(String),
+}
+
+/// All errors that occurred during evaluation.
+#[derive(Debug)]
+pub struct EvalErr {
+    pub errors: Vec<EvaluationError>,
+}
+
+/// An error that can happen during evaluation.
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum EvaluationError {
+    /// Malformed evaluation plan with graph containing cycle.
+    #[error("Evaluation Error: invalid evaluation plan detected `{0}`")]
+    InvalidEvaluationPlan(String),
 }
 
 /// Used when an error occurs during the the logical to eval plan conversion. Allows the conversion

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod env;
+mod error;
 pub mod eval;
 pub mod plan;
 
@@ -25,8 +26,8 @@ mod tests {
     };
 
     fn evaluate(logical: LogicalPlan<BindingsOp>, bindings: MapBindings<Value>) -> Value {
-        let planner = plan::EvaluatorPlanner;
-        let mut plan = planner.compile(&logical);
+        let mut planner = plan::EvaluatorPlanner::new();
+        let mut plan = planner.compile(&logical).expect("Expect no plan error");
 
         if let Ok(out) = plan.execute_mut(bindings) {
             out.result

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod env;
-mod error;
+pub mod error;
 pub mod eval;
 pub mod plan;
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -691,49 +691,52 @@ impl<'c> EvaluatorPlanner<'c> {
                         })
                     }
                     CallName::CollAvg(setq) => {
-                        assert_eq!(args.len(), 1);
+                        correct_num_args_or_err!(self, args, 1, "coll_avg");
                         Box::new(EvalFnCollAvg {
                             setq: plan_set_quantifier(setq),
                             elems: args.pop().unwrap(),
                         })
                     }
                     CallName::CollCount(setq) => {
-                        assert_eq!(args.len(), 1);
+                        correct_num_args_or_err!(self, args, 1, "coll_count");
                         Box::new(EvalFnCollCount {
                             setq: plan_set_quantifier(setq),
                             elems: args.pop().unwrap(),
                         })
                     }
                     CallName::CollMax(setq) => {
-                        assert_eq!(args.len(), 1);
+                        correct_num_args_or_err!(self, args, 1, "coll_max");
                         Box::new(EvalFnCollMax {
                             setq: plan_set_quantifier(setq),
                             elems: args.pop().unwrap(),
                         })
                     }
                     CallName::CollMin(setq) => {
-                        assert_eq!(args.len(), 1);
+                        correct_num_args_or_err!(self, args, 1, "coll_min");
                         Box::new(EvalFnCollMin {
                             setq: plan_set_quantifier(setq),
                             elems: args.pop().unwrap(),
                         })
                     }
                     CallName::CollSum(setq) => {
-                        assert_eq!(args.len(), 1);
+                        correct_num_args_or_err!(self, args, 1, "coll_sum");
                         Box::new(EvalFnCollSum {
                             setq: plan_set_quantifier(setq),
                             elems: args.pop().unwrap(),
                         })
                     }
-                    CallName::ByName(name) => {
-                        let function = self
-                            .catalog
-                            .get_function(name)
-                            .expect("function to exist in catalog");
-
-                        let eval = function.plan_eval();
-                        Box::new(EvalFnBaseTableExpr { args, expr: eval })
-                    }
+                    CallName::ByName(name) => match self.catalog.get_function(name) {
+                        None => {
+                            self.errors.push(PlanningError::IllegalState(format!(
+                                "Function to exist in catalog {name}",
+                            )));
+                            Box::new(ErrorNode::new())
+                        }
+                        Some(function) => {
+                            let eval = function.plan_eval();
+                            Box::new(EvalFnBaseTableExpr { args, expr: eval })
+                        }
+                    },
                 }
             }
         }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -63,12 +63,13 @@ impl EvaluatorPlanner {
 
     #[inline]
     pub fn compile(&mut self, plan: &LogicalPlan<BindingsOp>) -> Result<EvalPlan, EvalErr> {
+        let plan = self.plan_eval(plan);
         if !self.errors.is_empty() {
             return Err(EvalErr {
-                errors: self.errors.clone(),
+                errors: std::mem::take(&mut self.errors),
             });
         }
-        Ok(self.plan_eval(plan))
+        Ok(plan)
     }
 
     #[inline]

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -31,7 +31,7 @@ use crate::eval::EvalPlan;
 use partiql_value::Value::Null;
 
 #[macro_export]
-macro_rules! correct_num_args_or_error {
+macro_rules! correct_num_args_or_err {
     ($self:expr, $args:expr, $exact_num:literal, $name:expr) => {
         if $args.len() != $exact_num {
             $self.errors.push(EvaluationError::IllegalState(format!(
@@ -517,55 +517,55 @@ impl EvaluatorPlanner {
                     .collect_vec();
                 match name {
                     CallName::Lower => {
-                        correct_num_args_or_error!(self, args, 1, "lower");
+                        correct_num_args_or_err!(self, args, 1, "lower");
                         Box::new(EvalFnLower {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::Upper => {
-                        correct_num_args_or_error!(self, args, 1, "upper");
+                        correct_num_args_or_err!(self, args, 1, "upper");
                         Box::new(EvalFnUpper {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::CharLength => {
-                        correct_num_args_or_error!(self, args, 1, "char_length");
+                        correct_num_args_or_err!(self, args, 1, "char_length");
                         Box::new(EvalFnCharLength {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::OctetLength => {
-                        correct_num_args_or_error!(self, args, 1, "octet_length");
+                        correct_num_args_or_err!(self, args, 1, "octet_length");
                         Box::new(EvalFnOctetLength {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::BitLength => {
-                        correct_num_args_or_error!(self, args, 1, "bit_length");
+                        correct_num_args_or_err!(self, args, 1, "bit_length");
                         Box::new(EvalFnBitLength {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::LTrim => {
-                        correct_num_args_or_error!(self, args, 2, "ltrim");
+                        correct_num_args_or_err!(self, args, 2, "ltrim");
                         let value = args.pop().unwrap();
                         let to_trim = args.pop().unwrap();
                         Box::new(EvalFnLtrim { value, to_trim })
                     }
                     CallName::BTrim => {
-                        correct_num_args_or_error!(self, args, 2, "btrim");
+                        correct_num_args_or_err!(self, args, 2, "btrim");
                         let value = args.pop().unwrap();
                         let to_trim = args.pop().unwrap();
                         Box::new(EvalFnBtrim { value, to_trim })
                     }
                     CallName::RTrim => {
-                        correct_num_args_or_error!(self, args, 2, "rtrim");
+                        correct_num_args_or_err!(self, args, 2, "rtrim");
                         let value = args.pop().unwrap();
                         let to_trim = args.pop().unwrap();
                         Box::new(EvalFnRtrim { value, to_trim })
                     }
                     CallName::Substring => {
-                        correct_num_args_or_error!(self, args, 2, 3, "substring");
+                        correct_num_args_or_err!(self, args, 2, 3, "substring");
                         let length = if args.len() == 3 {
                             Some(args.pop().unwrap())
                         } else {
@@ -581,13 +581,13 @@ impl EvaluatorPlanner {
                         })
                     }
                     CallName::Position => {
-                        correct_num_args_or_error!(self, args, 2, "position");
+                        correct_num_args_or_err!(self, args, 2, "position");
                         let haystack = args.pop().unwrap();
                         let needle = args.pop().unwrap();
                         Box::new(EvalFnPosition { needle, haystack })
                     }
                     CallName::Overlay => {
-                        correct_num_args_or_error!(self, args, 3, 4, "overlay");
+                        correct_num_args_or_err!(self, args, 3, 4, "overlay");
                         let length = if args.len() == 4 {
                             Some(args.pop().unwrap())
                         } else {
@@ -605,73 +605,73 @@ impl EvaluatorPlanner {
                         })
                     }
                     CallName::Exists => {
-                        correct_num_args_or_error!(self, args, 1, "exists");
+                        correct_num_args_or_err!(self, args, 1, "exists");
                         Box::new(EvalFnExists {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::Abs => {
-                        correct_num_args_or_error!(self, args, 1, "abs");
+                        correct_num_args_or_err!(self, args, 1, "abs");
                         Box::new(EvalFnAbs {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::Mod => {
-                        correct_num_args_or_error!(self, args, 2, "mod");
+                        correct_num_args_or_err!(self, args, 2, "mod");
                         let rhs = args.pop().unwrap();
                         let lhs = args.pop().unwrap();
                         Box::new(EvalFnModulus { lhs, rhs })
                     }
                     CallName::Cardinality => {
-                        correct_num_args_or_error!(self, args, 1, "cardinality");
+                        correct_num_args_or_err!(self, args, 1, "cardinality");
                         Box::new(EvalFnCardinality {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractYear => {
-                        correct_num_args_or_error!(self, args, 1, "extract year");
+                        correct_num_args_or_err!(self, args, 1, "extract year");
                         Box::new(EvalFnExtractYear {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractMonth => {
-                        correct_num_args_or_error!(self, args, 1, "extract month");
+                        correct_num_args_or_err!(self, args, 1, "extract month");
                         Box::new(EvalFnExtractMonth {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractDay => {
-                        correct_num_args_or_error!(self, args, 1, "extract day");
+                        correct_num_args_or_err!(self, args, 1, "extract day");
                         Box::new(EvalFnExtractDay {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractHour => {
-                        correct_num_args_or_error!(self, args, 1, "extract hour");
+                        correct_num_args_or_err!(self, args, 1, "extract hour");
                         Box::new(EvalFnExtractHour {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractMinute => {
-                        correct_num_args_or_error!(self, args, 1, "extract minute");
+                        correct_num_args_or_err!(self, args, 1, "extract minute");
                         Box::new(EvalFnExtractMinute {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractSecond => {
-                        correct_num_args_or_error!(self, args, 1, "extract second");
+                        correct_num_args_or_err!(self, args, 1, "extract second");
                         Box::new(EvalFnExtractSecond {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractTimezoneHour => {
-                        correct_num_args_or_error!(self, args, 1, "extract timezone_hour");
+                        correct_num_args_or_err!(self, args, 1, "extract timezone_hour");
                         Box::new(EvalFnExtractTimezoneHour {
                             value: args.pop().unwrap(),
                         })
                     }
                     CallName::ExtractTimezoneMinute => {
-                        correct_num_args_or_error!(self, args, 1, "extract timezone_minute");
+                        correct_num_args_or_err!(self, args, 1, "extract timezone_minute");
                         Box::new(EvalFnExtractTimezoneMinute {
                             value: args.pop().unwrap(),
                         })

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -52,9 +52,8 @@ mod tests {
 
     #[track_caller]
     fn evaluate(logical: LogicalPlan<BindingsOp>, bindings: MapBindings<Value>) -> Value {
-        let planner = plan::EvaluatorPlanner;
-
-        let mut plan = planner.compile(&logical);
+        let mut planner = plan::EvaluatorPlanner::new();
+        let mut plan = planner.compile(&logical).expect("Expect no plan error");
         println!("{}", plan.to_dot_graph());
 
         if let Ok(out) = plan.execute_mut(bindings) {

--- a/partiql/benches/bench_eval_multi_like.rs
+++ b/partiql/benches/bench_eval_multi_like.rs
@@ -341,7 +341,9 @@ fn compile(parsed: &partiql_parser::Parsed) -> LogicalPlan<BindingsOp> {
 }
 #[inline]
 fn plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
-    EvaluatorPlanner::default().compile(logical)
+    EvaluatorPlanner::default()
+        .compile(logical)
+        .expect("Expect no plan error")
 }
 #[inline]
 pub(crate) fn evaluate(mut eval: EvalPlan, bindings: MapBindings<Value>) -> Value {


### PR DESCRIPTION
Part of #349.

Changes the logical to eval plan lowering API to use a `Result` type rather than panicking on errors. Other evaluation APIs will be changed in an upcoming PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.