### PR TITLE
Slight refactor to PathSteps in grammar

### DIFF
--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -1098,42 +1098,27 @@ FunctionArgName: ast::SymbolPrimitive = {
 //
 // See the path expression conformance tests under `partiql-tests` or parser unit-tests for more examples.
 PathSteps: Vec<ast::PathStep> = {
-    <path:PathSteps> "." <v:PathExprVarRef> => {
-        let mut steps = path;
-        steps.push(ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) }));
-        steps
-    },
-    <lo:@L> <path:PathSteps> "[" "*" "]" <hi:@R> => {
-        let mut steps = path;
-        steps.push(ast::PathStep::PathWildCard);
-        steps
-    },
-    <lo:@L> <path:PathSteps>  "." "*" <hi:@R> => {
-         let mut steps = path;
-         steps.push(ast::PathStep::PathUnpivot);
-         steps
-    },
-    <lo:@L> <path:PathSteps> "[" <expr:ExprQuery> "]" <hi:@R> => {
-        let step = ast::PathStep::PathExpr(
-            ast::PathExpr{
-                index: Box::new(*expr),
-            });
-
+    <path:PathSteps> <step:PathStep> => {
         let mut steps = path;
         steps.push(step);
         steps
     },
+    <step:PathStep> => {
+        vec![step]
+    },
+}
+PathStep: ast::PathStep = {
     "." <v:PathExprVarRef> => {
-        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })]
+        ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(v) })
     },
     "[" "*" "]" => {
-        vec![ast::PathStep::PathWildCard]
+        ast::PathStep::PathWildCard
     },
     "." "*" => {
-        vec![ast::PathStep::PathUnpivot]
+        ast::PathStep::PathUnpivot
     },
     "[" <expr:ExprQuery> "]" => {
-        vec![ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })]
+        ast::PathStep::PathExpr( ast::PathExpr{ index: Box::new(*expr) })
     },
 }
 


### PR DESCRIPTION
Code refactor provided by @jpschorr who noticed some repetition in the lalrpop rule for `PathSteps`. Merging this can also help us check on the performance regression (https://github.com/partiql/partiql-lang-rust/commit/0f49d1b63f5743061eeebb94d9024a66f4efdb13#commitcomment-120867182) part of #405.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
