### PR TITLE
Add AST to logical plan lowering for `IN` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `partiql-extension-ion-functions` extension which contains an extension function for reading from an Ion file
 - Add `partiql-catalog` including an experimental `Catalog` interface and implementation
 - Implements the `COLL_*` functions -- `COLL_AVG`, `COLL_COUNT`, `COLL_MAX`, `COLL_MIN`, `COLL_SUM`
+- Adds AST to logical plan lowering for `IN` expressions
 ### Fixes
 - Fix parsing of `EXTRACT` datetime parts `YEAR`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE`
 - Fix logical plan to eval plan conversion for `EvalOrderBySortSpec` with arguments `DESC` and `NULLS LAST`

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -867,6 +867,24 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         Traverse::Continue
     }
 
+    fn enter_in(&mut self, _in: &'ast ast::In) -> Traverse {
+        self.enter_env();
+        Traverse::Continue
+    }
+    fn exit_in(&mut self, _in: &'ast ast::In) -> Traverse {
+        let mut env = self.exit_env();
+        eq_or_fault!(self, env.len(), 2, "env.len() != 2");
+
+        let rhs = env.pop().unwrap();
+        let lhs = env.pop().unwrap();
+        self.push_vexpr(logical::ValueExpr::BinaryExpr(
+            logical::BinaryOp::In,
+            Box::new(lhs),
+            Box::new(rhs),
+        ));
+        Traverse::Continue
+    }
+
     fn enter_like(&mut self, _like: &'ast Like) -> Traverse {
         self.enter_env();
         Traverse::Continue


### PR DESCRIPTION
`IN` expressions are currently part of AST parsing and logical/eval plan. The lowering from AST to logical plan hadn't been added yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.