### PR TITLE
Use `partiql_ast::ast::AstTypeMap` for `LocationMap`

### DIFF
--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-indexmap = { version = "1.9", default-features = false, features = ["serde"] }
+indexmap = { version = "1.9", default-features = false }
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 serde = { version = "1.*", features = ["derive"], optional = true }
 

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-indexmap = { version = "1.9", features = ["serde"] }
+indexmap = { version = "1.9", default-features = false, features = ["serde"] }
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 serde = { version = "1.*", features = ["derive"], optional = true }
 
@@ -31,7 +31,8 @@ default = []
 serde = [
   "dep:serde",
   "rust_decimal/serde-with-str",
-  "rust_decimal/serde"
+  "rust_decimal/serde",
+  "indexmap/serde",
 ]
 
 [dependencies.partiql-ast-macros]

--- a/partiql-ast/Cargo.toml
+++ b/partiql-ast/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-indexmap = "1.9"
+indexmap = { version = "1.9", features = ["serde"] }
 rust_decimal = { version = "1.25.0", default-features = false, features = ["std"] }
 serde = { version = "1.*", features = ["derive"], optional = true }
 

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -30,8 +30,6 @@ use parse::{parse_partiql, AstData, ErrorData};
 use partiql_ast::ast;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
 use partiql_source_map::location::BytePosition;
-
-use partiql_ast::ast::NodeId;
 use partiql_source_map::metadata::LocationMap;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -82,7 +80,7 @@ pub struct Parsed<'input> {
     pub text: &'input str,
     pub offsets: LineOffsetTracker,
     pub ast: Box<ast::Expr>,
-    pub locations: LocationMap<NodeId>,
+    pub locations: LocationMap,
 }
 
 /// The output of errors when parsing PartiQL statement strings: an errors and auxiliary data.

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -12,7 +12,6 @@ use crate::parse::parser_state::{IdGenerator, ParserState};
 use crate::preprocessor::{PreprocessingPartiqlLexer, BUILT_INS};
 use lalrpop_util as lpop;
 use partiql_ast::ast;
-use partiql_ast::ast::NodeId;
 use partiql_source_map::line_offset_tracker::LineOffsetTracker;
 use partiql_source_map::location::{ByteOffset, BytePosition, ToLocated};
 use partiql_source_map::metadata::LocationMap;
@@ -41,7 +40,7 @@ type LalrpopErrorRecovery<'input> =
 #[derive(Debug, Clone)]
 pub(crate) struct AstData {
     pub ast: Box<ast::Expr>,
-    pub locations: LocationMap<NodeId>,
+    pub locations: LocationMap,
     pub offsets: LineOffsetTracker,
 }
 
@@ -535,6 +534,7 @@ mod tests {
 
     mod set_ops {
         use super::*;
+        use partiql_ast::ast::NodeId;
 
         #[derive(Default)]
         pub(crate) struct NullIdGenerator {}

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -53,7 +53,7 @@ pub(crate) struct ParserState<'input, Id: IdGenerator> {
     /// Generator for 'fresh' [`NodeId`]s
     pub id_gen: Id,
     /// Maps AST [`NodeId`]s to the location in the source from which each was derived.
-    pub locations: LocationMap<NodeId>,
+    pub locations: LocationMap,
     /// Any errors accumulated during parse.
     pub errors: ParseErrors<'input>,
 

--- a/partiql-source-map/Cargo.toml
+++ b/partiql-source-map/Cargo.toml
@@ -19,6 +19,8 @@ edition.workspace = true
 bench = false
 
 [dependencies]
+partiql-ast = { path = "../partiql-ast", version = "0.5.*" }
+
 smallvec = { version = "1.*" }
 serde = { version = "1.*", features = ["derive"], optional = true }
 

--- a/partiql-source-map/src/metadata.rs
+++ b/partiql-source-map/src/metadata.rs
@@ -1,5 +1,5 @@
 use crate::location::{BytePosition, Location};
-use std::collections::HashMap;
+use partiql_ast::ast::AstTypeMap;
 
 /// Map of `T` to a [`Location<BytePosition>>`]
-pub type LocationMap<T> = HashMap<T, Location<BytePosition>>;
+pub type LocationMap = AstTypeMap<Location<BytePosition>>;


### PR DESCRIPTION
*Description of changes:*
Addressing the comment in PR #389, this PR re-uses the `AstTypeMap` for `LocationMap` which removes a dependency to `HashMap` as `AstTypeMap` uses `IndexMap`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
