### PR TITLE
Add `operators_by_id` to Logical Plan to get Nodes and their OpId

### DIFF
--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -86,7 +86,6 @@ impl<'c> EvaluatorPlanner<'c> {
 
     #[inline]
     fn plan_eval(&mut self, lg: &LogicalPlan<BindingsOp>) -> EvalPlan {
-        let ops = lg.operators();
         let flows = lg.flows();
 
         let mut graph: StableGraph<_, _> = Default::default();
@@ -94,7 +93,7 @@ impl<'c> EvaluatorPlanner<'c> {
 
         for (s, d, w) in flows {
             let mut add_node = |op_id: &OpId| {
-                let logical_op = &ops[op_id.index() - 1];
+                let logical_op = lg.operator(*op_id).unwrap();
                 *seen
                     .entry(*op_id)
                     .or_insert_with(|| graph.add_node(self.get_eval_node(logical_op)))

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -142,6 +142,11 @@ where
         &self.nodes
     }
 
+    /// Returns the operators of the plan.
+    pub fn operators_by_id(&self) -> impl Iterator<Item = (OpId, &T)> {
+        self.nodes.iter().enumerate().map(|(i, n)| (OpId(i + 1), n))
+    }
+
     /// Returns the data flows of the plan.
     pub fn flows(&self) -> &Vec<(OpId, OpId, u8)> {
         &self.edges

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -142,7 +142,7 @@ where
         &self.nodes
     }
 
-    /// Returns the operators of the plan.
+    /// Returns the operators of the plan with their `OpId`.
     pub fn operators_by_id(&self) -> impl Iterator<Item = (OpId, &T)> {
         self.nodes.iter().enumerate().map(|(i, n)| (OpId(i + 1), n))
     }


### PR DESCRIPTION
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
