### PR TITLE
Change `BindingsName` to hold `Cow<str>` rather than  `String` to reduce `clone` needed for lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+
+- *BREAKING:* partiql-value: `BindingsName` changed to hold `Cow<str>` rather than  `String`
 - *BREAKING:* partiql-eval: Construction of expression evaluators changed to separate binding from evaluation of expression. & implement strict eval
 - *BREAKING:* partiql-value: `Value` trait's `is_null_or_missing` renamed to `is_absent`
 - *BREAKING:* partiql-value: `Value` trait's `coerce_to_tuple`, `coerece_to_bag`, and `coerce_to_list` methods renamed to `coerce_into_tuple`, `coerece_into_bag`, and `coerece_into_list`.

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
@@ -71,7 +72,7 @@ fn join_data() -> MapBindings<Value> {
 fn scan(name: &str, as_key: &str) -> BindingsOp {
     BindingsOp::Scan(logical::Scan {
         expr: ValueExpr::VarRef(
-            BindingsName::CaseInsensitive(name.into()),
+            BindingsName::CaseInsensitive(Cow::Owned(name.to_string())),
             VarRefType::Global,
         ),
         as_key: as_key.to_string(),
@@ -82,11 +83,11 @@ fn scan(name: &str, as_key: &str) -> BindingsOp {
 fn path_var(name: &str, component: &str) -> ValueExpr {
     ValueExpr::Path(
         Box::new(ValueExpr::VarRef(
-            BindingsName::CaseInsensitive(name.into()),
+            BindingsName::CaseInsensitive(Cow::Owned(name.to_string())),
             VarRefType::Local,
         )),
         vec![PathComponent::Key(BindingsName::CaseInsensitive(
-            component.to_string(),
+            Cow::Owned(component.to_string()),
         ))],
     )
 }
@@ -158,11 +159,11 @@ fn eval_bench(c: &mut Criterion) {
         let from = logical_plan.add_operator(BindingsOp::Scan(logical::Scan {
             expr: ValueExpr::Path(
                 Box::new(ValueExpr::VarRef(
-                    BindingsName::CaseInsensitive("hr".to_string()),
+                    BindingsName::CaseInsensitive(Cow::Borrowed("hr")),
                     VarRefType::Local,
                 )),
                 vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                    "employeesNestScalars".to_string(),
+                    Cow::Borrowed("employeesNestScalars"),
                 ))],
             ),
             as_key: "x".to_string(),

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -55,7 +55,7 @@ pub mod basic {
         #[inline]
         fn get(&self, name: &BindingsName) -> Option<&T> {
             let idx = match name {
-                BindingsName::CaseSensitive(s) => self.sensitive.get(s),
+                BindingsName::CaseSensitive(s) => self.sensitive.get(s.as_ref()),
                 BindingsName::CaseInsensitive(s) => {
                     self.insensitive.get(&UniCase::new(s.to_string()))
                 }
@@ -120,22 +120,22 @@ mod tests {
         // by ref
         let bindings = MapBindings::from(&t);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             Some(&Value::from(tuple![("p", 1)]))
         );
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("b".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("b".to_string().into())),
             Some(&Value::from(2))
         );
 
         // by ownership
         let bindings = MapBindings::from(t);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             Some(&Value::from(tuple![("p", 1)]))
         );
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("b".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("b".to_string().into())),
             Some(&Value::from(2))
         );
     }
@@ -144,22 +144,22 @@ mod tests {
     fn test_bindings_from_value() {
         let bindings = MapBindings::from(Value::Null);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             None
         );
         let bindings = MapBindings::from(&Value::Null);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             None
         );
         let bindings = MapBindings::from(Value::Missing);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             None
         );
         let bindings = MapBindings::from(&Value::Missing);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             None
         );
 
@@ -168,22 +168,22 @@ mod tests {
         // by ref
         let bindings = MapBindings::from(&t);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             Some(&Value::from(tuple![("p", 1)]))
         );
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("b".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("b".to_string().into())),
             Some(&Value::from(2))
         );
 
         // by ownership
         let bindings = MapBindings::from(t);
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("a".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("a".to_string().into())),
             Some(&Value::from(tuple![("p", 1)]))
         );
         assert_eq!(
-            bindings.get(&BindingsName::CaseInsensitive("b".to_string())),
+            bindings.get(&BindingsName::CaseInsensitive("b".to_string().into())),
             Some(&Value::from(2))
         );
     }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -69,7 +69,7 @@ mod tests {
     fn scan(name: &str, as_key: &str) -> BindingsOp {
         BindingsOp::Scan(logical::Scan {
             expr: ValueExpr::VarRef(
-                BindingsName::CaseInsensitive(name.into()),
+                BindingsName::CaseInsensitive(name.to_string().into()),
                 VarRefType::Global,
             ),
             as_key: as_key.to_string(),
@@ -80,11 +80,11 @@ mod tests {
     fn path_var(name: &str, component: &str) -> ValueExpr {
         ValueExpr::Path(
             Box::new(ValueExpr::VarRef(
-                BindingsName::CaseInsensitive(name.into()),
+                BindingsName::CaseInsensitive(name.to_string().into()),
                 VarRefType::Local,
             )),
             vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                component.to_string(),
+                component.to_string().into(),
             ))],
         )
     }
@@ -176,7 +176,7 @@ mod tests {
                             VarRefType::Local,
                         )),
                         vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                            "lhs".to_string(),
+                            "lhs".to_string().into(),
                         ))],
                     )),
                     Box::new(ValueExpr::Lit(Box::new(rhs))),
