### PR TITLE
Preliminary work to create a Catalog, plumb it through lowering and evaluation with a `read_ion` extension function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING:* partiql-ast: `visit` fn returns a `partiql-ast::Recurse` type to indicate if visitation of children nodes should continue
 - *BREAKING:* partiql-logical-planner: modifies `lower(parsed: &Parsed)` to return a Result type of `Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError>` rather than a `logical::LogicalPlan<logical::BindingsOp>`
   - This is part of an effort to replace `panic`s with `Result`s
+- *BREAKING:* partiql-logical-planner: Adds a `LogicalPlanner` to encapsulate the `lower` method
+- *BREAKING:* partiql-eval: Adds a `EvaluatorPlanner` now requires a `Catalog` to be supplied at initialization
+- *BREAKING:* partiql-logical-planner: `CallDef` and related types moved to partiql-catalog
 ### Added
 - Implements built-in function `EXTRACT`
 - Add `partiql-extension-ion` extension for encoding/decoding `Value` to/from Ion data
+- Add `partiql-extension-ion-functions` extension which contains an extension function for reading from an Ion file
+- Add `partiql-catalog` including an experimental `Catalog` interface and implementation
 ### Fixes
 - Fix parsing of `EXTRACT` datetime parts `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`
 - Fix logical plan to eval plan conversion for `EvalOrderBySortSpec` with arguments `DESC` and `NULLS LAST`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "partiql",
   "partiql-ast",
   "partiql-ast/partiql-ast-macros",
+  "partiql-catalog",
   "partiql-conformance-tests",
   "partiql-conformance-test-generator",
   "partiql-source-map",
@@ -23,7 +24,10 @@ members = [
   "partiql-rewriter",
   "partiql-types",
   "partiql-value",
+
+
   "extension/partiql-extension-ion",
+  "extension/partiql-extension-ion-functions",
 ]
 
 [profile.dev.build-override]

--- a/extension/partiql-extension-ion-functions/Cargo.toml
+++ b/extension/partiql-extension-ion-functions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "partiql-extension-ion"
-description = "PartiQL Ion extensions"
+name = "partiql-extension-ion-functions"
+description = "PartiQL Ion function extensions"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -21,7 +21,11 @@ edition.workspace = true
 bench = false
 
 [dependencies]
+partiql-extension-ion = {path = "../partiql-extension-ion"}
 partiql-value = { path = "../../partiql-value", version = "0.3.*" }
+partiql-catalog = { path = "../../partiql-catalog", version = "0.3.*" }
+partiql-logical = { path = "../../partiql-logical", version = "0.3.*" }
+
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.6"
@@ -33,9 +37,15 @@ once_cell = "1"
 regex = "1.7"
 thiserror = "1.0"
 delegate = "0.9"
+zstd = "0.12"
+flate2 = "1.0"
 
 [dev-dependencies]
 criterion = "0.4"
+partiql-parser = { path = "../../partiql-parser", version = "0.3.*" }
+partiql-logical = { path = "../../partiql-logical", version = "0.3.*" }
+partiql-logical-planner = { path = "../../partiql-logical-planner", version = "0.3.*" }
+partiql-eval = { path = "../../partiql-eval", version = "0.3.*" }
 
 [features]
 default = []

--- a/extension/partiql-extension-ion-functions/LICENSE
+++ b/extension/partiql-extension-ion-functions/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/extension/partiql-extension-ion-functions/resources/test/test.ion
+++ b/extension/partiql-extension-ion-functions/resources/test/test.ion
@@ -1,0 +1,39 @@
+// Copy 1
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "put"}
+{Program: "p2", Operation: "get"}
+{Program: "p3", Operation: "update"}
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "get"}
+{Program: "p2", Operation: "put"}
+{Program: "p1", Operation: "get"}
+
+// Copy 2 - Same data as Copy 1
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "put"}
+{Program: "p2", Operation: "get"}
+{Program: "p3", Operation: "update"}
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "get"}
+{Program: "p2", Operation: "put"}
+{Program: "p1", Operation: "get"}
+
+// Copy 3 - Same data as Copy 1
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "put"}
+{Program: "p2", Operation: "get"}
+{Program: "p3", Operation: "update"}
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "get"}
+{Program: "p2", Operation: "put"}
+{Program: "p1", Operation: "get"}
+
+// Copy 4 - Same data as Copy 1
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "put"}
+{Program: "p2", Operation: "get"}
+{Program: "p3", Operation: "update"}
+{Program: "p1", Operation: "get"}
+{Program: "p1", Operation: "get"}
+{Program: "p2", Operation: "put"}
+{Program: "p1", Operation: "get"}

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -22,16 +22,26 @@ use thiserror::Error;
 ///
 /// ### Notes
 /// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
-#[derive(Error, Debug, Clone, PartialEq)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum IonExtensionError {
-    /// Stream error.
+    /// Function error.
     #[error("`read_ion` function error: `{}`", .0)]
     FunctionError(String),
+
+    /// Io error.
+    #[error("`read_ion` io error: `{}`", .0)]
+    IoError(std::io::Error),
 
     /// Any other reading error.
     #[error("Ion read error: unknown error")]
     Unknown,
+}
+
+impl From<std::io::Error> for IonExtensionError {
+    fn from(e: std::io::Error) -> Self {
+        IonExtensionError::IoError(e)
+    }
 }
 
 #[derive(Debug)]
