### PR TITLE
Lower COUNT(*) to logical plan; fix multiple aggregations bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `OUTER` bag operator (`OUTER UNION`, `OUTER INTERSECT`, `OUTER EXCEPT`) implementation
 - Add `NullSortedValue` to specify ordering null or missing values `partiql_value::Value`s before or after all other values
 - Implements the aggregation functions `ANY`, `SOME`, `EVERY` and their `COLL_` versions
+- Add `COUNT(*)` implementation
 
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
@@ -47,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes variable resolution of some ORDER BY variables
 - Fixes nested list/bag/tuple type ordering for when `ASC NULLS LAST` and `DESC NULLS FIRST` are specified
 - partiql-value fix deep equality of list, bags, and tuples
+- Fixes bug when using multiple aggregations without a `GROUP BY`
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/partiql-catalog/src/call_defs.rs
+++ b/partiql-catalog/src/call_defs.rs
@@ -19,6 +19,7 @@ pub enum CallLookupError {
 pub enum CallArgument {
     Positional(ValueExpr),
     Named(String, ValueExpr),
+    Star,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Adds `COUNT(*)` lowering to `COUNT(1)`. Fixes a bug where a query with multiple aggregations without `GROUP BY` was only including the first aggregation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