@@ -686,7 +686,7 @@ mod tests {
                                 VarRefType::Local,
                             )),
                             vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                                "value".to_string(),
+                                "value".to_string().into(),
                             ))],
                         )),
                         from: Box::new(ValueExpr::Lit(Box::new(from))),
@@ -1156,7 +1156,7 @@ mod tests {
                             VarRefType::Local,
                         )),
                         vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                            "expr".to_string(),
+                            "expr".to_string().into(),
                         ))],
                     )),
                     is_type,
@@ -1222,7 +1222,7 @@ mod tests {
                             VarRefType::Local,
                         )),
                         vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                            "lhs".to_string(),
+                            "lhs".to_string().into(),
                         ))],
                     )),
                     rhs: Box::new(ValueExpr::Lit(Box::new(rhs))),
@@ -1277,9 +1277,9 @@ mod tests {
                     BindingsName::CaseInsensitive("data".into()),
                     VarRefType::Local,
                 )),
-                vec![PathComponent::Key(BindingsName::CaseInsensitive(format!(
-                    "arg{i}"
-                )))],
+                vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                    format!("arg{i}").into(),
+                ))],
             )
         }
 
@@ -1423,7 +1423,7 @@ mod tests {
                         VarRefType::Local,
                     )),
                     vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                        "a".to_string(),
+                        "a".to_string().into(),
                     ))],
                 ),
             )]),
@@ -1952,7 +1952,7 @@ mod tests {
                         VarRefType::Local,
                     )),
                     vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                        "balance".to_string(),
+                        "balance".to_string().into(),
                     ))],
                 )),
                 Box::new(ValueExpr::Lit(Box::new(Value::Integer(0)))),
@@ -1969,7 +1969,7 @@ mod tests {
                             VarRefType::Local,
                         )),
                         vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                            "firstName".to_string(),
+                            "firstName".to_string().into(),
                         ))],
                     ),
                 ),
@@ -1983,7 +1983,7 @@ mod tests {
                                 VarRefType::Local,
                             )),
                             vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                                "firstName".to_string(),
+                                "firstName".to_string().into(),
                             ))],
                         )),
                         Box::new(ValueExpr::Path(
@@ -1992,7 +1992,7 @@ mod tests {
                                 VarRefType::Local,
                             )),
                             vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                                "firstName".to_string(),
+                                "firstName".to_string().into(),
                             ))],
                         )),
                     ),
@@ -2037,7 +2037,7 @@ mod tests {
                         VarRefType::Local,
                     )),
                     vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                        "a".to_string(),
+                        "a".to_string().into(),
                     ))],
                 )),
                 Box::new(ValueExpr::Lit(Box::new(list![1].into()))),
@@ -2053,7 +2053,7 @@ mod tests {
                         VarRefType::Local,
                     )),
                     vec![PathComponent::Key(BindingsName::CaseInsensitive(
-                        "a".to_string(),
+                        "a".to_string().into(),
                     ))],
                 ),
             )]),
@@ -2234,7 +2234,7 @@ mod tests {
 
             let mut scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
-                    name: BindingsName::CaseInsensitive("someOrderedTable".to_string()),
+                    name: BindingsName::CaseInsensitive("someOrderedTable".to_string().into()),
                 }),
                 "x",
                 "y",
@@ -2260,7 +2260,7 @@ mod tests {
 
             let mut scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
-                    name: BindingsName::CaseInsensitive("someUnorderedTable".to_string()),
+                    name: BindingsName::CaseInsensitive("someUnorderedTable".to_string().into()),
                 }),
                 "x",
                 "y",
