### PR TITLE
Implements OUTER bag operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING:* partiql-logical-planner: moves `NameResolver` to `partiql-ast-passes`
 - *BREAKING:* partiql-values: removes `partiql` from value macro_rules; e.g. `partiql_bag` renames to `bag`.
 - *BREAKING:* partiql-ast: changed modeling of `Query` and `SetExpr` nodes to support `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
-  - Also affects the `Visitor` trait
+  - Affects the AST and visitor
 - *BREAKING:* partiql-ast: rename of `SetExpr` to `BagOpExpr` and `SetOp` to `BagOp`
   - Affects the AST and visitor
+- *BREAKING:* partiql-parser: `Parsed` struct's `ast` field is now an `ast::AstNode<ast::TopLevelQuery>`
+- *BREAKING:* partiql-eval: `Evaluable` trait's `update_input` fn now also takes in an `EvalContext`
 
 ### Added
 - Add ability for partiql-extension-ion extension encoding/decoding of `Value` to/from Ion `Element`
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
 - partiql-parser set quantifier for bag operators fixed to `DISTINCT`
+- partiql-parser set quantifier for bag operators fixed to be `DISTINCT` when unspecified
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *BREAKING:* partiql-values: removes `partiql` from value macro_rules; e.g. `partiql_bag` renames to `bag`.
 - *BREAKING:* partiql-ast: changed modeling of `Query` and `SetExpr` nodes to support `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
   - Also affects the `Visitor` trait
