### PR TITLE
IonExtension is intended to be `pub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- partiql-extension-ion-functions : Made `IonExtension` `pub`
 ### Added
 ### Fixes
 

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -45,7 +45,7 @@ impl From<std::io::Error> for IonExtensionError {
 }
 
 #[derive(Debug)]
-pub(crate) struct IonExtension {}
+pub struct IonExtension {}
 
 impl partiql_catalog::Extension for IonExtension {
     fn name(&self) -> String {


### PR DESCRIPTION
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
