### PR TITLE
Fix parsing of multiple consecutive path wildcard, unpivot, path expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to parse `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
 
 ### Fixes
+- Fixes parsing of multiple consecutive path wildcards, unpivots, and path expressions
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to parse `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
 
 ### Fixes
-- Fixes parsing of multiple consecutive path wildcards, unpivots, and path expressions
+- Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -841,37 +841,11 @@ ExprPrecedence02: Synth<ast::Expr> = {
 }
 
 PathExpr: ast::Path = {
-    <l:ExprPrecedence01> "." <steps:PathSteps> => ast::Path { root:Box::new(l.data), steps },
-    <l:ExprPrecedence01> "[" "*" "]" "." <s:PathSteps> => {
+    <l:ExprPrecedence01> <s:PathSteps> => {
         let step = ast::PathStep::PathWildCard;
         ast::Path {
             root: Box::new(l.data),
-            steps: std::iter::once(step).chain(s.into_iter()).collect()
-        }
-    },
-    <l:ExprPrecedence01> "[" <expr:ExprQuery> "]" "." <s:PathSteps> => {
-       let step = ast::PathStep::PathExpr(
-        ast::PathExpr{
-                index: Box::new(*expr),
-            }
-        );
-
-        ast::Path {
-            root: Box::new(l.data),
-            steps: std::iter::once(step).chain(s.into_iter()).collect()
-        }
-    },
-    <l:ExprPrecedence01> "[" "*" "]" => ast::Path {
-        root:Box::new(l.data), steps:vec![ast::PathStep::PathWildCard]
-    },
-    <l:ExprPrecedence01> "[" <expr:ExprQuery> "]" => {
-         let step = ast::PathStep::PathExpr(
-             ast::PathExpr{
-                 index: Box::new(*expr),
-             });
-
-        ast::Path {
-            root:Box::new(l.data), steps:vec![step]
+            steps: s
         }
     },
 }
@@ -1111,9 +1085,10 @@ FunctionArgName: ast::SymbolPrimitive = {
 // Examples:
 // a.b
 // a.*
-// a.[*]
 // a[*]
+// a[*][*]
 // a.b.c
+// a[*].b[*].c
 // "a".b
 // "a"."b"
 // { 'a': 1, 'b': 2 }.a
@@ -1137,7 +1112,6 @@ PathSteps: Vec<ast::PathStep> = {
          let mut steps = path;
          steps.push(ast::PathStep::PathUnpivot);
          steps
-         // ast::Path{ root:path.root, steps }
     },
     <lo:@L> <path:PathSteps> "[" <expr:ExprQuery> "]" <hi:@R> => {
         let step = ast::PathStep::PathExpr(
@@ -1149,17 +1123,17 @@ PathSteps: Vec<ast::PathStep> = {
         steps.push(step);
         steps
     },
+    "." <v:PathExprVarRef> => {
+        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
+    },
     "[" "*" "]" => {
         vec![ast::PathStep::PathWildCard]
     },
-    "[" <expr:ExprQuery> "]" => {
-        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
-    },
-    "*" => {
+    "." "*" => {
         vec![ast::PathStep::PathUnpivot]
     },
-    <v:PathExprVarRef> => {
-        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
+    "[" <expr:ExprQuery> "]" => {
+        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
     },
 }
 


### PR DESCRIPTION
Fixes #403.
Fixes #404.

Fix the parsing of multiple, consecutive path wildcard (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`). Previously these would not parse correctly.

Points the `partiql-tests` git submodule to https://github.com/partiql/partiql-tests/pull/100 branch. Once that's merged, will rebase this PR to point to `partiql-tests` `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
