### PR TITLE
Add feature flags to conformance tests based on test type

### DIFF
--- a/partiql-conformance-tests/Cargo.toml
+++ b/partiql-conformance-tests/Cargo.toml
@@ -53,7 +53,13 @@ serde = { version = "1.*", features = ["derive"], optional = true }
 serde_json = { version = "1.*", optional = true }
 
 [features]
-default = []
+default = ["base"]
+base = ["syntax", "semantics", "strict", "permissive"]
+syntax=[]
+semantics=[]
+strict=[]
+permissive=[]
+experimental=[]
 conformance_test=[]
 report_tool = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]

--- a/partiql-conformance-tests/README.md
+++ b/partiql-conformance-tests/README.md
@@ -16,6 +16,41 @@ cargo test --package partiql-conformance-tests --features "conformance_test"
 
 ---
 
+Conformance tests are generated from the [PartiQL Test Data](partiql-tests/README.md).
+
+### Default Tests
+The default tests can be run with:
+```shell
+cargo test --package partiql-conformance-tests --features "conformance_test" 
+```
+
+Which is equivalent to
+```shell
+cargo test --package partiql-conformance-tests --no-default-features --features "base,conformance_test" 
+```
+
+### Test Categories
+It is also possible to run subsets of the tests. See the set of test categories in [Cargo.toml](Cargo.toml)
+
+To run only `semantic` analysis tests:
+```shell
+cargo test --package partiql-conformance-tests --no-default-features --features "semantic,conformance_test" 
+```
+
+
+To run only `strict` tests:
+```shell
+cargo test --package partiql-conformance-tests --no-default-features --features "strict,conformance_test" 
+```
+
+To run `experimental` tests in addition to all default tests:
+```shell
+cargo test --package partiql-conformance-tests --features "experimental, conformance_test" 
+```
+
+
+### Individual Tests
+
 Running an individual test (or subset of tests) can vary by the IDE being used. Using CLion, you may need to first edit
 the test run configuration and enable the "Use all features in test" checkbox or explicitly add the 
 `--features "conformance_test"` test option.


### PR DESCRIPTION
This adds all existing test features as default, so running without specifying features works as it has:
```
cargo test --package partiql-conformance-tests --features "conformance_test" 
```

Which is equivalent to 
```
cargo test --package partiql-conformance-tests --no-default-features --features "base,conformance_test" 
```

But it also allows the ability to run subsets of the tests.

To run only `semantic` analysis tests:
```
cargo test --package partiql-conformance-tests --no-default-features --features "semantic,conformance_test" 
```


To run only `strict` tests:
```
cargo test --package partiql-conformance-tests --no-default-features --features "strict,conformance_test" 
```

To run `experimental` tests in addition to all default tests:
```
cargo test --package partiql-conformance-tests --features "experimental, conformance_test" 
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
