### PR TITLE
Remove panics in `EvalExpr`, `Evaluable`, and `execute_mut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 ### Added
+- Ability to add and view errors during evaluation with partiql-eval's `EvalContext`
 ### Fixes
 
 ## [0.4.1] - 2023-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- *BREAKING:* partiql-eval: `evaluate` on `Evaluable` returns a `Value` rather than an `Option<Value>`
 ### Added
 - Ability to add and view errors during evaluation with partiql-eval's `EvalContext`
 ### Fixes

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -33,9 +33,15 @@ pub struct EvalErr {
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum EvaluationError {
+    /// Internal error that was not due to user input or API violation.
+    #[error("Illegal State: {0}")]
+    IllegalState(String),
     /// Malformed evaluation plan with graph containing cycle.
     #[error("Evaluation Error: invalid evaluation plan detected `{0}`")]
     InvalidEvaluationPlan(String),
+    /// Feature has not yet been implemented.
+    #[error("Not yet implemented: {0}")]
+    NotYetImplemented(String),
 }
 
 /// Used when an error occurs during the the logical to eval plan conversion. Allows the conversion

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -56,7 +56,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -64,8 +64,9 @@ impl EvalPlan {
                             )],
                         });
                     }
-                    result = src.unwrap().evaluate(&*ctx);
+                    result = Some(src.unwrap().evaluate(&*ctx));
 
+                    // return on first evaluation error
                     if ctx.has_errors() {
                         return Err(EvalErr {
                             errors: ctx.errors(),
@@ -116,7 +117,6 @@ impl EvalPlan {
                     }
                     Some(val) => val,
                 };
-                // TODO: decide on `evaluate`'s type. Currently returns an `Option`. For error handling, perhaps a `Result` type is better here.
                 Ok(Evaluated { result })
             }
             Err(e) => Err(EvalErr {

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -2266,7 +2266,7 @@ mod tests {
                 partiql_tuple![("x", partiql_tuple![("a", 0), ("b", 0)]), ("y", 0)],
                 partiql_tuple![("x", partiql_tuple![("a", 1), ("b", 1)]), ("y", 1)],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.1.1
@@ -2298,7 +2298,7 @@ mod tests {
                     ("y", value::Value::Missing)
                 ],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.1.1
@@ -2323,7 +2323,7 @@ mod tests {
             let scan_res = scan.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", 0)]];
-            assert_eq!(Value::Bag(Box::new(expected)), scan_res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), scan_res);
         }
 
         // Spec 5.1.1
@@ -2348,7 +2348,7 @@ mod tests {
             let res = scan.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", value::Value::Missing)]];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
     }
 
@@ -2386,7 +2386,7 @@ mod tests {
                 partiql_tuple![("symbol", "tdc"), ("price", 31.06)],
                 partiql_tuple![("symbol", "amzn"), ("price", 840.05)],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.2.1
@@ -2407,7 +2407,7 @@ mod tests {
             let res = unpivot.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", 1), ("y", "_1")]];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
     }
 }


### PR DESCRIPTION
Should close out #349. Removes the panics in `EvalExpr` and `Evaluable` and allows for multiple error logging. Current implementation stores the errors in `EvalContext` and updates using interior mutability.

Additionally, changes the `Evaluable` trait's method `evaluate` to return a `Value` rather than an `Option<Value>`, since the optionality of the output value wasn't used anywhere.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