@@ -107,8 +117,8 @@ impl BaseTableExpr for EvalFnReadIon {
 }
 
 fn parse_ion_file<'a>(path: &str) -> BaseTableExprResult<'a> {
-    let path = PathBuf::from(path).canonicalize().unwrap();
-    let file = File::open(path).unwrap();
+    let path = PathBuf::from(path).canonicalize()?;
+    let file = File::open(path)?;
 
     parse_ion_read(file)
 }

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -1,0 +1,229 @@
+use ion_rs::data_source::ToIonDataSource;
+use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
+use partiql_catalog::{
+    BaseTableExpr, BaseTableExprResult, BaseTableExprResultError, BaseTableExprResultValueIter,
+    BaseTableFunctionInfo, Catalog,
+};
+use partiql_catalog::{CatalogError, ObjectId, TableFunction};
+use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
+use partiql_extension_ion::Encoding;
+use partiql_logical as logical;
+use partiql_value::Value;
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::Debug;
+use std::fs::{read, File};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors in ion extension.
+///
+/// ### Notes
+/// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
+#[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum IonExtensionError {
+    /// Stream error.
+    #[error("`read_ion` function error: `{}`", .0)]
+    FunctionError(String),
+
+    /// Any other reading error.
+    #[error("Ion read error: unknown error")]
+    Unknown,
+}
+
+#[derive(Debug)]
+pub(crate) struct IonExtension {}
+
+impl partiql_catalog::Extension for IonExtension {
+    fn name(&self) -> String {
+        "ion".into()
+    }
+
+    fn load(&self, catalog: &mut Box<dyn Catalog>) -> Result<(), Box<dyn Error>> {
+        match catalog.add_table_function(TableFunction::new(Box::new(ReadIonFunction::new()))) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(Box::new(e) as Box<dyn Error>),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ReadIonFunction {
+    call_def: CallDef,
+}
+
+impl ReadIonFunction {
+    pub fn new() -> Self {
+        ReadIonFunction {
+            call_def: CallDef {
+                names: vec!["read_ion"],
+                overloads: vec![CallSpec {
+                    input: vec![CallSpecArg::Positional],
+                    output: Box::new(|args| {
+                        logical::ValueExpr::Call(logical::CallExpr {
+                            name: logical::CallName::ByName("read_ion".to_string()),
+                            arguments: args,
+                        })
+                    }),
+                }],
+            },
+        }
+    }
+}
+
+impl BaseTableFunctionInfo for ReadIonFunction {
+    fn call_def(&self) -> &CallDef {
+        &self.call_def
+    }
+
+    fn plan_eval(&self) -> Box<dyn BaseTableExpr> {
+        Box::new(EvalFnReadIon {})
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct EvalFnReadIon {}
+
+impl BaseTableExpr for EvalFnReadIon {
+    fn evaluate(&self, args: &[Cow<Value>]) -> BaseTableExprResult {
+        if let Some(arg1) = args.first() {
+            match arg1.as_ref() {
+                Value::String(path) => parse_ion_file(&path),
+                _ => {
+                    let error = IonExtensionError::FunctionError(
+                        "expected string path argument".to_string(),
+                    );
+                    Err(Box::new(error) as BaseTableExprResultError)
+                }
+            }
+        } else {
+            let error = IonExtensionError::FunctionError("expected path argument".to_string());
+            Err(Box::new(error) as BaseTableExprResultError)
+        }
+    }
+}
+
+fn parse_ion_file<'a>(path: &str) -> BaseTableExprResult<'a> {
+    let path = PathBuf::from(path).canonicalize().unwrap();
+    let mut file = File::open(path).unwrap();
+
+    parse_ion_read(file)
+}
+
+fn parse_ion_read<'a>(mut reader: impl 'a + Read + Seek) -> BaseTableExprResult<'a> {
+    let mut header: [u8; 4] = [0; 4];
+    reader.read(&mut header).expect("file header");
+    reader.seek(SeekFrom::Start(0)).expect("file seek");
+
+    if header.starts_with(&[0x1f, 0x8b]) {
+        let decoder = flate2::read::GzDecoder::new(reader);
+        let buffered = BufReader::new(decoder);
+        parse_ion_buff(buffered)
+    } else if header.starts_with(&[0x28, 0xB5, 0x2F, 0xFD]) {
+        let decoder = zstd::Decoder::new(reader).expect("zstd reader creation");
+        let buffered = BufReader::new(decoder);
+        parse_ion_buff(buffered)
+    } else {
+        let buffered = BufReader::new(reader);
+        parse_ion_buff(buffered)
+    }
+}
+
+fn parse_ion_buff<'a, I: 'a + ToIonDataSource>(input: I) -> BaseTableExprResult<'a> {
+    let err_map = |e| Box::new(e) as BaseTableExprResultError;
+    let mut reader = ion_rs::ReaderBuilder::new().build(input).unwrap();
+    let decoder =
+        IonDecoderBuilder::new(IonDecoderConfig::default().with_mode(Encoding::Ion)).build(reader);
+    let mut decoder = decoder.map_err(err_map)?.map(move |it| it.map_err(err_map));
+    Ok(Box::new(decoder) as BaseTableExprResultValueIter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use itertools::Itertools;
+
+    use partiql_catalog::{Catalog, Extension, PartiqlCatalog};
+    use partiql_eval::env::basic::MapBindings;
+    use partiql_parser::{Parsed, ParserResult};
+    use partiql_value::{partiql_bag, partiql_list, partiql_tuple, DateTime, Value};
+    use rust_decimal_macros::dec;
+    use std::num::NonZeroU8;
+
+    #[track_caller]
+    #[inline]
+    pub(crate) fn parse(statement: &str) -> ParserResult {
+        partiql_parser::Parser::default().parse(statement)
+    }
+
+    #[track_caller]
+    #[inline]
+    pub(crate) fn lower(
+        catalog: &Box<dyn Catalog>,
+        parsed: &Parsed,
+    ) -> partiql_logical::LogicalPlan<partiql_logical::BindingsOp> {
+        let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
+        planner.lower(parsed).expect("lower")
+    }
+
+    #[track_caller]
+    #[inline]
+    pub(crate) fn evaluate(
+        catalog: &Box<dyn Catalog>,
+        logical: partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+        bindings: MapBindings<Value>,
+    ) -> Value {
+        let planner = partiql_eval::plan::EvaluatorPlanner::new(catalog);
+
+        let mut plan = planner.compile(&logical);
+
+        if let Ok(out) = plan.execute_mut(bindings) {
+            out.result
+        } else {
+            Value::Missing
+        }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn pass_eval(statement: &str, env: &Option<Value>, expected: &Value) {
+        let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
+        let ext = IonExtension {};
+        ext.load(&mut catalog);
+
+        let parsed = parse(statement);
+        let lowered = lower(&catalog, &parsed.expect("parse"));
+        let bindings = env
+            .as_ref()
+            .map(|e| (e).into())
+            .unwrap_or_else(MapBindings::default);
+        let out = evaluate(&catalog, lowered, bindings);
+
+        assert!(out.is_bag());
+        assert_eq!(&out, expected);
+    }
+
+    #[test]
+    fn custom_ion_scan() {
+        let value = partiql_bag![
+            partiql_tuple![("Program", "p1"), ("Operation", "get")],
+            partiql_tuple![("Program", "p1"), ("Operation", "put")],
+            partiql_tuple![("Program", "p2"), ("Operation", "get")],
+            partiql_tuple![("Program", "p2"), ("Operation", "put")],
+            partiql_tuple![("Program", "p3"), ("Operation", "update")],
+        ]
+        .into();
+
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("resources/test/test.ion");
+        let path = path.as_path().display();
+
+        let query = format!("SELECT DISTINCT Program, Operation from read_ion('{path}') as fel");
+        pass_eval(&query, &None, &value);
+    }
+}

--- a/partiql-ast/partiql-ast-macros/Cargo.toml
+++ b/partiql-ast/partiql-ast-macros/Cargo.toml
@@ -22,8 +22,8 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-quote = "1.0.*"
-syn = {version="1.0.*", default-features = true, features=["full"]}
+quote = "1.0"
+syn = {version="2.0", default-features = true, features=["full"]}
 proc-macro2 = "1.0.*"
-darling = "0.14.*"
+darling = "0.20"
 Inflector = "0.11.*"

--- a/partiql-catalog/Cargo.toml
+++ b/partiql-catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "partiql-types"
-description = "PartiQL Type Definitions"
+name = "partiql-catalog"
+description = "PartiQL Catalog Definitions"
 authors.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -21,6 +21,10 @@ edition.workspace = true
 bench = false
 
 [dependencies]
+partiql-value = { path = "../partiql-value", version = "0.3.*" }
+partiql-parser = { path = "../partiql-parser", version = "0.3.*" }
+partiql-logical = { path = "../partiql-logical", version = "0.3.*" }
+thiserror = "1.0"
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.6"

--- a/partiql-catalog/LICENSE
+++ b/partiql-catalog/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/partiql-catalog/src/call_defs.rs
+++ b/partiql-catalog/src/call_defs.rs
@@ -1,0 +1,94 @@
+use itertools::Itertools;
+use partiql_logical as logical;
+use partiql_logical::ValueExpr;
+use partiql_value::Value;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use thiserror::Error;
+
+use unicase::UniCase;
+
+/// An error that can happen during call lookup
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CallLookupError {
+    /// Invalid number of arguments to the function call.
+    #[error("Invalid number of arguments: {0}")]
+    InvalidNumberOfArguments(String),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum CallArgument {
+    Positional(ValueExpr),
+    Named(String, ValueExpr),
+}
+
+#[derive(Debug)]
+pub struct CallDef {
+    pub names: Vec<&'static str>,
+    pub overloads: Vec<CallSpec>,
+}
+
+impl CallDef {
+    pub fn lookup(
+        &self,
+        args: &Vec<CallArgument>,
+        name: &str,
+    ) -> Result<ValueExpr, CallLookupError> {
+        'overload: for overload in &self.overloads {
+            let formals = &overload.input;
+            if formals.len() != args.len() {
+                continue 'overload;
+            }
+
+            let mut actuals = vec![];
+            for i in 0..formals.len() {
+                let formal = &formals[i];
+                let actual = &args[i];
+                if let Some(vexpr) = formal.transform(actual) {
+                    actuals.push(vexpr);
+                } else {
+                    continue 'overload;
+                }
+            }
+
+            return Ok((overload.output)(actuals));
+        }
+        Err(CallLookupError::InvalidNumberOfArguments(name.into()))
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum CallSpecArg {
+    Positional,
+    Named(UniCase<&'static str>),
+}
+
+impl CallSpecArg {
+    pub(crate) fn transform(&self, arg: &CallArgument) -> Option<ValueExpr> {
+        match (self, arg) {
+            (CallSpecArg::Positional, CallArgument::Positional(ve)) => Some(ve.clone()),
+            (CallSpecArg::Named(formal_name), CallArgument::Named(arg_name, ve)) => {
+                if formal_name == &UniCase::new(arg_name.as_str()) {
+                    Some(ve.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl CallSpecArg {}
+
+pub struct CallSpec {
+    pub input: Vec<CallSpecArg>,
+    pub output: Box<dyn Fn(Vec<ValueExpr>) -> logical::ValueExpr + Send + Sync>,
+}
+
+impl Debug for CallSpec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CallSpec [{:?}]", &self.input)
+    }
+}

--- a/partiql-catalog/src/call_defs.rs
+++ b/partiql-catalog/src/call_defs.rs
@@ -1,8 +1,6 @@
-use itertools::Itertools;
 use partiql_logical as logical;
 use partiql_logical::ValueExpr;
-use partiql_value::Value;
-use std::collections::HashMap;
+
 use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -1,0 +1,230 @@
+use crate::call_defs::CallDef;
+use partiql_value::Value;
+use std::borrow::Cow;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
+use thiserror::Error;
+use unicase::UniCase;
+
+pub mod call_defs;
+
+pub trait Extension: Debug {
+    fn name(&self) -> String;
+    fn load(&self, catalog: &mut Box<dyn Catalog>) -> Result<(), Box<dyn Error>>;
+}
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
+struct CatalogId(u64);
+
+impl From<u64> for CatalogId {
+    fn from(value: u64) -> Self {
+        CatalogId(value)
+    }
+}
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
+struct EntryId(u64);
+
+impl From<u64> for EntryId {
+    fn from(value: u64) -> Self {
+        EntryId(value)
+    }
+}
+
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
+pub struct ObjectId {
+    catalog_id: CatalogId,
+    entry_id: EntryId,
+}
+
+// Table Function
+
+pub type BaseTableExprResultError = Box<dyn Error>;
+pub type BaseTableExprResultValueIter<'a> =
+    Box<dyn 'a + Iterator<Item = Result<Value, BaseTableExprResultError>>>;
+pub type BaseTableExprResult<'a> =
+    Result<BaseTableExprResultValueIter<'a>, BaseTableExprResultError>;
+
+pub trait BaseTableExpr: Debug {
+    fn evaluate(&self, args: &[Cow<Value>]) -> BaseTableExprResult;
+}
+
+pub trait BaseTableFunctionInfo: Debug {
+    fn call_def(&self) -> &CallDef;
+    fn plan_eval(&self) -> Box<dyn BaseTableExpr>;
+}
+
+// TODO
+#[derive(Debug)]
+pub struct TableFunction {
+    info: Box<dyn BaseTableFunctionInfo>,
+}
+
+impl TableFunction {
+    pub fn new(info: Box<dyn BaseTableFunctionInfo>) -> Self {
+        TableFunction { info }
+    }
+}
+
+/// Catalog Errors.
+///
+/// ### Notes
+/// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
+#[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CatalogError {
+    /// Entry exists error.
+    #[error("Catalog error: entry already exists for `{}`", .0)]
+    EntryExists(String),
+
+    /// Entry error.
+    #[error("Catalog error: `{}`", .0)]
+    EntryError(String),
+
+    /// Any other catalog error.
+    #[error("Catalog error: unknown error")]
+    Unknown,
+}
+
+pub trait Catalog: Debug {
+    fn add_table_function(&mut self, info: TableFunction) -> Result<ObjectId, CatalogError>;
+
+    fn get_function(&self, name: &str) -> Option<FunctionEntry>;
+}
+
+#[derive(Debug)]
+pub struct FunctionEntry<'a> {
+    id: ObjectId,
+    function: &'a FunctionEntryFunction,
+}
+
+#[derive(Debug)]
+pub enum FunctionEntryFunction {
+    Table(TableFunction),
+    Scalar(),
+    Aggregate(),
+}
+
+impl<'a> FunctionEntry<'a> {
+    pub fn call_def(&'a self) -> &'a CallDef {
+        match &self.function {
+            FunctionEntryFunction::Table(tf) => tf.info.call_def(),
+            FunctionEntryFunction::Scalar() => todo!(),
+            FunctionEntryFunction::Aggregate() => todo!(),
+        }
+    }
+
+    pub fn plan_eval(&'a self) -> Box<dyn BaseTableExpr> {
+        match &self.function {
+            FunctionEntryFunction::Table(tf) => tf.info.plan_eval(),
+            FunctionEntryFunction::Scalar() => todo!(),
+            FunctionEntryFunction::Aggregate() => todo!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PartiqlCatalog {
+    functions: CatalogEntrySet<FunctionEntryFunction>,
+
+    id: CatalogId,
+}
+
+impl Default for PartiqlCatalog {
+    fn default() -> Self {
+        PartiqlCatalog {
+            functions: Default::default(),
+
+            id: CatalogId(1),
+        }
+    }
+}
+
+impl PartiqlCatalog {}
+
+impl Catalog for PartiqlCatalog {
+    fn add_table_function(&mut self, info: TableFunction) -> Result<ObjectId, CatalogError> {
+        let call_def = info.info.call_def();
+        let names = call_def.names.clone();
+        if let Some((name, aliases)) = names.split_first() {
+            let id = self
+                .functions
+                .add(&name, &aliases, FunctionEntryFunction::Table(info))?;
+            Ok(ObjectId {
+                catalog_id: self.id,
+                entry_id: id,
+            })
+        } else {
+            return Err(CatalogError::EntryError(
+                "Function definition has no name".into(),
+            ));
+        }
+    }
+
+    fn get_function(&self, name: &str) -> Option<FunctionEntry> {
+        self.functions.find_by_name(name).map(|(eid, entry)| {
+            //
+            FunctionEntry {
+                id: ObjectId {
+                    catalog_id: self.id,
+                    entry_id: eid,
+                },
+                function: entry,
+            }
+        })
+    }
+}
+
+#[derive(Debug)]
+struct CatalogEntrySet<T> {
+    entries: HashMap<EntryId, T>,
+    by_name: HashMap<UniCase<String>, EntryId>,
+
+    next_id: AtomicU64,
+}
+
+impl<T> Default for CatalogEntrySet<T> {
+    fn default() -> Self {
+        CatalogEntrySet {
+            entries: Default::default(),
+            by_name: Default::default(),
+            next_id: 1.into(),
+        }
+    }
+}
+
+impl<T> CatalogEntrySet<T> {
+    fn add(&mut self, name: &str, aliases: &[&str], info: T) -> Result<EntryId, CatalogError> {
+        let name = UniCase::from(name);
+        if self.by_name.contains_key(&name) {
+            return Err(CatalogError::EntryExists(name.to_string()));
+        }
+
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst).into();
+        if let Some(old_val) = self.entries.insert(id, info) {
+            return Err(CatalogError::Unknown);
+        }
+
+        self.by_name.insert(name, id);
+
+        Ok(id)
+    }
+
+    fn find_by_name(&self, name: &str) -> Option<(EntryId, &T)> {
+        let name = UniCase::from(name);
+        if let Some(eid) = self.by_name.get(&name) {
+            self.entries.get(eid).map(|e| (*eid, e))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn todo() {}
+}

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -40,8 +40,6 @@ pub struct ObjectId {
     entry_id: EntryId,
 }
 
-// Table Function
-
 pub type BaseTableExprResultError = Box<dyn Error>;
 pub type BaseTableExprResultValueIter<'a> =
     Box<dyn 'a + Iterator<Item = Result<Value, BaseTableExprResultError>>>;
@@ -165,16 +163,15 @@ impl Catalog for PartiqlCatalog {
     }
 
     fn get_function(&self, name: &str) -> Option<FunctionEntry> {
-        self.functions.find_by_name(name).map(|(eid, entry)| {
-            //
-            FunctionEntry {
+        self.functions
+            .find_by_name(name)
+            .map(|(eid, entry)| FunctionEntry {
                 id: ObjectId {
                     catalog_id: self.id,
                     entry_id: eid,
                 },
                 function: entry,
-            }
-        })
+            })
     }
 }
 

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -33,6 +33,7 @@ partiql-conformance-test-generator = { path = "../partiql-conformance-test-gener
 
 [dependencies]
 partiql-parser = { path = "../partiql-parser", version = "0.3.*" }
+partiql-catalog = { path = "../partiql-catalog", version = "0.3.*" }
 partiql-ast = { path = "../partiql-ast", version = "0.3.*" }
 partiql-logical-planner = { path = "../partiql-logical-planner", version = "0.3.*" }
 partiql-logical = { path = "../partiql-logical", version = "0.3.*" }

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[track_caller]
 #[inline]
 pub(crate) fn lower(
-    catalog: &Box<dyn Catalog>,
+    catalog: &dyn Catalog,
     parsed: &Parsed,
 ) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
     let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
@@ -35,7 +35,7 @@ pub(crate) fn lower(
 #[track_caller]
 #[inline]
 pub(crate) fn evaluate(
-    catalog: &Box<dyn Catalog>,
+    catalog: &dyn Catalog,
     logical: logical::LogicalPlan<logical::BindingsOp>,
     bindings: MapBindings<Value>,
 ) -> Value {
@@ -84,7 +84,7 @@ pub(crate) fn fail_semantics(_statement: &str) {
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn pass_semantics(statement: &str) {
-    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
+    let catalog = PartiqlCatalog::default();
     let parsed = pass_syntax(statement);
     // TODO add Result to lower call
     let lowered: Result<_, ()> = Ok(lower(&catalog, &parsed));
@@ -98,7 +98,7 @@ pub(crate) fn pass_semantics(statement: &str) {
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn fail_eval(statement: &str, mode: EvaluationMode, env: &Option<TestValue>) {
-    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
+    let catalog = PartiqlCatalog::default();
     if let EvaluationMode::Error = mode {
         eprintln!("EvaluationMode::Error currently unsupported");
         return;
@@ -126,7 +126,7 @@ pub(crate) fn pass_eval(
     env: &Option<TestValue>,
     expected: &TestValue,
 ) {
-    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
+    let catalog = PartiqlCatalog::default();
     if let EvaluationMode::Error = mode {
         eprintln!("EvaluationMode::Error currently unsupported");
         return;

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -1,3 +1,4 @@
+use partiql_catalog::{Catalog, PartiqlCatalog};
 use partiql_eval as eval;
 use partiql_eval::env::basic::MapBindings;
 use partiql_logical as logical;
@@ -24,18 +25,21 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[track_caller]
 #[inline]
 pub(crate) fn lower(
+    catalog: &Box<dyn Catalog>,
     parsed: &Parsed,
 ) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
-    partiql_logical_planner::lower(parsed)
+    let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
+    planner.lower(parsed)
 }
 
 #[track_caller]
 #[inline]
 pub(crate) fn evaluate(
+    catalog: &Box<dyn Catalog>,
     logical: logical::LogicalPlan<logical::BindingsOp>,
     bindings: MapBindings<Value>,
 ) -> Value {
-    let planner = eval::plan::EvaluatorPlanner;
+    let planner = eval::plan::EvaluatorPlanner::new(catalog);
 
     let mut plan = planner.compile(&logical);
 
@@ -80,9 +84,10 @@ pub(crate) fn fail_semantics(_statement: &str) {
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn pass_semantics(statement: &str) {
+    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
     let parsed = pass_syntax(statement);
     // TODO add Result to lower call
-    let lowered: Result<_, ()> = Ok(lower(&parsed));
+    let lowered: Result<_, ()> = Ok(lower(&catalog, &parsed));
     assert!(
         lowered.is_ok(),
         "For `{statement}`, expected `Ok(_)`, but was `{lowered:#?}`"
@@ -93,19 +98,20 @@ pub(crate) fn pass_semantics(statement: &str) {
 #[inline]
 #[allow(dead_code)]
 pub(crate) fn fail_eval(statement: &str, mode: EvaluationMode, env: &Option<TestValue>) {
+    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
     if let EvaluationMode::Error = mode {
         eprintln!("EvaluationMode::Error currently unsupported");
         return;
     }
 
     let parsed = parse(statement);
-    let lowered_result = lower(&parsed.expect("parse"));
+    let lowered_result = lower(&catalog, &parsed.expect("parse"));
     let lowered = lowered_result.expect("lower");
     let bindings = env
         .as_ref()
         .map(|e| (&e.value).into())
         .unwrap_or_else(MapBindings::default);
-    let out = evaluate(lowered, bindings);
+    let out = evaluate(&catalog, lowered, bindings);
 
     println!("{:?}", &out);
     // TODO assert failure
@@ -120,19 +126,20 @@ pub(crate) fn pass_eval(
     env: &Option<TestValue>,
     expected: &TestValue,
 ) {
+    let mut catalog = Box::new(PartiqlCatalog::default()) as Box<dyn Catalog>;
     if let EvaluationMode::Error = mode {
         eprintln!("EvaluationMode::Error currently unsupported");
         return;
     }
 
     let parsed = parse(statement);
-    let lowered_result = lower(&parsed.expect("parse"));
+    let lowered_result = lower(&catalog, &parsed.expect("parse"));
     let lowered = lowered_result.expect("lower");
     let bindings = env
         .as_ref()
         .map(|e| (&e.value).into())
         .unwrap_or_else(MapBindings::default);
-    let out = evaluate(lowered, bindings);
+    let out = evaluate(&catalog, lowered, bindings);
 
     println!("{:?}", &out);
     assert_eq!(out, expected.value);

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -23,10 +23,11 @@ bench = false
 [dependencies]
 partiql-logical = { path = "../partiql-logical", version = "0.3.*" }
 partiql-value = { path = "../partiql-value", version = "0.3.*" }
+partiql-catalog = { path = "../partiql-catalog", version = "0.3.*" }
 petgraph = "0.6.*"
 ordered-float = "3.*"
 itertools = "0.10.*"
-unicase = "2.*"
+unicase = "2.6"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.26"
 thiserror = "1.0"

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use partiql_catalog::PartiqlCatalog;
 
 use partiql_eval::env::basic::MapBindings;
 use partiql_eval::eval::EvalPlan;
@@ -120,7 +121,8 @@ fn logical_plan() -> LogicalPlan<BindingsOp> {
 }
 
 fn eval_plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
-    let planner = plan::EvaluatorPlanner;
+    let catalog = PartiqlCatalog::default();
+    let planner = plan::EvaluatorPlanner::new(&catalog);
 
     planner.compile(logical)
 }

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -2,7 +2,7 @@ use crate::env::Bindings;
 use crate::eval::expr::pattern_match::like_to_re_pattern;
 use crate::eval::EvalContext;
 use itertools::Itertools;
-use partiql_catalog::{BaseTableExpr, BaseTableExprResult, BaseTableExprResultError};
+use partiql_catalog::BaseTableExpr;
 use partiql_logical::Type;
 use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -9,6 +9,7 @@ mod tests {
 
     use crate::env::basic::MapBindings;
     use crate::plan;
+    use partiql_catalog::PartiqlCatalog;
     use rust_decimal_macros::dec;
 
     use partiql_logical as logical;
@@ -25,7 +26,8 @@ mod tests {
     };
 
     fn evaluate(logical: LogicalPlan<BindingsOp>, bindings: MapBindings<Value>) -> Value {
-        let planner = plan::EvaluatorPlanner;
+        let catalog = PartiqlCatalog::default();
+        let planner = plan::EvaluatorPlanner::new(&catalog);
         let mut plan = planner.compile(&logical);
 
         if let Ok(out) = plan.execute_mut(bindings) {

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -31,11 +31,11 @@ use partiql_catalog::Catalog;
 use partiql_value::Value::Null;
 
 pub struct EvaluatorPlanner<'c> {
-    catalog: &'c Box<dyn Catalog>,
+    catalog: &'c dyn Catalog,
 }
 
 impl<'c> EvaluatorPlanner<'c> {
-    pub fn new(catalog: &'c Box<dyn Catalog>) -> Self {
+    pub fn new(catalog: &'c dyn Catalog) -> Self {
         EvaluatorPlanner { catalog }
     }
 
@@ -642,14 +642,11 @@ impl<'c> EvaluatorPlanner<'c> {
                     CallName::ByName(name) => {
                         let function = self
                             .catalog
-                            .get_function(&name)
+                            .get_function(name)
                             .expect("function to exist in catalog");
 
                         let eval = function.plan_eval();
-                        Box::new(EvalFnBaseTableExpr {
-                            args: args,
-                            expr: eval,
-                        })
+                        Box::new(EvalFnBaseTableExpr { args, expr: eval })
                     }
                 }
             }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -18,8 +18,8 @@ use crate::eval::evaluable::{
 use crate::eval::expr::pattern_match::like_to_re_pattern;
 use crate::eval::expr::{
     EvalBagExpr, EvalBetweenExpr, EvalBinOp, EvalBinOpExpr, EvalDynamicLookup, EvalExpr, EvalFnAbs,
-    EvalFnBitLength, EvalFnBtrim, EvalFnCardinality, EvalFnCharLength, EvalFnExists,
-    EvalFnExtractDay, EvalFnExtractHour, EvalFnExtractMinute, EvalFnExtractMonth,
+    EvalFnBaseTableExpr, EvalFnBitLength, EvalFnBtrim, EvalFnCardinality, EvalFnCharLength,
+    EvalFnExists, EvalFnExtractDay, EvalFnExtractHour, EvalFnExtractMinute, EvalFnExtractMonth,
     EvalFnExtractSecond, EvalFnExtractTimezoneHour, EvalFnExtractTimezoneMinute, EvalFnExtractYear,
     EvalFnLower, EvalFnLtrim, EvalFnModulus, EvalFnOctetLength, EvalFnOverlay, EvalFnPosition,
     EvalFnRtrim, EvalFnSubstring, EvalFnUpper, EvalIsTypeExpr, EvalLikeMatch,
@@ -27,12 +27,18 @@ use crate::eval::expr::{
     EvalTupleExpr, EvalUnaryOp, EvalUnaryOpExpr, EvalVarRef,
 };
 use crate::eval::EvalPlan;
+use partiql_catalog::Catalog;
 use partiql_value::Value::Null;
 
-#[derive(Default)]
-pub struct EvaluatorPlanner;
+pub struct EvaluatorPlanner<'c> {
+    catalog: &'c Box<dyn Catalog>,
+}
 
-impl EvaluatorPlanner {
+impl<'c> EvaluatorPlanner<'c> {
+    pub fn new(catalog: &'c Box<dyn Catalog>) -> Self {
+        EvaluatorPlanner { catalog }
+    }
+
     #[inline]
     pub fn compile(&self, plan: &LogicalPlan<BindingsOp>) -> EvalPlan {
         self.plan_eval(plan)
@@ -631,6 +637,18 @@ impl EvaluatorPlanner {
                         assert_eq!(args.len(), 1);
                         Box::new(EvalFnExtractTimezoneMinute {
                             value: args.pop().unwrap(),
+                        })
+                    }
+                    CallName::ByName(name) => {
+                        let function = self
+                            .catalog
+                            .get_function(&name)
+                            .expect("function to exist in catalog");
+
+                        let eval = function.plan_eval();
+                        Box::new(EvalFnBaseTableExpr {
+                            args: args,
+                            expr: eval,
                         })
                     }
                 }

--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -26,10 +26,11 @@ partiql-extension-ion = {path = "../extension/partiql-extension-ion", version = 
 partiql-logical = { path = "../partiql-logical", version = "0.3.*" }
 partiql-ast = { path = "../partiql-ast", version = "0.3.*" }
 partiql-parser = { path = "../partiql-parser", version = "0.3.*" }
+partiql-catalog = { path = "../partiql-catalog", version = "0.3.*" }
 ion-rs = "0.17"
 ordered-float = "3.*"
 itertools = "0.10.*"
-unicase = "2.*"
+unicase = "2.6"
 indexmap = "1.9"
 petgraph = "0.6.*"
 num = "0.4"

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -4,9 +4,8 @@ use partiql_logical as logical;
 use partiql_logical::ValueExpr;
 use partiql_value::Value;
 use std::collections::HashMap;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
-use crate::error::LowerError;
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
 use unicase::UniCase;
 

--- a/partiql-logical-planner/src/error.rs
+++ b/partiql-logical-planner/src/error.rs
@@ -1,3 +1,4 @@
+use partiql_catalog::call_defs::CallLookupError;
 use thiserror::Error;
 
 /// Contains the errors that occur during AST to logical plan conversion
@@ -33,4 +34,17 @@ pub enum LowerError {
     /// Indicates that this aggregation function is not supported.
     #[error("Unsupported aggregation function: {0}")]
     UnsupportedAggregationFunction(String),
+
+    /// Any other lowering error.
+    #[error("Lowering error: {0}")]
+    Unknown(String),
+}
+
+impl From<CallLookupError> for LowerError {
+    fn from(err: CallLookupError) -> Self {
+        match err {
+            CallLookupError::InvalidNumberOfArguments(e) => LowerError::InvalidNumberOfArguments(e),
+            e => LowerError::Unknown(e.to_string()),
+        }
+    }
 }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -24,12 +24,14 @@ use partiql_value::{BindingsName, Value};
 
 use std::collections::{HashMap, HashSet};
 
-use crate::call_defs::{CallArgument, FnSymTab, FN_SYM_TAB};
+use crate::builtins::{FnSymTab, FN_SYM_TAB};
 use crate::name_resolver;
 use itertools::Itertools;
+use partiql_catalog::call_defs::{CallArgument, CallDef};
 
 use crate::error::{LowerError, LoweringError};
 
+use partiql_catalog::Catalog;
 use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
 use partiql_extension_ion::Encoding;
 use partiql_logical::AggFunc::{AggAvg, AggCount, AggMax, AggMin, AggSum};
@@ -143,7 +145,7 @@ impl IdGenerator {
 }
 
 #[derive(Debug)]
-pub struct AstToLogical {
+pub struct AstToLogical<'a> {
     // current stack of node ids
     id_stack: Vec<NodeId>,
 
@@ -169,8 +171,10 @@ pub struct AstToLogical {
     // output
     plan: LogicalPlan<BindingsOp>,
 
+    // catalog & data flow data
     key_registry: name_resolver::KeyRegistry,
     fnsym_tab: &'static FnSymTab,
+    catalog: &'a Box<dyn Catalog>,
 
     // list of errors encountered during AST lowering
     errors: Vec<LowerError>,
@@ -209,8 +213,8 @@ fn infer_id(expr: &ValueExpr) -> Option<SymbolPrimitive> {
     }
 }
 
-impl AstToLogical {
-    pub fn new(registry: name_resolver::KeyRegistry) -> Self {
+impl<'a> AstToLogical<'a> {
+    pub fn new(catalog: &'a Box<dyn Catalog>, registry: name_resolver::KeyRegistry) -> Self {
         let fnsym_tab: &FnSymTab = &FN_SYM_TAB;
         AstToLogical {
             id_stack: Default::default(),
@@ -239,6 +243,7 @@ impl AstToLogical {
 
             key_registry: registry,
             fnsym_tab,
+            catalog,
 
             errors: vec![],
         }
@@ -504,7 +509,7 @@ impl AstToLogical {
 // so there is nothing done between the `enter_<x>` and `exit_<x>` calls.
 // By convention, processing for them is done in the `enter_<x>` calls here.
 //
-impl<'ast> Visitor<'ast> for AstToLogical {
+impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
     fn enter_ast_node(&mut self, id: NodeId) -> Traverse {
         self.id_stack.push(id);
         Traverse::Continue
@@ -915,11 +920,20 @@ impl<'ast> Visitor<'ast> for AstToLogical {
         let args = self.exit_call();
         let name = call.func_name.value.to_lowercase();
 
+        let call_def_to_vexpr =
+            |call_def: &CallDef| call_def.lookup(&args, &name).map_err(Into::into);
+
         let call_expr = self
             .fnsym_tab
-            .lookup(name.as_ref())
-            .ok_or_else(|| LowerError::UnsupportedFunction(name.clone()))
-            .and_then(|c| c.lookup(&args, name));
+            .lookup(&name)
+            .and_then(|cd| Some(call_def_to_vexpr(cd)))
+            .or_else(|| {
+                self.catalog
+                    .get_function(&name)
+                    .and_then(|e| Some(call_def_to_vexpr(e.call_def())))
+            })
+            .unwrap_or_else(|| Err(LowerError::UnsupportedFunction(name.clone())));
+
         let expr = match call_expr {
             Ok(expr) => expr,
             Err(err) => {

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -24,7 +24,7 @@ bench = false
 partiql-value = { path = "../partiql-value", version = "0.3.*" }
 ordered-float = "3.*"
 itertools = "0.10.*"
-unicase = "2.*"
+unicase = "2.6"
 
 serde = { version = "1.*", features = ["derive"], optional = true }
 

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -659,6 +659,7 @@ pub enum CallName {
     ExtractSecond,
     ExtractTimezoneHour,
     ExtractTimezoneMinute,
+    ByName(String),
 }
 
 /// Indicates if a set should be reduced to its distinct elements or not.

--- a/partiql-parser/Cargo.toml
+++ b/partiql-parser/Cargo.toml
@@ -36,7 +36,7 @@ bigdecimal = "~0.2.0"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 
 lalrpop-util = "0.20"
-logos = "~0.12.0"
+logos = "0.12"
 
 itertools = "~0.10.3"
 

--- a/partiql-value/Cargo.toml
+++ b/partiql-value/Cargo.toml
@@ -23,7 +23,7 @@ bench = false
 [dependencies]
 ordered-float = "3.*"
 itertools = "0.10.*"
-unicase = "2.*"
+unicase = "2.6"
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.26"
 ion-rs = "0.17"

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -104,6 +104,15 @@ macro_rules! partiql_bag {
     );
 }
 
+impl<'a> IntoIterator for &'a Bag {
+    type Item = &'a Value;
+    type IntoIter = BagIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BagIter(self.0.iter())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BagIter<'a>(slice::Iter<'a, Value>);
 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -104,6 +104,15 @@ macro_rules! partiql_list {
     );
 }
 
+impl<'a> IntoIterator for &'a List {
+    type Item = &'a Value;
+    type IntoIter = ListIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ListIter(self.0.iter())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ListIter<'a>(slice::Iter<'a, Value>);
 

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -25,6 +25,7 @@ bench = false
 [dev-dependencies]
 partiql-parser = { path = "../partiql-parser" }
 partiql-ast = { path = "../partiql-ast" }
+partiql-catalog = { path = "../partiql-catalog"}
 partiql-value = { path = "../partiql-value" }
 partiql-logical = { path = "../partiql-logical" }
 partiql-logical-planner = { path = "../partiql-logical-planner" }


### PR DESCRIPTION
MVP for a Catalog for eventually holding Functions, Types, Schemas, etc. For now, it is able to hold a `BaseTableFunction` that is used to allow scanning of arbitrary data sources via an 'extension' plug-in interface. 

The new `partiql-extension-ion-functions` crate provides an example an extension in `IonExtension`, which registers a `ReadIonFunction`.


### Added
- Add `partiql-extension-ion-functions` extension which contains an extension function for reading from an Ion file
- Add `partiql-catalog` including an experimental `Catalog` interface and implementation

### Changed
- *BREAKING:* partiql-logical-planner: Adds a `LogicalPlanner` to encapsulate the `lower` method
- *BREAKING:* partiql-eval: Adds a `EvaluatorPlanner` now requires a `Catalog` to be supplied at initialization
- *BREAKING:* partiql-logical-planner: `CallDef` and related types moved to partiql-catalog


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