+- *BREAKING:* partiql-ast: rename of `SetExpr` to `BagOpExpr` and `SetOp` to `BagOp`
+  - Affects the AST and visitor
 
 ### Added
 - Add ability for partiql-extension-ion extension encoding/decoding of `Value` to/from Ion `Element`
 - Add `partiql-types` crate that includes data models for PartiQL Types.
 - Add `partiql_ast_passes::static_typer` for type annotating the AST.
 - Add ability to parse `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
+- Add `OUTER` bag operator (`OUTER UNION`, `OUTER INTERSECT`, `OUTER EXCEPT`) implementation
 
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
+- partiql-parser set quantifier for bag operators fixed to `DISTINCT`
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/partiql-ast-passes/src/name_resolver.rs
+++ b/partiql-ast-passes/src/name_resolver.rs
@@ -104,7 +104,7 @@ pub struct NameResolver {
 impl NameResolver {
     pub fn resolve(
         &mut self,
-        query: &ast::AstNode<ast::Query>,
+        query: &ast::AstNode<ast::TopLevelQuery>,
     ) -> Result<KeyRegistry, AstTransformationError> {
         query.visit(self);
         if !self.errors.is_empty() {

--- a/partiql-ast-passes/src/partiql_typer.rs
+++ b/partiql-ast-passes/src/partiql_typer.rs
@@ -1,6 +1,6 @@
 use crate::error::{AstTransformError, AstTransformationError};
 use partiql_ast::ast::{
-    AstNode, AstTypeMap, Bag, Expr, List, Lit, NodeId, Query, QuerySet, Struct,
+    AstNode, AstTypeMap, Bag, Expr, List, Lit, NodeId, Query, QuerySet, Struct, TopLevelQuery,
 };
 use partiql_ast::visit::{Traverse, Visit, Visitor};
 use partiql_catalog::Catalog;
@@ -29,7 +29,7 @@ impl<'c> AstPartiqlTyper<'c> {
 
     pub fn type_nodes(
         mut self,
-        query: &AstNode<Query>,
+        query: &AstNode<TopLevelQuery>,
     ) -> Result<AstTypeMap<PartiqlType>, AstTransformationError> {
         query.visit(&mut self);
         if self.errors.is_empty() {
@@ -220,7 +220,6 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use partiql_ast::ast;
     use partiql_catalog::PartiqlCatalog;
     use partiql_types::{PartiqlType, TypeKind};
 
@@ -262,10 +261,7 @@ mod tests {
             .expect("Expect successful parse");
 
         let typer = AstPartiqlTyper::new(catalog);
-        if let ast::Expr::Query(q) = parsed.ast.as_ref() {
-            typer.type_nodes(q)
-        } else {
-            panic!("Typing statement other than `Query` are unsupported")
-        }
+        let q = &parsed.ast;
+        typer.type_nodes(q)
     }
 }

--- a/partiql-ast-passes/src/partiql_typer.rs
+++ b/partiql-ast-passes/src/partiql_typer.rs
@@ -68,7 +68,7 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
 
     fn enter_query_set(&mut self, _query_set: &'ast QuerySet) -> Traverse {
         match _query_set {
-            QuerySet::SetOp(_) => {
+            QuerySet::BagOp(_) => {
                 todo!()
             }
             QuerySet::Select(_) => {}

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -270,7 +270,7 @@ pub struct WithElement {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum QuerySet {
-    SetOp(Box<AstNode<SetExpr>>),
+    BagOp(Box<AstNode<BagOpExpr>>),
     Select(Box<AstNode<Select>>),
     Expr(Box<Expr>),
     Values(Vec<Box<Expr>>),
@@ -279,9 +279,9 @@ pub enum QuerySet {
 
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct SetExpr {
+pub struct BagOpExpr {
     #[visit(skip)]
-    pub setop: SetOperator,
+    pub bag_op: BagOperator,
     #[visit(skip)]
     pub setq: SetQuantifier,
     pub lhs: Box<AstNode<Query>>,
@@ -290,7 +290,7 @@ pub struct SetExpr {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SetOperator {
+pub enum BagOperator {
     Union,
     Except,
     Intersect,

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -237,10 +237,10 @@ pub trait Visitor<'ast> {
     fn exit_query_set(&mut self, _query_set: &'ast ast::QuerySet) -> Traverse {
         Traverse::Continue
     }
-    fn enter_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Traverse {
+    fn enter_bag_op_expr(&mut self, _set_expr: &'ast ast::BagOpExpr) -> Traverse {
         Traverse::Continue
     }
-    fn exit_set_expr(&mut self, _set_expr: &'ast ast::SetExpr) -> Traverse {
+    fn exit_bag_op_expr(&mut self, _set_expr: &'ast ast::BagOpExpr) -> Traverse {
         Traverse::Continue
     }
     fn enter_select(&mut self, _select: &'ast ast::Select) -> Traverse {

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -60,7 +60,7 @@ impl Evaluable for ErrorNode {
         panic!("ErrorNode will not be evaluated")
     }
 
-    fn update_input(&mut self, _input: Value, _branch_num: u8) {
+    fn update_input(&mut self, _input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         panic!("ErrorNode will not be evaluated")
     }
 }

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -36,7 +36,7 @@ pub enum EvalType {
 /// `Evaluable` represents each evaluation operator in the evaluation plan as an evaluable entity.
 pub trait Evaluable: Debug {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Value;
-    fn update_input(&mut self, input: Value, branch_num: u8);
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext);
     fn get_vars(&self) -> Option<&[String]> {
         None
     }
@@ -121,7 +121,7 @@ impl Evaluable for EvalScan {
         Value::Bag(Box::new(value))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 
@@ -181,7 +181,7 @@ impl Evaluable for EvalJoin {
 
         let mut output_bag = bag![];
         let input_env = self.input.take().unwrap_or_else(|| Value::from(tuple![]));
-        self.left.update_input(input_env.clone(), 0);
+        self.left.update_input(input_env.clone(), 0, ctx);
         let lhs_values = self.left.evaluate(ctx);
         let left_bindings = match lhs_values {
             Value::Bag(t) => *t,
@@ -203,7 +203,7 @@ impl Evaluable for EvalJoin {
                         .as_tuple_ref()
                         .as_ref()
                         .tuple_concat(b_l.as_tuple_ref().borrow());
-                    self.right.update_input(Value::from(env_b_l), 0);
+                    self.right.update_input(Value::from(env_b_l), 0, ctx);
                     let rhs_values = self.right.evaluate(ctx);
 
                     let right_bindings = match rhs_values {
@@ -247,7 +247,7 @@ impl Evaluable for EvalJoin {
                         .as_tuple_ref()
                         .as_ref()
                         .tuple_concat(b_l.as_tuple_ref().borrow());
-                    self.right.update_input(Value::from(env_b_l), 0);
+                    self.right.update_input(Value::from(env_b_l), 0, ctx);
                     let rhs_values = self.right.evaluate(ctx);
 
                     let right_bindings = match rhs_values {
@@ -308,7 +308,7 @@ impl Evaluable for EvalJoin {
         Value::Bag(Box::new(output_bag))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 
@@ -776,7 +776,7 @@ impl Evaluable for EvalGroupBy {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -821,7 +821,7 @@ impl Evaluable for EvalPivot {
         Value::from(tuple)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -879,7 +879,7 @@ impl Evaluable for EvalUnpivot {
         Value::from(unpivoted)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 
@@ -926,7 +926,7 @@ impl Evaluable for EvalFilter {
         Value::from(filtered.collect::<Bag>())
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -971,7 +971,7 @@ impl Evaluable for EvalHaving {
         Value::from(filtered.collect::<Bag>())
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1049,7 +1049,7 @@ impl Evaluable for EvalOrderBy {
         Value::from(List::from(values))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1111,7 +1111,7 @@ impl Evaluable for EvalLimitOffset {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1148,7 +1148,7 @@ impl Evaluable for EvalSelectValue {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1195,7 +1195,7 @@ impl Evaluable for EvalSelect {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1232,7 +1232,7 @@ impl Evaluable for EvalSelectAll {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1259,7 +1259,7 @@ impl Evaluable for EvalExprQuery {
         self.expr.evaluate(&input_value, ctx).into_owned()
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1288,7 +1288,7 @@ impl Evaluable for EvalDistinct {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1304,7 +1304,7 @@ impl Evaluable for EvalSink {
         self.input.take().unwrap_or_else(|| Missing)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
         self.input = Some(input);
     }
 }
@@ -1339,8 +1339,203 @@ impl EvalExpr for EvalSubQueryExpr {
     }
 }
 
+///
+/// Coercion function F for bag operators described in RFC-0007
+/// - F(absent_value) -> << >>
+/// - F(scalar_value) -> << scalar_value >> # singleton bag
+/// - F(tuple_value)  -> << tuple_value >>  # singleton bag, see future extensions
+/// - F(array_value)  -> bag_value          # discard ordering
+/// - F(bag_value)    -> bag_value          # identity
+///
+fn coerce_to_bag(v: Value) -> Bag {
+    match v {
+        Null | Missing => bag![],
+        Value::Bag(b) => *b,
+        Value::List(l) => Bag::from(*l),
+        scalar_or_tuple => Bag::from(vec![scalar_or_tuple]),
+    }
+}
+
+/// Represents the `OUTER UNION` bag operator.
+#[derive(Debug, PartialEq)]
+pub(crate) struct EvalOuterUnion {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) l_input: Option<Value>,
+    pub(crate) r_input: Option<Value>,
+}
+
+impl EvalOuterUnion {
+    pub(crate) fn new(setq: SetQuantifier) -> Self {
+        EvalOuterUnion {
+            setq,
+            l_input: None,
+            r_input: None,
+        }
+    }
+}
+
+impl Evaluable for EvalOuterUnion {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
+        let lhs = self.l_input.take().unwrap_or(Missing);
+        let rhs = self.r_input.take().unwrap_or(Missing);
+        match self.setq {
+            SetQuantifier::All => {
+                let mut result = coerce_to_bag(lhs);
+                coerce_to_bag(rhs).into_iter().for_each(|elem| {
+                    result.push(elem);
+                });
+                Value::from(result)
+            }
+            SetQuantifier::Distinct => {
+                let mut result: HashSet<Value> = HashSet::from_iter(coerce_to_bag(lhs).into_iter());
+                coerce_to_bag(rhs).into_iter().for_each(|elem| {
+                    result.insert(elem);
+                });
+                Value::from(Bag::from(result))
+            }
+        }
+    }
+
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+        match branch_num {
+            0 => self.l_input = Some(input),
+            1 => self.r_input = Some(input),
+            _ => ctx.add_error(EvaluationError::IllegalState(
+                "Invalid branch number".to_string(),
+            )),
+        }
+    }
+}
+
+/// Represents the `OUTER INTERSECT` bag operator.
+#[derive(Debug, PartialEq)]
+pub(crate) struct EvalOuterIntersect {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) l_input: Option<Value>,
+    pub(crate) r_input: Option<Value>,
+}
+
+impl EvalOuterIntersect {
+    pub(crate) fn new(setq: SetQuantifier) -> Self {
+        EvalOuterIntersect {
+            setq,
+            l_input: None,
+            r_input: None,
+        }
+    }
+}
+
+impl Evaluable for EvalOuterIntersect {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
+        let lhs = self.l_input.take().unwrap_or(Missing);
+        let rhs = self.r_input.take().unwrap_or(Missing);
+
+        match self.setq {
+            SetQuantifier::All => {
+                let mut result: Vec<Value> = Vec::new();
+                let mut lhs_multiplicities: HashMap<Value, usize> = HashMap::new();
+                coerce_to_bag(lhs).into_iter().for_each(|elem| {
+                    lhs_multiplicities
+                        .entry(elem)
+                        .and_modify(|m| *m += 1)
+                        .or_insert(1);
+                });
+                coerce_to_bag(rhs).into_iter().for_each(|elem| {
+                    if lhs_multiplicities.contains_key(&elem) {
+                        *lhs_multiplicities.get_mut(&elem).unwrap() += 1;
+                        result.push(elem);
+                    }
+                });
+                Value::from(Bag::from(result))
+            }
+            SetQuantifier::Distinct => {
+                let mut result: HashSet<Value> = HashSet::new();
+                let lhs_set: HashSet<Value> = HashSet::from_iter(coerce_to_bag(lhs).into_iter());
+                coerce_to_bag(rhs).into_iter().for_each(|elem| {
+                    if lhs_set.contains(&elem) {
+                        result.insert(elem);
+                    }
+                });
+                Value::from(Bag::from(result))
+            }
+        }
+    }
+
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+        match branch_num {
+            0 => self.l_input = Some(input),
+            1 => self.r_input = Some(input),
+            _ => ctx.add_error(EvaluationError::IllegalState(
+                "Invalid branch number".to_string(),
+            )),
+        }
+    }
+}
+
+/// Represents the `OUTER EXCEPT` bag operator.
+#[derive(Debug, PartialEq)]
+pub(crate) struct EvalOuterExcept {
+    pub(crate) setq: SetQuantifier,
+    pub(crate) l_input: Option<Value>,
+    pub(crate) r_input: Option<Value>,
+}
+
+impl EvalOuterExcept {
+    pub(crate) fn new(setq: SetQuantifier) -> Self {
+        EvalOuterExcept {
+            setq,
+            l_input: None,
+            r_input: None,
+        }
+    }
+}
+
+impl Evaluable for EvalOuterExcept {
+    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
+        let lhs = self.l_input.take().unwrap_or(Missing);
+        let rhs = self.r_input.take().unwrap_or(Missing);
+        let mut result: Vec<Value> = Vec::new();
+        let mut rhs_multiplicities: HashMap<Value, usize> = HashMap::new();
+        coerce_to_bag(rhs).into_iter().for_each(|elem| {
+            rhs_multiplicities
+                .entry(elem)
+                .and_modify(|m| *m += 1)
+                .or_insert(1);
+        });
+        coerce_to_bag(lhs).into_iter().for_each(|elem| {
+            if rhs_multiplicities.contains_key(&elem) {
+                let m = rhs_multiplicities.get_mut(&elem).unwrap();
+                if *m > 0 {
+                    *m -= 1
+                } else {
+                    result.push(elem)
+                }
+            } else {
+                result.push(elem)
+            }
+        });
+        match self.setq {
+            SetQuantifier::All => Value::from(Bag::from(result)),
+            SetQuantifier::Distinct => {
+                let result = HashSet::from_iter(result.into_iter());
+                Value::from(Bag::from(result))
+            }
+        }
+    }
+
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+        match branch_num {
+            0 => self.l_input = Some(input),
+            1 => self.r_input = Some(input),
+            _ => ctx.add_error(EvaluationError::IllegalState(
+                "Invalid branch number".to_string(),
+            )),
+        }
+    }
+}
+
 /// Indicates if a set should be reduced to its distinct elements or not.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum SetQuantifier {
     All,
     Distinct,

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -1442,8 +1442,11 @@ impl Evaluable for EvalOuterIntersect {
                 });
                 coerce_to_bag(rhs).into_iter().for_each(|elem| {
                     if lhs_multiplicities.contains_key(&elem) {
-                        *lhs_multiplicities.get_mut(&elem).unwrap() += 1;
-                        result.push(elem);
+                        let m = lhs_multiplicities.get_mut(&elem).unwrap();
+                        if *m > 0 {
+                            *m -= 1;
+                            result.push(elem);
+                        }
                     }
                 });
                 Value::from(Bag::from(result))

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -113,7 +113,7 @@ impl EvalPlan {
 
                     let res =
                         res.ok_or_else(|| err_illegal_state("Error in retrieving source value"))?;
-                    self.get_node(dst_id)?.update_input(res, branch_num);
+                    self.get_node(dst_id)?.update_input(res, branch_num, &*ctx);
                 }
             }
         }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 use partiql_logical as logical;
 
 use partiql_logical::{
-    AggFunc, BinaryOp, BindingsOp, CallName, GroupingStrategy, IsTypeExpr, JoinKind, LogicalPlan,
-    OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier, SortSpecNullOrder,
-    SortSpecOrder, Type, UnaryOp, ValueExpr,
+    AggFunc, BagOperator, BinaryOp, BindingsOp, CallName, GroupingStrategy, IsTypeExpr, JoinKind,
+    LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier,
+    SortSpecNullOrder, SortSpecOrder, Type, UnaryOp, ValueExpr,
 };
 
 use crate::error::{ErrorNode, PlanErr, PlanningError};
@@ -283,12 +283,38 @@ impl<'c> EvaluatorPlanner<'c> {
                     input: None,
                 })
             }
-            BindingsOp::SetOp => {
-                self.errors.push(PlanningError::NotYetImplemented(
-                    "BindingsOp::SetOp not yet implemented in evaluator".to_string(),
-                ));
-                Box::new(ErrorNode::new())
-            }
+            BindingsOp::BagOp(logical::BagOp {
+                bag_op: setop,
+                setq,
+            }) => match setop {
+                BagOperator::Union => {
+                    self.errors.push(PlanningError::NotYetImplemented(
+                        "BagOperator::Union not yet implemented in evaluator".to_string(),
+                    ));
+                    Box::new(ErrorNode::new())
+                }
+                BagOperator::Intersect => {
+                    self.errors.push(PlanningError::NotYetImplemented(
+                        "BagOperator::Intersect not yet implemented in evaluator".to_string(),
+                    ));
+                    Box::new(ErrorNode::new())
+                }
+                BagOperator::Except => {
+                    self.errors.push(PlanningError::NotYetImplemented(
+                        "BagOperator::Except not yet implemented in evaluator".to_string(),
+                    ));
+                    Box::new(ErrorNode::new())
+                }
+                BagOperator::OuterUnion => Box::new(eval::evaluable::EvalOuterUnion::new(
+                    plan_set_quantifier(setq),
+                )),
+                BagOperator::OuterIntersect => Box::new(eval::evaluable::EvalOuterIntersect::new(
+                    plan_set_quantifier(setq),
+                )),
+                BagOperator::OuterExcept => Box::new(eval::evaluable::EvalOuterExcept::new(
+                    plan_set_quantifier(setq),
+                )),
+            },
         }
     }
 

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::lower::AstToLogical;
-use partiql_ast::ast;
-use partiql_ast_passes::error::{AstTransformError, AstTransformationError};
+
+use partiql_ast_passes::error::AstTransformationError;
 use partiql_ast_passes::name_resolver::NameResolver;
 use partiql_logical as logical;
 use partiql_parser::Parsed;
@@ -24,18 +24,11 @@ impl<'c> LogicalPlanner<'c> {
         &self,
         parsed: &Parsed,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
-        if let ast::Expr::Query(q) = parsed.ast.as_ref() {
-            let mut resolver = NameResolver::default();
-            let registry = resolver.resolve(q)?;
-            let planner = AstToLogical::new(self.catalog, registry);
-            planner.lower_query(q)
-        } else {
-            Err(AstTransformationError {
-                errors: vec![AstTransformError::NotYetImplemented(
-                    "Expr type not supported yet".to_string(),
-                )],
-            })
-        }
+        let q = &parsed.ast;
+        let mut resolver = NameResolver::default();
+        let registry = resolver.resolve(q)?;
+        let planner = AstToLogical::new(self.catalog, registry);
+        planner.lower_query(q)
     }
 }
 

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -4,18 +4,18 @@ use num::Integer;
 use ordered_float::OrderedFloat;
 use partiql_ast::ast;
 use partiql_ast::ast::{
-    Assignment, Bag, Between, BinOp, BinOpKind, Call, CallAgg, CallArg, CallArgNamed,
-    CaseSensitivity, CreateIndex, CreateTable, Ddl, DdlOp, Delete, Dml, DmlOp, DropIndex,
-    DropTable, Expr, FromClause, FromLet, FromLetKind, GroupByExpr, GroupKey, GroupingStrategy,
-    Insert, InsertValue, Item, Join, JoinKind, JoinSpec, Like, List, Lit, NodeId, NullOrderingSpec,
-    OnConflict, OrderByExpr, OrderingSpec, Path, PathStep, ProjectExpr, Projection, ProjectionKind,
-    Query, QuerySet, Remove, SearchedCase, Select, Set, SetExpr, SetQuantifier, Sexp, SimpleCase,
-    SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
+    Assignment, Bag, BagOpExpr, BagOperator, Between, BinOp, BinOpKind, Call, CallAgg, CallArg,
+    CallArgNamed, CaseSensitivity, CreateIndex, CreateTable, Ddl, DdlOp, Delete, Dml, DmlOp,
+    DropIndex, DropTable, Expr, FromClause, FromLet, FromLetKind, GroupByExpr, GroupKey,
+    GroupingStrategy, Insert, InsertValue, Item, Join, JoinKind, JoinSpec, Like, List, Lit, NodeId,
+    NullOrderingSpec, OnConflict, OrderByExpr, OrderingSpec, Path, PathStep, ProjectExpr,
+    Projection, ProjectionKind, Query, QuerySet, Remove, SearchedCase, Select, Set, SetQuantifier,
+    Sexp, SimpleCase, SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
 };
 use partiql_ast::visit::{Traverse, Visit, Visitor};
 use partiql_logical as logical;
 use partiql_logical::{
-    AggregateExpression, BagExpr, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch,
+    AggregateExpression, BagExpr, BagOp, BetweenExpr, BindingsOp, IsTypeExpr, LikeMatch,
     LikeNonStringNonLiteralMatch, ListExpr, LogicalPlan, OpId, PathComponent, Pattern,
     PatternMatchExpr, SortSpecOrder, TupleExpr, ValueExpr,
 };
@@ -160,8 +160,6 @@ pub struct AstToLogical<'a> {
 
     from_lets: HashSet<ast::NodeId>,
 
-    siblings: Vec<Vec<NodeId>>,
-
     aliases: FnvIndexMap<NodeId, SymbolPrimitive>,
 
     // generator of 'fresh' ids
@@ -229,8 +227,6 @@ impl<'a> AstToLogical<'a> {
             aggregate_exprs: Default::default(),
 
             from_lets: Default::default(),
-
-            siblings: Default::default(),
 
             aliases: Default::default(),
 
@@ -586,26 +582,10 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
 
     fn enter_query(&mut self, _query: &'ast Query) -> Traverse {
         self.enter_benv();
-        self.siblings.push(vec![]);
-        self.enter_q();
         Traverse::Continue
     }
 
     fn exit_query(&mut self, _query: &'ast Query) -> Traverse {
-        let clauses = self.exit_q();
-
-        let mut clauses = clauses.evaluation_order().into_iter();
-        if let Some(mut src_id) = clauses.next() {
-            for dst_id in clauses {
-                self.plan.add_flow(src_id, dst_id);
-                src_id = dst_id;
-            }
-
-            self.push_bexpr(src_id);
-        }
-
-        self.siblings.pop();
-
         let mut benv = self.exit_benv();
         eq_or_fault!(self, benv.len(), 1, "Expect benv.len() == 1");
 
@@ -618,12 +598,13 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
 
     fn enter_query_set(&mut self, _query_set: &'ast QuerySet) -> Traverse {
         self.enter_env();
+        self.enter_benv();
 
         match _query_set {
-            QuerySet::SetOp(_) => {
-                not_yet_implemented_fault!(self, "QuerySet::SetOp".to_string());
+            QuerySet::BagOp(_) => {}
+            QuerySet::Select(_) => {
+                self.enter_q();
             }
-            QuerySet::Select(_) => {}
             QuerySet::Expr(_) => {}
             QuerySet::Values(_) => {
                 not_yet_implemented_fault!(self, "QuerySet::Values".to_string());
@@ -635,14 +616,48 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         Traverse::Continue
     }
 
-    fn exit_query_set(&mut self, _query_set: &'ast QuerySet) -> Traverse {
+    fn exit_query_set(&mut self, query_set: &'ast QuerySet) -> Traverse {
         let env = self.exit_env();
+        let mut benv = self.exit_benv();
 
-        match _query_set {
-            QuerySet::SetOp(_) => {
-                not_yet_implemented_fault!(self, "QuerySet::SetOp".to_string());
+        match query_set {
+            QuerySet::BagOp(bag_op) => {
+                eq_or_fault!(self, benv.len(), 2, "benv.len() != 2");
+                let rid = benv.pop().unwrap();
+                let lid = benv.pop().unwrap();
+
+                let bag_operator = match bag_op.node.bag_op {
+                    BagOperator::Union => logical::BagOperator::Union,
+                    BagOperator::Except => logical::BagOperator::Except,
+                    BagOperator::Intersect => logical::BagOperator::Intersect,
+                    BagOperator::OuterUnion => logical::BagOperator::OuterUnion,
+                    BagOperator::OuterExcept => logical::BagOperator::OuterExcept,
+                    BagOperator::OuterIntersect => logical::BagOperator::OuterIntersect,
+                };
+                let setq = match bag_op.node.setq {
+                    SetQuantifier::All => logical::SetQuantifier::All,
+                    SetQuantifier::Distinct => logical::SetQuantifier::Distinct,
+                };
+
+                let id = self.plan.add_operator(BindingsOp::BagOp(BagOp {
+                    bag_op: bag_operator,
+                    setq,
+                }));
+                self.plan.add_flow_with_branch_num(lid, id, 0);
+                self.plan.add_flow_with_branch_num(rid, id, 1);
+                self.push_bexpr(id);
             }
-            QuerySet::Select(_) => {}
+            QuerySet::Select(_) => {
+                let clauses = self.exit_q();
+                let mut clauses = clauses.evaluation_order().into_iter();
+                if let Some(mut src_id) = clauses.next() {
+                    for dst_id in clauses {
+                        self.plan.add_flow(src_id, dst_id);
+                        src_id = dst_id;
+                    }
+                    self.push_bexpr(src_id);
+                }
+            }
             QuerySet::Expr(_) => {
                 eq_or_fault!(self, env.len(), 1, "env.len() != 1");
                 let expr = env.into_iter().next().unwrap();
@@ -660,11 +675,11 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         Traverse::Continue
     }
 
-    fn enter_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Traverse {
+    fn enter_bag_op_expr(&mut self, _set_expr: &'ast BagOpExpr) -> Traverse {
         Traverse::Continue
     }
 
-    fn exit_set_expr(&mut self, _set_expr: &'ast SetExpr) -> Traverse {
+    fn exit_bag_op_expr(&mut self, _set_expr: &'ast BagOpExpr) -> Traverse {
         Traverse::Continue
     }
 
@@ -1278,8 +1293,6 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         self.enter_env();
 
         let id = *self.current_node();
-        true_or_fault!(self, !self.siblings.is_empty(), "self.siblings is empty");
-        self.siblings.last_mut().unwrap().push(id);
 
         for sym in [&from_let.as_alias, &from_let.at_alias, &from_let.by_alias]
             .into_iter()

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -92,11 +92,6 @@ where
     }
 
     /// Adds a data flow with a branch number.
-    /// TODO: decide if `branch_num` is necessary within the current implementation. JOINs were
-    ///  previously modeled as having separate data flows and the branch number was used to
-    ///  distinguish between the LHS and RHS of a JOIN. JOINs have since been refactored to support
-    ///  LATERAL JOINs which don't have separate data flows within the logical plan.
-    ///  Tracking issue for possible removal: https://github.com/partiql/partiql-lang-rust/issues/237
     #[inline]
     pub fn add_flow_with_branch_num(&mut self, src: OpId, dst: OpId, branch_num: u8) {
         assert!(src.index() <= self.operator_count());

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -204,7 +204,7 @@ pub enum BindingsOp {
     OrderBy(OrderBy),
     LimitOffset(LimitOffset),
     Join(Join),
-    SetOp,
+    BagOp(BagOp),
     Project(Project),
     ProjectAll,
     ProjectValue(ProjectValue),
@@ -295,6 +295,26 @@ pub struct SortSpec {
 pub struct LimitOffset {
     pub limit: Option<ValueExpr>,
     pub offset: Option<ValueExpr>,
+}
+
+/// [`BagOp`] represents a bag operator, e.g. `UNION ALL` in `SELECT a, b FROM foo UNION ALL SELECT c, d FROM bar`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct BagOp {
+    pub bag_op: BagOperator,
+    pub setq: SetQuantifier,
+}
+
+/// Represents the supported bag operator types.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum BagOperator {
+    Union,
+    Except,
+    Intersect,
+    OuterUnion,
+    OuterExcept,
+    OuterIntersect,
 }
 
 /// ['Join`] represents a join operator, e.g. implicit `CROSS JOIN` specified by comma in `FROM`

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -79,7 +79,7 @@ impl Parser {
 pub struct Parsed<'input> {
     pub text: &'input str,
     pub offsets: LineOffsetTracker,
-    pub ast: Box<ast::Expr>,
+    pub ast: ast::AstNode<ast::TopLevelQuery>,
     pub locations: LocationMap,
 }
 

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -600,7 +600,6 @@ mod tests {
         }
 
         #[test]
