### PR TITLE
Move `name_resolver` to a different crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "partiql",
   "partiql-ast",
   "partiql-ast/partiql-ast-macros",
+  "partiql-ast-passes",
   "partiql-catalog",
   "partiql-conformance-tests",
   "partiql-conformance-test-generator",

--- a/partiql-ast-passes/Cargo.toml
+++ b/partiql-ast-passes/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "partiql-ast-passes"
+description = "A crate for PartiQL AST transformation passes"
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license = "Apache-2.0"
+readme = "../README.md"
+keywords = ["sql", "ast", "query", "compilers", "interpreters", "visitors", "passes"]
+categories = ["database", "compilers", "ast-implementations"]
+exclude = [
+  "**/.git/**",
+  "**/.github/**",
+]
+version.workspace = true
+edition.workspace = true
+
+[lib]
+path = "src/lib.rs"
+bench = false
+
+[dependencies]
+partiql-ast = { path = "../partiql-ast", version = "0.5.*" }
+partiql-catalog = { path = "../partiql-catalog", version = "0.5.*" }
+
+fnv = "1"
+indexmap = "1.9"
+thiserror = "1.0"
+
+[dev-dependencies]
+
+[features]
+default = []

--- a/partiql-ast-passes/LICENSE
+++ b/partiql-ast-passes/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/partiql-ast-passes/src/error.rs
+++ b/partiql-ast-passes/src/error.rs
@@ -1,16 +1,16 @@
 use partiql_catalog::call_defs::CallLookupError;
 use thiserror::Error;
 