@@ -2289,7 +2289,7 @@ mod tests {
             p0.insert("someOrderedTable", some_ordered_table().into());
 
             let table_ref = EvalGlobalVarRef {
-                name: BindingsName::CaseInsensitive("someOrderedTable".to_string()),
+                name: BindingsName::CaseInsensitive("someOrderedTable".to_string().into()),
             };
             let path_to_scalar = EvalPath {
                 expr: Box::new(table_ref),
@@ -2314,7 +2314,7 @@ mod tests {
             p0.insert("someOrderedTable", some_ordered_table().into());
 
             let table_ref = EvalGlobalVarRef {
-                name: BindingsName::CaseInsensitive("someOrderedTable".to_string()),
+                name: BindingsName::CaseInsensitive("someOrderedTable".to_string().into()),
             };
             let path_to_scalar = EvalPath {
                 expr: Box::new(table_ref),
@@ -2354,7 +2354,7 @@ mod tests {
 
             let mut unpivot = EvalUnpivot::new(
                 Box::new(EvalGlobalVarRef {
-                    name: BindingsName::CaseInsensitive("justATuple".to_string()),
+                    name: BindingsName::CaseInsensitive("justATuple".to_string().into()),
                 }),
                 "price",
                 Some("symbol".into()),
@@ -2378,7 +2378,7 @@ mod tests {
 
             let mut unpivot = EvalUnpivot::new(
                 Box::new(EvalGlobalVarRef {
-                    name: BindingsName::CaseInsensitive("nonTuple".to_string()),
+                    name: BindingsName::CaseInsensitive("nonTuple".to_string().into()),
                 }),
                 "x",
                 Some("y".into()),

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -19,6 +19,7 @@ use partiql_logical::{
     LikeNonStringNonLiteralMatch, ListExpr, LogicalPlan, OpId, PathComponent, Pattern,
     PatternMatchExpr, SortSpecOrder, TupleExpr, ValueExpr, VarRefType,
 };
+use std::borrow::Cow;
 
 use partiql_value::{BindingsName, Value};
 
@@ -181,28 +182,28 @@ pub struct AstToLogical<'a> {
 /// Attempt to infer an alias for a simple variable reference expression.
 /// For example infer such that  `SELECT a, b.c.d.e ...` <=> `SELECT a as a, b.c.d.e as e`  
 fn infer_id(expr: &ValueExpr) -> Option<SymbolPrimitive> {
-    let sensitive = |value| {
+    let sensitive = |value: &str| {
         Some(SymbolPrimitive {
-            value,
+            value: value.to_string(),
             case: CaseSensitivity::CaseSensitive,
         })
     };
-    let insensitive = |value| {
+    let insensitive = |value: &str| {
         Some(SymbolPrimitive {
-            value,
+            value: value.to_string(),
             case: CaseSensitivity::CaseInsensitive,
         })
     };
 
     match expr {
-        ValueExpr::VarRef(BindingsName::CaseInsensitive(s), _) => insensitive(s.clone()),
-        ValueExpr::VarRef(BindingsName::CaseSensitive(s), _) => sensitive(s.clone()),
+        ValueExpr::VarRef(BindingsName::CaseInsensitive(s), _) => insensitive(s.as_ref()),
+        ValueExpr::VarRef(BindingsName::CaseSensitive(s), _) => sensitive(s.as_ref()),
         ValueExpr::Path(_root, steps) => match steps.last() {
-            Some(PathComponent::Key(BindingsName::CaseInsensitive(s))) => insensitive(s.clone()),
-            Some(PathComponent::Key(BindingsName::CaseSensitive(s))) => sensitive(s.clone()),
+            Some(PathComponent::Key(BindingsName::CaseInsensitive(s))) => insensitive(s.as_ref()),
+            Some(PathComponent::Key(BindingsName::CaseSensitive(s))) => sensitive(s.as_ref()),
             Some(PathComponent::KeyExpr(ke)) => match &**ke {
-                ValueExpr::VarRef(BindingsName::CaseInsensitive(s), _) => insensitive(s.clone()),
-                ValueExpr::VarRef(BindingsName::CaseSensitive(s), _) => sensitive(s.clone()),
+                ValueExpr::VarRef(BindingsName::CaseInsensitive(s), _) => insensitive(s.as_ref()),
+                ValueExpr::VarRef(BindingsName::CaseSensitive(s), _) => sensitive(s.as_ref()),
                 _ => None,
             },
             _ => None,
@@ -283,16 +284,18 @@ impl<'a> AstToLogical<'a> {
 
     fn resolve_varref(&self, varref: &ast::VarRef) -> logical::ValueExpr {
         // Convert a `SymbolPrimitive` into a `BindingsName`
-        fn symprim_to_binding(sym: &SymbolPrimitive) -> BindingsName {
+        fn symprim_to_binding(sym: &SymbolPrimitive) -> BindingsName<'static> {
             match sym.case {
-                CaseSensitivity::CaseSensitive => BindingsName::CaseSensitive(sym.value.clone()),
+                CaseSensitivity::CaseSensitive => {
+                    BindingsName::CaseSensitive(Cow::Owned(sym.value.clone()))
+                }
                 CaseSensitivity::CaseInsensitive => {
-                    BindingsName::CaseInsensitive(sym.value.clone())
+                    BindingsName::CaseInsensitive(Cow::Owned(sym.value.clone()))
                 }
             }
         }
         // Convert a `name_resolver::Symbol` into a `BindingsName`
-        fn sym_to_binding(sym: &name_resolver::Symbol) -> Option<BindingsName> {
+        fn sym_to_binding(sym: &name_resolver::Symbol) -> Option<BindingsName<'static>> {
             match sym {
                 name_resolver::Symbol::Known(sym) => Some(symprim_to_binding(sym)),
                 name_resolver::Symbol::Unknown(_) => None,
@@ -378,7 +381,9 @@ impl<'a> AstToLogical<'a> {
                                             let formatted_num = format!("_{}", num);
                                             if formatted_num == varref.name.value {
                                                 let expr = ValueExpr::VarRef(
-                                                    BindingsName::CaseInsensitive(formatted_num),
+                                                    BindingsName::CaseInsensitive(Cow::Owned(
+                                                        formatted_num,
+                                                    )),
                                                     VarRefType::Local,
                                                 );
                                                 if !lookups.contains(&expr) {
@@ -390,7 +395,7 @@ impl<'a> AstToLogical<'a> {
                                                     Box::new(ValueExpr::VarRef(
                                                         sym_to_binding(produce).unwrap_or({
                                                             BindingsName::CaseInsensitive(
-                                                                formatted_num,
+                                                                Cow::Owned(formatted_num),
                                                             )
                                                         }),
                                                         VarRefType::Local,
@@ -1166,7 +1171,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         // E.g. SELECT a, SUM(b) FROM t GROUP BY a
         //      SELECT a AS a, $__agg_1 AS b FROM t GROUP BY a
         let new_name = "$__agg".to_owned() + &self.agg_id.id();
-        let new_binding_name = BindingsName::CaseSensitive(new_name.clone());
+        let new_binding_name = BindingsName::CaseSensitive(Cow::Owned(new_name.clone()));
         let new_expr = ValueExpr::VarRef(new_binding_name, VarRefType::Local);
         self.push_vexpr(new_expr);
 
@@ -1273,8 +1278,12 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                 qualifier: _,
             } = _var_ref;
             let name = match case {
-                CaseSensitivity::CaseSensitive => BindingsName::CaseSensitive(value.clone()),
-                CaseSensitivity::CaseInsensitive => BindingsName::CaseInsensitive(value.clone()),
+                CaseSensitivity::CaseSensitive => {
+                    BindingsName::CaseSensitive(Cow::Owned(value.clone()))
+                }
+                CaseSensitivity::CaseInsensitive => {
+                    BindingsName::CaseInsensitive(Cow::Owned(value.clone()))
+                }
             };
             self.push_vexpr(ValueExpr::VarRef(name, VarRefType::Local));
         }
@@ -1331,9 +1340,9 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                 match path {
                     ValueExpr::Lit(val) => match *val {
                         Value::Integer(idx) => logical::PathComponent::Index(idx),
-                        Value::String(k) => {
-                            logical::PathComponent::Key(BindingsName::CaseInsensitive(*k))
-                        }
+                        Value::String(k) => logical::PathComponent::Key(
+                            BindingsName::CaseInsensitive(Cow::Owned(*k)),
+                        ),
                         expr => logical::PathComponent::IndexExpr(Box::new(ValueExpr::Lit(
                             Box::new(expr),
                         ))),
@@ -1608,7 +1617,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             };
             for (alias, expr) in select_clause_exprs.iter_mut() {
                 if *expr == value {
-                    let new_binding_name = BindingsName::CaseSensitive(alias.clone());
+                    let new_binding_name = BindingsName::CaseSensitive(Cow::Owned(alias.clone()));
                     let new_expr = ValueExpr::VarRef(new_binding_name, VarRefType::Local);
                     *expr = new_expr
                 }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -28,7 +28,7 @@
 ///     Box::new(ValueExpr::VarRef(BindingsName::CaseInsensitive(
 ///         "v".into(),
 ///     ), VarRefType::Local)),
-///     vec![PathComponent::Key(BindingsName::CaseInsensitive("a".to_string()))],
+///     vec![PathComponent::Key(BindingsName::CaseInsensitive("a".to_string().into()))],
 /// );
 ///
 /// let select_value = p.add_operator(BindingsOp::ProjectValue(ProjectValue {
@@ -415,7 +415,7 @@ pub enum ValueExpr {
     Lit(Box<Value>),
     DynamicLookup(Box<Vec<ValueExpr>>),
     Path(Box<ValueExpr>, Vec<PathComponent>),
-    VarRef(BindingsName, VarRefType),
+    VarRef(BindingsName<'static>, VarRefType),
     TupleExpr(TupleExpr),
     ListExpr(ListExpr),
     BagExpr(BagExpr),
@@ -471,7 +471,7 @@ pub enum BinaryOp {
 /// Represents a path component in a plan.
 pub enum PathComponent {
     /// E.g. `b` in `a.b`
-    Key(BindingsName),
+    Key(BindingsName<'static>),
     /// E.g. 4 in `a[4]`
     Index(i64),
     KeyExpr(Box<ValueExpr>),

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -27,9 +27,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Hash, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum BindingsName {
-    CaseSensitive(String),
-    CaseInsensitive(String),
+pub enum BindingsName<'s> {
+    CaseSensitive(Cow<'s, str>),
+    CaseInsensitive(Cow<'s, str>),
 }
 
 // TODO these are all quite simplified for PoC/demonstration
@@ -2093,20 +2093,20 @@ mod tests {
         // case sensitive
         assert_eq!(
             Some(&Value::from(1)),
-            tuple.get(&BindingsName::CaseSensitive("a".to_string()))
+            tuple.get(&BindingsName::CaseSensitive(Cow::Owned("a".to_string())))
         );
         assert_eq!(
             Some(&Value::from(2)),
-            tuple.get(&BindingsName::CaseSensitive("A".to_string()))
+            tuple.get(&BindingsName::CaseSensitive(Cow::Owned("A".to_string())))
         );
         // case insensitive
         assert_eq!(
             Some(&Value::from(1)),
-            tuple.get(&BindingsName::CaseInsensitive("a".to_string()))
+            tuple.get(&BindingsName::CaseInsensitive(Cow::Owned("a".to_string())))
         );
         assert_eq!(
             Some(&Value::from(1)),
-            tuple.get(&BindingsName::CaseInsensitive("A".to_string()))
+            tuple.get(&BindingsName::CaseInsensitive(Cow::Owned("A".to_string())))
         );
     }
 
@@ -2116,20 +2116,20 @@ mod tests {
         // case sensitive
         assert_eq!(
             Some(Value::from(2)),
-            tuple.remove(&BindingsName::CaseSensitive("A".to_string()))
+            tuple.remove(&BindingsName::CaseSensitive(Cow::Owned("A".to_string())))
         );
         assert_eq!(
             Some(Value::from(1)),
-            tuple.remove(&BindingsName::CaseSensitive("a".to_string()))
+            tuple.remove(&BindingsName::CaseSensitive(Cow::Owned("a".to_string())))
         );
         // case insensitive
         assert_eq!(
             Some(Value::from(3)),
-            tuple.remove(&BindingsName::CaseInsensitive("A".to_string()))
+            tuple.remove(&BindingsName::CaseInsensitive(Cow::Owned("A".to_string())))
         );
         assert_eq!(
             Some(Value::from(4)),
-            tuple.remove(&BindingsName::CaseInsensitive("a".to_string()))
+            tuple.remove(&BindingsName::CaseInsensitive(Cow::Owned("a".to_string())))
         );
     }
 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -41,6 +41,11 @@ impl List {
     }
 
     #[inline]
+    pub fn take_val(self, idx: i64) -> Option<Value> {
+        self.0.into_iter().nth(idx as usize)
+    }
+
+    #[inline]
     pub fn iter(&self) -> ListIter {
         ListIter(self.0.iter())
     }


### PR DESCRIPTION
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
