### PR TITLE
Improvements to Value iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *BREAKING:* partiql-eval: Construction of expression evaluators changed to separate binding from evaluation of expression. & implement strict eval
 - *BREAKING:* partiql-value: `Value` trait's `is_null_or_missing` renamed to `is_absent`
+- *BREAKING:* partiql-value: `Value` trait's `coerce_to_tuple`, `coerece_to_bag`, and `coerce_to_list` methods renamed to `coerce_into_tuple`, `coerece_into_bag`, and `coerece_into_list`.
+- *BREAKING:* partiql-value: `Tuple`'s `pairs` and `into_pairs` changed to return concrete `Iterator` types.
 - *BREAKING:* partiql-eval: `EvaluatorPlanner` construction now takes an `EvaluationMode` parameter.
 - *BREAKING:* partiql-eval: `like_to_re_pattern` is no longer public.
 - *BREAKING:* partiql-value: Box Decimals in `Value` to assure `Value` fits in 16 bytes.

--- a/extension/partiql-extension-ion/src/decode.rs
+++ b/extension/partiql-extension-ion/src/decode.rs
@@ -124,6 +124,11 @@ impl<'a> Iterator for IonValueIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
 }
 
 struct IonValueIterInner<D, R>
@@ -519,7 +524,7 @@ where
         let is_bag = has_annotation(reader, BAG_ANNOT);
         let list = decode_list(self, reader);
         if is_bag {
-            Ok(Bag::from(list?.coerce_to_list()).into())
+            Ok(Bag::from(list?.coerce_into_list()).into())
         } else {
             list
         }

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -716,7 +716,7 @@ impl Evaluable for EvalGroupBy {
             EvalGroupingStrategy::GroupFull => {
                 let mut groups: HashMap<Tuple, Vec<Value>> = HashMap::new();
                 for v in input_value.into_iter() {
-                    let v_as_tuple = v.coerce_to_tuple();
+                    let v_as_tuple = v.coerce_into_tuple();
                     let group = self.eval_group(&v_as_tuple, ctx);
                     // Compute next aggregation result for each of the aggregation expressions
                     for aggregate_expr in self.aggregate_exprs.iter_mut() {
@@ -798,7 +798,7 @@ impl Evaluable for EvalPivot {
         let tuple: Tuple = input_value
             .into_iter()
             .filter_map(|binding| {
-                let binding = binding.coerce_to_tuple();
+                let binding = binding.coerce_into_tuple();
                 let key = self.key.evaluate(&binding, ctx);
                 if let Value::String(s) = key.as_ref() {
                     let value = self.value.evaluate(&binding, ctx);
@@ -852,7 +852,7 @@ impl Evaluable for EvalUnpivot {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Value {
         let tuple = match self.expr.evaluate(&Tuple::new(), ctx).into_owned() {
             Value::Tuple(tuple) => *tuple,
-            other => other.coerce_to_tuple(),
+            other => other.coerce_into_tuple(),
         };
 
         let as_key = self.as_key.as_str();
@@ -911,7 +911,7 @@ impl Evaluable for EvalFilter {
 
         let filtered = input_value
             .into_iter()
-            .map(Value::coerce_to_tuple)
+            .map(Value::coerce_into_tuple)
             .filter_map(|v| self.eval_filter(&v, ctx).then_some(v));
         Value::from(filtered.collect::<Bag>())
     }
@@ -956,7 +956,7 @@ impl Evaluable for EvalHaving {
 
         let filtered = input_value
             .into_iter()
-            .map(Value::coerce_to_tuple)
+            .map(Value::coerce_into_tuple)
             .filter_map(|v| self.eval_having(&v, ctx).then_some(v));
         Value::from(filtered.collect::<Bag>())
     }
@@ -1128,7 +1128,7 @@ impl Evaluable for EvalSelectValue {
         let ordered = input_value.is_ordered();
 
         let values = input_value.into_iter().map(|v| {
-            let v_as_tuple = v.coerce_to_tuple();
+            let v_as_tuple = v.coerce_into_tuple();
             self.expr.evaluate(&v_as_tuple, ctx).into_owned()
         });
 
@@ -1166,7 +1166,7 @@ impl Evaluable for EvalSelect {
         let ordered = input_value.is_ordered();
 
         let values = input_value.into_iter().map(|v| {
-            let v_as_tuple = v.coerce_to_tuple();
+            let v_as_tuple = v.coerce_into_tuple();
 
             let tuple_pairs = self.exprs.iter().filter_map(|(alias, expr)| {
                 let evaluated_val = expr.evaluate(&v_as_tuple, ctx);
@@ -1210,9 +1210,9 @@ impl Evaluable for EvalSelectAll {
         let ordered = input_value.is_ordered();
 
         let values = input_value.into_iter().map(|val| {
-            val.coerce_to_tuple()
+            val.coerce_into_tuple()
                 .into_values()
-                .flat_map(|v| v.coerce_to_tuple().into_pairs())
+                .flat_map(|v| v.coerce_into_tuple().into_pairs())
                 .collect::<Tuple>()
         });
 
@@ -1244,7 +1244,7 @@ impl EvalExprQuery {
 
 impl Evaluable for EvalExprQuery {
     fn evaluate(&mut self, ctx: &dyn EvalContext) -> Value {
-        let input_value = self.input.take().unwrap_or(Value::Null).coerce_to_tuple();
+        let input_value = self.input.take().unwrap_or(Value::Null).coerce_into_tuple();
 
         self.expr.evaluate(&input_value, ctx).into_owned()
     }

--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -75,10 +75,19 @@ where
 {
     type Item = V;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             SetQuantified::All(i) => i.next(),
             SetQuantified::Distinct(i) => i.next(),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            SetQuantified::All(i) => i.size_hint(),
+            SetQuantified::Distinct(i) => i.size_hint(),
         }
     }
 }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -182,7 +182,7 @@ mod tests {
         let mut bindings = MapBindings::default();
         bindings.insert("data", list![Tuple::from([("lhs", lhs)])].into());
 
-        let result = evaluate(plan, bindings).coerce_to_bag();
+        let result = evaluate(plan, bindings).coerce_into_bag();
         assert!(!&result.is_empty());
         let expected_result = if expected_first_elem != Missing {
             bag!(Tuple::from([("result", expected_first_elem)]))
@@ -689,7 +689,7 @@ mod tests {
             let mut bindings = MapBindings::default();
             bindings.insert("data", list![Tuple::from([("value", value)])].into());
 
-            let result = evaluate(plan, bindings).coerce_to_bag();
+            let result = evaluate(plan, bindings).coerce_into_bag();
             assert!(!&result.is_empty());
             let expected_result = bag!(Tuple::from([("result", expected_first_elem)]));
             assert_eq!(expected_result, result);
@@ -1154,7 +1154,7 @@ mod tests {
         let mut bindings = MapBindings::default();
         bindings.insert("data", list![Tuple::from([("expr", expr)])].into());
 
-        let result = evaluate(plan, bindings).coerce_to_bag();
+        let result = evaluate(plan, bindings).coerce_into_bag();
         assert!(!&result.is_empty());
         assert_eq!(bag!(Tuple::from([("result", expected_first_elem)])), result);
     }
@@ -1216,7 +1216,7 @@ mod tests {
         let mut bindings = MapBindings::default();
         bindings.insert("data", list![Tuple::from([("lhs", lhs)])].into());
 
-        let result = evaluate(plan, bindings).coerce_to_bag();
+        let result = evaluate(plan, bindings).coerce_into_bag();
         assert!(!&result.is_empty());
         let expected_result = if expected_first_elem != Missing {
             bag!(Tuple::from([("result", expected_first_elem)]))
@@ -1280,7 +1280,7 @@ mod tests {
             .for_each(|(i, e)| data.insert(&format!("arg{i}"), e));
         bindings.insert("data", list![data].into());
 
-        let result = evaluate(plan, bindings).coerce_to_bag();
+        let result = evaluate(plan, bindings).coerce_into_bag();
         assert!(!&result.is_empty());
         assert_eq!(bag!(Tuple::from([("result", expected_first_elem)])), result);
     }

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -108,6 +108,7 @@ impl<'a> IntoIterator for &'a Bag {
     type Item = &'a Value;
     type IntoIter = BagIter<'a>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         BagIter(self.0.iter())
     }
@@ -119,8 +120,14 @@ pub struct BagIter<'a>(slice::Iter<'a, Value>);
 impl<'a> Iterator for BagIter<'a> {
     type Item = &'a Value;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -138,8 +145,14 @@ pub struct BagIntoIterator(vec::IntoIter<Value>);
 impl Iterator for BagIntoIterator {
     type Item = Value;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -119,8 +119,14 @@ pub struct ListIter<'a>(slice::Iter<'a, Value>);
 impl<'a> Iterator for ListIter<'a> {
     type Item = &'a Value;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -138,8 +144,14 @@ pub struct ListIntoIterator(vec::IntoIter<Value>);
 impl Iterator for ListIntoIterator {
     type Item = Value;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 


### PR DESCRIPTION
- Implement `size_hint` for applicable iterators
- rename `coerce_to_*` methods to `coerce_into_*` when they take ownership
- reify some iterators rather than use `impl Iterator` 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