-/// Contains the errors that occur during AST to logical plan conversion
+/// Contains the errors that occur during AST transformations
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct LoweringError {
-    pub errors: Vec<LowerError>,
+pub struct AstTransformationError {
+    pub errors: Vec<AstTransformError>,
 }
 
-/// An error that can happen during the AST to logical plan conversion
+/// Represents an AST transform Error
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
-pub enum LowerError {
+pub enum AstTransformError {
     /// Indicates that AST lowering has not yet been implemented for this feature.
     #[error("Not yet implemented: {0}")]
     NotYetImplemented(String),
@@ -40,11 +40,13 @@ pub enum LowerError {
     Unknown(String),
 }
 
-impl From<CallLookupError> for LowerError {
+impl From<CallLookupError> for AstTransformError {
     fn from(err: CallLookupError) -> Self {
         match err {
-            CallLookupError::InvalidNumberOfArguments(e) => LowerError::InvalidNumberOfArguments(e),
-            e => LowerError::Unknown(e.to_string()),
+            CallLookupError::InvalidNumberOfArguments(e) => {
+                AstTransformError::InvalidNumberOfArguments(e)
+            }
+            e => AstTransformError::Unknown(e.to_string()),
         }
     }
 }

--- a/partiql-ast-passes/src/lib.rs
+++ b/partiql-ast-passes/src/lib.rs
@@ -1,0 +1,8 @@
+//! The PartiQL Abstract Syntax Tree (AST) passes.
+//!
+//! # Note
+//!
+//! This API is currently unstable and subject to change.
+
+pub mod error;
+pub mod name_resolver;

--- a/partiql-ast-passes/src/name_resolver.rs
+++ b/partiql-ast-passes/src/name_resolver.rs
@@ -1,4 +1,4 @@
-use crate::error::{LowerError, LoweringError};
+use crate::error::{AstTransformError, AstTransformationError};
 use fnv::FnvBuildHasher;
 use indexmap::{IndexMap, IndexSet};
 use partiql_ast::ast;
@@ -98,17 +98,17 @@ pub struct NameResolver {
     aliases: FnvIndexMap<ast::NodeId, Symbol>,
 
     // errors that occur during name resolution
-    errors: Vec<LowerError>,
+    errors: Vec<AstTransformError>,
 }
 
 impl NameResolver {
     pub fn resolve(
         &mut self,
         query: &ast::AstNode<ast::Query>,
-    ) -> Result<KeyRegistry, LoweringError> {
+    ) -> Result<KeyRegistry, AstTransformationError> {
         query.visit(self);
         if !self.errors.is_empty() {
-            return Err(LoweringError {
+            return Err(AstTransformationError {
                 errors: std::mem::take(&mut self.errors),
             });
         }
@@ -152,10 +152,10 @@ impl NameResolver {
     }
 
     #[inline]
-    fn exit_lateral(&mut self) -> Result<Vec<ast::NodeId>, LowerError> {
-        self.lateral_stack
-            .pop()
-            .ok_or_else(|| LowerError::IllegalState("Expected non-empty lateral stack".to_string()))
+    fn exit_lateral(&mut self) -> Result<Vec<ast::NodeId>, AstTransformError> {
+        self.lateral_stack.pop().ok_or_else(|| {
+            AstTransformError::IllegalState("Expected non-empty lateral stack".to_string())
+        })
     }
 
     #[inline]
@@ -164,10 +164,10 @@ impl NameResolver {
     }
 
     #[inline]
-    fn exit_child_stack(&mut self) -> Result<Vec<ast::NodeId>, LowerError> {
-        self.id_child_stack
-            .pop()
-            .ok_or_else(|| LowerError::IllegalState("Expected non-empty child stack".to_string()))
+    fn exit_child_stack(&mut self) -> Result<Vec<ast::NodeId>, AstTransformError> {
+        self.id_child_stack.pop().ok_or_else(|| {
+            AstTransformError::IllegalState("Expected non-empty child stack".to_string())
+        })
     }
 
     #[inline]
@@ -176,10 +176,10 @@ impl NameResolver {
     }
 
     #[inline]
-    fn exit_keyref(&mut self) -> Result<KeyRefs, LowerError> {
-        self.keyref_stack
-            .pop()
-            .ok_or_else(|| LowerError::IllegalState("Expected non-empty keyrefs".to_string()))
+    fn exit_keyref(&mut self) -> Result<KeyRefs, AstTransformError> {
+        self.keyref_stack.pop().ok_or_else(|| {
+            AstTransformError::IllegalState("Expected non-empty keyrefs".to_string())
+        })
     }
 
     #[inline]

--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -35,6 +35,7 @@ partiql-conformance-test-generator = { path = "../partiql-conformance-test-gener
 partiql-parser = { path = "../partiql-parser", version = "0.5.*" }
 partiql-catalog = { path = "../partiql-catalog", version = "0.5.*" }
 partiql-ast = { path = "../partiql-ast", version = "0.5.*" }
+partiql-ast-passes = { path = "../partiql-ast-passes", version = "0.5.*" }
 partiql-logical-planner = { path = "../partiql-logical-planner", version = "0.5.*" }
 partiql-logical = { path = "../partiql-logical", version = "0.5.*" }
 partiql-value = { path = "../partiql-value", version = "0.5.*" }

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -1,10 +1,10 @@
+use partiql_ast_passes::error::AstTransformationError;
 use partiql_catalog::{Catalog, PartiqlCatalog};
 use partiql_eval as eval;
 use partiql_eval::env::basic::MapBindings;
 use partiql_eval::error::PlanErr;
 use partiql_eval::eval::{EvalPlan, EvalResult};
 use partiql_logical as logical;
-use partiql_logical_planner::error::LoweringError;
 use partiql_parser::{Parsed, ParserResult};
 use partiql_value::Value;
 
@@ -29,7 +29,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 pub(crate) fn lower(
     catalog: &dyn Catalog,
     parsed: &Parsed,
-) -> Result<logical::LogicalPlan<logical::BindingsOp>, LoweringError> {
+) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
     let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
     planner.lower(parsed)
 }

--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -27,6 +27,7 @@ partiql-logical = { path = "../partiql-logical", version = "0.5.*" }
 partiql-ast = { path = "../partiql-ast", version = "0.5.*" }
 partiql-parser = { path = "../partiql-parser", version = "0.5.*" }
 partiql-catalog = { path = "../partiql-catalog", version = "0.5.*" }
+partiql-ast-passes = { path = "../partiql-ast-passes", version = "0.5.*" }
 ion-rs = "0.17"
 ordered-float = "3.*"
 itertools = "0.10.*"


### PR DESCRIPTION
*Description of changes:*
This PR is in preparation of upcomming work for adding an AST Typer. The name resolver seems to be required by the `typer` but it being in `partiql-logical-planner` implies its use only in planner.

In addition, this PR defines a new crate call `partiql-ast-passes` (could pick a better name and open to ideas)  that intends to include passes on AST transformation. Arguably `lower` in `partiql-logical-planner` can also be part of this new crate but leaving it out for now, as logical planning is a major transform and perhaps deserves its own crate.

* This PR also updates the `partiql-tests` sub-module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
