### PR TITLE
Add subquery lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `partiql_ast_passes::static_typer` for type annotating the AST.
 - Add ability to parse `ORDER BY`, `LIMIT`, `OFFSET` in children of set operators
 - Add `OUTER` bag operator (`OUTER UNION`, `OUTER INTERSECT`, `OUTER EXCEPT`) implementation
+- Add ast to logical plan lowering for subqueries
 
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -1422,7 +1422,7 @@ impl Evaluable for EvalOuterIntersect {
         let bag: Bag = match self.setq {
             SetQuantifier::All => {
                 let mut lhs = lhs.counts();
-                Bag::from_iter(rhs.filter(|elem| match lhs.get_mut(&elem) {
+                Bag::from_iter(rhs.filter(|elem| match lhs.get_mut(elem) {
                     Some(count) if *count > 0 => {
                         *count -= 1;
                         true
@@ -1477,7 +1477,7 @@ impl Evaluable for EvalOuterExcept {
         let rhs = bagop_iter(self.r_input.take().unwrap_or(Missing));
 
         let mut exclude = rhs.counts();
-        let excepted = lhs.filter(|elem| match exclude.get_mut(&elem) {
+        let excepted = lhs.filter(|elem| match exclude.get_mut(elem) {
             Some(count) if *count > 0 => {
                 *count -= 1;
                 false


### PR DESCRIPTION
Lower subqueries to the logical plan's `SubQueryExpr` node. Targets the [`feat-bag-ops`](https://github.com/partiql/partiql-lang-rust/tree/feat-bag-ops) branch since both PRs adjust some query lowering code. Once #400 is merged, this PR will target `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
