### PR TITLE
Change AST to logical plan function argument lowering to return Result

### DIFF
--- a/partiql-logical-planner/src/call_defs.rs
+++ b/partiql-logical-planner/src/call_defs.rs
@@ -6,6 +6,7 @@ use partiql_value::Value;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
+use crate::error::LowerError;
 use unicase::UniCase;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -21,7 +22,11 @@ pub struct CallDef {
 }
 
 impl CallDef {
-    pub(crate) fn lookup(&self, args: &Vec<CallArgument>) -> ValueExpr {
+    pub(crate) fn lookup(
+        &self,
+        args: &Vec<CallArgument>,
+        name: String,
+    ) -> Result<ValueExpr, LowerError> {
         'overload: for overload in &self.overloads {
             let formals = &overload.input;
             if formals.len() != args.len() {
@@ -39,10 +44,9 @@ impl CallDef {
                 }
             }
 
-            return (overload.output)(actuals);
+            return Ok((overload.output)(actuals));
         }
-
-        todo!("mismatched formal/actual arguments to {}", &self.names[0])
+        Err(LowerError::InvalidNumberOfArguments(name))
     }
 }
 

--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -22,6 +22,10 @@ pub enum LowerError {
     #[error("Error with literal: {literal}: {error}")]
     Literal { literal: String, error: String },
 
+    /// Invalid number of arguments to the function call.
+    #[error("Invalid number of arguments: {0}")]
+    InvalidNumberOfArguments(String),
+
     /// Indicates that this function is not supported.
     #[error("Unsupported function: {0}")]
     UnsupportedFunction(String),


### PR DESCRIPTION
AST to logical plan lowering would panic when an incorrect number of arguments was provided to the function. Changed in this PR to return a `Result` type for this case.

Also changes the recovery behavior to add a `Missing` literal to the environment stack to prevent some downstream irrelevant errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
