### PR TITLE
Update lalrpop to v0.20

### DIFF
--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-lalrpop = "0.19.8"
+lalrpop = "0.20"
 
 [dependencies]
 partiql-ast = { path = "../partiql-ast", version = "0.3.*" }
@@ -35,7 +35,7 @@ num-bigint = "~0.4.0"
 bigdecimal = "~0.2.0"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 
-lalrpop-util = "0.19.8"
+lalrpop-util = "0.20"
 logos = "~0.12.0"
 
 itertools = "~0.10.3"

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -122,8 +122,8 @@ impl<'input> From<LalrpopError<'input>> for ParseError<'input, BytePosition> {
                 ParseError::Unknown(location.into())
             }
 
-            // TODO do something with UnrecognizedEOF.expected
-            lalrpop_util::ParseError::UnrecognizedEOF { expected: _, .. } => {
+            // TODO do something with UnrecognizedEof.expected
+            lalrpop_util::ParseError::UnrecognizedEof { expected: _, .. } => {
                 ParseError::UnexpectedEndOfInput
             }
 


### PR DESCRIPTION
Upgrades lalrpop to v0.20. Required a very small code change. Changes in lalrpop v0.20: https://github.com/lalrpop/lalrpop/blob/master/RELEASES.md#0200-2023-05-02

Main benefit/feature seems to be:
> faster compilation time by up to 2x

which should help w/ the current build times.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