-        #[ignore]
         fn limit() {
             let l = parse_null_id!(
                 r#"SELECT a FROM b UNION SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5"#

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -595,6 +595,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         fn limit() {
             let l = parse_null_id!(
                 r#"SELECT a FROM b UNION SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5"#

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -102,35 +102,35 @@ WithCycleClause : () = {
 //    - all set operations are left-associative and are thus expressed as left-self-recursive rules
 
 QuerySet: ast::AstNode<ast::QuerySet> = {
-    <lo:@L> <lhs:Query> <setop:SetOp> <setq:SetQuantifier> <rhs:SingleQuery> <hi:@R> => {
+    <lo:@L> <lhs:Query> <bag_op:BagOp> <setq:SetQuantifier> <rhs:SingleQuery> <hi:@R> => {
         let lhs = strip_query(lhs);
         let rhs = strip_query_set(rhs, state, lo, hi);
-        let set_expr = state.node(ast::SetExpr {
-             setop,
+        let bag_expr = state.node(ast::BagOpExpr {
+             bag_op,
              setq,
              lhs: Box::new(lhs),
              rhs: Box::new(rhs)
         }, lo..hi);
-        state.node(ast::QuerySet::SetOp(Box::new( set_expr )), lo..hi)
+        state.node(ast::QuerySet::BagOp(Box::new( bag_expr )), lo..hi)
 	},
     <SingleQuery>,
 }
 
 #[inline]
-SetOp: ast::SetOperator = {
-    "UNION" => ast::SetOperator::Union,
-    "OUTER" "UNION" => ast::SetOperator::OuterUnion,
-    "EXCEPT" => ast::SetOperator::Except,
-    "OUTER" "EXCEPT" => ast::SetOperator::OuterExcept,
-    "INTERSECT" => ast::SetOperator::Intersect,
-    "OUTER" "INTERSECT" => ast::SetOperator::OuterIntersect,
+BagOp: ast::BagOperator = {
+    "UNION" => ast::BagOperator::Union,
+    "OUTER" "UNION" => ast::BagOperator::OuterUnion,
+    "EXCEPT" => ast::BagOperator::Except,
+    "OUTER" "EXCEPT" => ast::BagOperator::OuterExcept,
+    "INTERSECT" => ast::BagOperator::Intersect,
+    "OUTER" "INTERSECT" => ast::BagOperator::OuterIntersect,
 
 }
 
 #[inline]
 SetQuantifier: ast::SetQuantifier = {
-    "DISTINCT" => ast::SetQuantifier::Distinct,
-    "ALL"? => ast::SetQuantifier::All,
+    "DISTINCT"? => ast::SetQuantifier::Distinct,
+    "ALL" => ast::SetQuantifier::All,
 }
 
 


### PR DESCRIPTION
Implements the OUTER bag operators. Corrects a bug with the parsed set quantifier for bag operators. Previously when a set quantifier was unspecified, the default was `ALL`. Changed to be `DISTINCT`.

Other changes from this PR
- *BREAKING:* partiql-ast: rename of `SetExpr` to `BagOpExpr` and `SetOp` to `BagOp`
  - Affects the AST and visitor
- *BREAKING:* partiql-parser: `Parsed` struct's `ast` field is now an `ast::AstNode<ast::TopLevelQuery>`
- *BREAKING:* partiql-eval: `Evaluable` trait's `update_input` fn now also takes in an `EvalContext`
- Closes #237. `branch_num` is now used for bag operators. Removed the comment for `add_flow_with_branch_num` fn.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
