### PR TITLE
Add Catalog to NameResolver

### DIFF
--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -5,7 +5,7 @@ use partiql_ast_passes::name_resolver::NameResolver;
 use partiql_logical as logical;
 use partiql_parser::Parsed;
 
-use partiql_catalog::Catalog;
+use partiql_catalog::{Catalog, PartiqlCatalog};
 
 mod builtins;
 mod lower;
@@ -25,7 +25,8 @@ impl<'c> LogicalPlanner<'c> {
         parsed: &Parsed,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         let q = &parsed.ast;
-        let mut resolver = NameResolver::default();
+        let catalog = PartiqlCatalog::default();
+        let mut resolver = NameResolver::new(&catalog);
         let registry = resolver.resolve(q)?;
         let planner = AstToLogical::new(self.catalog, registry);
         planner.lower_query(q)


### PR DESCRIPTION
*Description of changes:*

During the work for adding a steel thread for PartiQL Typing (Recent PR #389) and after merging #410 to `feat-type-plan-poc` it is realized that we need to refactor the code to remove `DynamicLocalup` `VarExpr` with the assumption that we work based off of Typing and Value Environment from the Catalog. We have a Typing Environment in the Catalog at the moment and we are going to add the Variable Environment as well. In preparation for such task, we need to make the `NameResolver` Catalog aware. In that regard this commit adds the `Catalog` to `NameResolver`

Expecting subsequent PR(s) for the name resolving using the Catalog.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
