### PR TITLE
[WIP] Add scalar builtins to catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 ### Added
+- Ability to add and view errors during evaluation with partiql-eval's `EvalContext`
 ### Fixes
 
 ## [0.4.1] - 2023-05-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- *BREAKING:* partiql-eval: `evaluate` on `Evaluable` returns a `Value` rather than an `Option<Value>`
 ### Added
 - Ability to add and view errors during evaluation with partiql-eval's `EvalContext`
 ### Fixes

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -1,10 +1,10 @@
 use ion_rs::data_source::ToIonDataSource;
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
-use partiql_catalog::TableFunction;
 use partiql_catalog::{
     BaseTableExpr, BaseTableExprResult, BaseTableExprResultError, BaseTableExprResultValueIter,
     BaseTableFunctionInfo, Catalog,
 };
+use partiql_catalog::{FunctionEntryFunction, TableFunction};
 use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
 use partiql_extension_ion::Encoding;
 use partiql_logical as logical;
@@ -53,7 +53,9 @@ impl partiql_catalog::Extension for IonExtension {
     }
 
     fn load(&self, catalog: &mut dyn Catalog) -> Result<(), Box<dyn Error>> {
-        match catalog.add_table_function(TableFunction::new(Box::new(ReadIonFunction::new()))) {
+        match catalog.add_function(FunctionEntryFunction::Table(TableFunction::new(Box::new(
+            ReadIonFunction::new(),
+        )))) {
             Ok(_) => Ok(()),
             Err(e) => Err(Box::new(e) as Box<dyn Error>),
         }

--- a/partiql-catalog/src/builtins.rs
+++ b/partiql-catalog/src/builtins.rs
@@ -1,0 +1,67 @@
+use crate::call_defs::{CallDef, CallSpec, CallSpecArg};
+use crate::{ScalarExpr, ScalarExprResult, ScalarFunctionInfo};
+use partiql_logical::{CallExpr, CallName, ValueExpr};
+use partiql_value::Value;
+use std::borrow::Cow;
+
+#[inline]
+#[track_caller]
+fn string_transform<FnTransform>(value: &Value, transform_fn: FnTransform) -> Value
+where
+    FnTransform: Fn(&str) -> Value,
+{
+    match value {
+        Value::Null => Value::Null,
+        Value::String(s) => transform_fn(s.as_ref()),
+        _ => Value::Missing,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CharLenFunction {
+    call_def: CallDef,
+}
+
+impl CharLenFunction {
+    pub fn new() -> Self {
+        CharLenFunction {
+            call_def: CallDef {
+                names: vec!["char_length", "character_length"],
+                overloads: vec![CallSpec {
+                    input: vec![CallSpecArg::Positional],
+                    output: Box::new(|args| {
+                        ValueExpr::Call(CallExpr {
+                            name: CallName::ByName("char_length".to_string()),
+                            arguments: args,
+                        })
+                    }),
+                }],
+            },
+        }
+    }
+}
+
+impl ScalarFunctionInfo for CharLenFunction {
+    fn call_def(&self) -> &CallDef {
+        &self.call_def
+    }
+
+    fn plan_eval(&self) -> Box<dyn ScalarExpr> {
+        Box::new(EvalFnCharLength {})
+    }
+}
+
+/// Represents a built-in character length string function, e.g. `char_length('123456789')`.
+#[derive(Debug)]
+pub(crate) struct EvalFnCharLength {}
+
+impl ScalarExpr for EvalFnCharLength {
+    fn evaluate(&self, args: &[Cow<Value>]) -> ScalarExprResult {
+        if args.len() != 1 {
+            todo!("Error plumbing")
+        }
+        let value = args.first().unwrap();
+        let transformed = string_transform(value.as_ref(), |s| s.chars().count().into());
+        Ok(Cow::Owned(transformed))
+    }
+}

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -33,9 +33,15 @@ pub struct EvalErr {
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum EvaluationError {
+    /// Internal error that was not due to user input or API violation.
+    #[error("Illegal State: {0}")]
+    IllegalState(String),
     /// Malformed evaluation plan with graph containing cycle.
     #[error("Evaluation Error: invalid evaluation plan detected `{0}`")]
     InvalidEvaluationPlan(String),
+    /// Feature has not yet been implemented.
+    #[error("Not yet implemented: {0}")]
+    NotYetImplemented(String),
 }
 
 /// Used when an error occurs during the the logical to eval plan conversion. Allows the conversion

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -56,7 +56,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Option<Value> {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -64,8 +64,9 @@ impl EvalPlan {
                             )],
                         });
                     }
-                    result = src.unwrap().evaluate(&*ctx);
+                    result = Some(src.unwrap().evaluate(&*ctx));
 
+                    // return on first evaluation error
                     if ctx.has_errors() {
                         return Err(EvalErr {
                             errors: ctx.errors(),
@@ -116,7 +117,6 @@ impl EvalPlan {
                     }
                     Some(val) => val,
                 };
-                // TODO: decide on `evaluate`'s type. Currently returns an `Option`. For error handling, perhaps a `Result` type is better here.
                 Ok(Evaluated { result })
             }
             Err(e) => Err(EvalErr {

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -2266,7 +2266,7 @@ mod tests {
                 partiql_tuple![("x", partiql_tuple![("a", 0), ("b", 0)]), ("y", 0)],
                 partiql_tuple![("x", partiql_tuple![("a", 1), ("b", 1)]), ("y", 1)],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.1.1
@@ -2298,7 +2298,7 @@ mod tests {
                     ("y", value::Value::Missing)
                 ],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.1.1
@@ -2323,7 +2323,7 @@ mod tests {
             let scan_res = scan.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", 0)]];
-            assert_eq!(Value::Bag(Box::new(expected)), scan_res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), scan_res);
         }
 
         // Spec 5.1.1
@@ -2348,7 +2348,7 @@ mod tests {
             let res = scan.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", value::Value::Missing)]];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
     }
 
@@ -2386,7 +2386,7 @@ mod tests {
                 partiql_tuple![("symbol", "tdc"), ("price", 31.06)],
                 partiql_tuple![("symbol", "amzn"), ("price", 840.05)],
             ];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
 
         // Spec 5.2.1
@@ -2407,7 +2407,7 @@ mod tests {
             let res = unpivot.evaluate(&ctx);
 
             let expected = partiql_bag![partiql_tuple![("x", 1), ("y", "_1")]];
-            assert_eq!(Value::Bag(Box::new(expected)), res.unwrap());
+            assert_eq!(Value::Bag(Box::new(expected)), res);
         }
     }
 }

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -9,21 +9,6 @@ use std::fmt::Debug;
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
 use unicase::UniCase;
 
-fn function_call_def_char_len() -> CallDef {
-    CallDef {
-        names: vec!["char_length", "character_length"],
-        overloads: vec![CallSpec {
-            input: vec![CallSpecArg::Positional],
-            output: Box::new(|args| {
-                logical::ValueExpr::Call(logical::CallExpr {
-                    name: logical::CallName::CharLength,
-                    arguments: args,
-                })
-            }),
-        }],
-    }
-}
-
 fn function_call_def_octet_len() -> CallDef {
     CallDef {
         names: vec!["octet_length"],
@@ -677,7 +662,6 @@ pub fn function_call_def() -> FnSymTab {
     let mut synonyms: HashMap<UniCase<String>, UniCase<String>> = HashMap::new();
 
     for def in [
-        function_call_def_char_len(),
         function_call_def_octet_len(),
         function_call_def_bit_len(),
         function_call_def_lower(),

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -638,7 +638,6 @@ pub struct CallExpr {
 pub enum CallName {
     Lower,
     Upper,
-    CharLength,
     OctetLength,
     BitLength,
     LTrim,


### PR DESCRIPTION
(targets the `remove-panics-evalexpr-evaluable` branch. PR will target `main` once #374 is merged)

WIP to move scalar builtins to catalog. Currently just moves one scalar builtin, `char_length`, into the catalog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
