### PR TITLE
Modify `parse_embedded_ion_str` to return `Result`, not `expect()`

### DIFF
--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -13,12 +13,19 @@ pub enum LowerError {
     /// Indicates that AST lowering has not yet been implemented for this feature.
     #[error("Not yet implemented: {0}")]
     NotYetImplemented(String),
+
     /// Indicates that there is an internal error that was not due to user input or API violation.
     #[error("Illegal State: {0}")]
     IllegalState(String),
+
+    /// Indicates that there was an error interpreting a literal value.
+    #[error("Error with literal: {literal}: {error}")]
+    Literal { literal: String, error: String },
+
     /// Indicates that this function is not supported.
     #[error("Unsupported function: {0}")]
     UnsupportedFunction(String),
+
     /// Indicates that this aggregation function is not supported.
     #[error("Unsupported aggregation function: {0}")]
     UnsupportedAggregationFunction(String),


### PR DESCRIPTION
Follow on to #361 and #362 to make sure ion parsing returns `Result` rather than panicking

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
