### PR TITLE
Refactor `EvalGroupBy` and Aggregations to avoid duplicate effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `NullSortedValue` to specify ordering null or missing values `partiql_value::Value`s before or after all other values
 - Implements the aggregation functions `ANY`, `SOME`, `EVERY` and their `COLL_` versions
 - Add `COUNT(*)` implementation
+- Add `to_vec` method to `List` and `Bag` to convert to a `Vec`
 
 ### Fixes
 - Fixes parsing of multiple consecutive path wildcards (e.g. `a[*][*][*]`), unpivot (e.g. `a.*.*.*`), and path expressions (e.g. `a[1 + 2][3 + 4][5 + 6]`)—previously these would not parse correctly.
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixes nested list/bag/tuple type ordering for when `ASC NULLS LAST` and `DESC NULLS FIRST` are specified
 - partiql-value fix deep equality of list, bags, and tuples
 - Fixes bug when using multiple aggregations without a `GROUP BY`
+- Performance improvements to grouping/evaluation
 
 ## [0.5.0] - 2023-06-06
 ### Changed

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = "1.0"
 assert_matches = "1.5.*"
 regex = "1.7"
 regex-syntax = "0.6"
+rustc-hash = "1"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -10,9 +10,9 @@ use partiql_value::{
 use rustc_hash::FxHashMap;
 use std::borrow::{Borrow, Cow};
 use std::cell::RefCell;
-use std::cmp::{max, min, Ordering};
+use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 
 use std::rc::Rc;
@@ -440,7 +440,7 @@ impl AggregateFunction for Avg {
                 let vals = list.to_vec();
                 if let [count, sum] = &vals[..] {
                     if let Value::Integer(n) = sum {
-                        // Avg does not do integer divison; convert to decimal
+                        // Avg does not do integer division; convert to decimal
                         let sum = Value::from(rust_decimal::Decimal::from(*n));
                         Ok(&sum / count)
                     } else {

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -4,12 +4,17 @@ use crate::eval::expr::EvalExpr;
 use crate::eval::{EvalContext, EvalPlan};
 use itertools::Itertools;
 use partiql_value::Value::{Boolean, Missing, Null};
-use partiql_value::{bag, tuple, Bag, List, NullSortedValue, Tuple, Value, ValueIntoIterator};
+use partiql_value::{
+    bag, list, tuple, Bag, List, NullSortedValue, Tuple, Value, ValueIntoIterator,
+};
+use rustc_hash::FxHashMap;
 use std::borrow::{Borrow, Cow};
 use std::cell::RefCell;
 use std::cmp::{max, min, Ordering};
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
+
 use std::rc::Rc;
 
 #[macro_export]
@@ -356,416 +361,232 @@ impl Evaluable for EvalJoin {
 pub(crate) struct AggregateExpression {
     pub(crate) name: String,
     pub(crate) expr: Box<dyn EvalExpr>,
-    pub(crate) func: AggFunc,
+    pub(crate) func: Box<dyn AggregateFunction>,
+}
+
+impl AggregateFunction for AggregateExpression {
+    #[inline]
+    fn next_distinct(
+        &self,
+        input_value: &Value,
+        state: &mut Option<Value>,
+        seen: &mut FxHashMap<Value, ()>,
+    ) {
+        if input_value.is_present() {
+            self.func.next_distinct(input_value, state, seen);
+        }
+    }
+
+    #[inline]
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        if input_value.is_present() {
+            self.func.next_value(input_value, state);
+        }
+    }
+
+    #[inline]
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        self.func.finalize(state)
+    }
 }
 
 /// Represents an SQL aggregation function computed on a collection of input values.
-pub trait AggregateFunction {
+pub trait AggregateFunction: Debug {
+    #[inline]
+    fn next_distinct(
+        &self,
+        input_value: &Value,
+        state: &mut Option<Value>,
+        seen: &mut FxHashMap<Value, ()>,
+    ) {
+        match seen.entry(input_value.clone()) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(v) => {
+                v.insert(());
+                self.next_value(input_value, state);
+            }
+        }
+    }
     /// Provides the next value for the given `group`.
-    fn next_value(&mut self, input_value: &Value, group: &Tuple);
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>);
     /// Returns the result of the aggregation function for a given `group`.
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError>;
-}
-
-#[derive(Debug)]
-pub(crate) enum AggFunc {
-    // TODO: modeling COUNT(*)
-    Avg(Avg),
-    Count(Count),
-    Max(Max),
-    Min(Min),
-    Sum(Sum),
-    Any(Any),
-    Every(Every),
-}
-
-impl AggregateFunction for AggFunc {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        match self {
-            AggFunc::Avg(v) => v.next_value(input_value, group),
-            AggFunc::Count(v) => v.next_value(input_value, group),
-            AggFunc::Max(v) => v.next_value(input_value, group),
-            AggFunc::Min(v) => v.next_value(input_value, group),
-            AggFunc::Sum(v) => v.next_value(input_value, group),
-            AggFunc::Any(v) => v.next_value(input_value, group),
-            AggFunc::Every(v) => v.next_value(input_value, group),
-        }
-    }
-
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        match self {
-            AggFunc::Avg(v) => v.compute(group),
-            AggFunc::Count(v) => v.compute(group),
-            AggFunc::Max(v) => v.compute(group),
-            AggFunc::Min(v) => v.compute(group),
-            AggFunc::Sum(v) => v.compute(group),
-            AggFunc::Any(v) => v.compute(group),
-            AggFunc::Every(v) => v.compute(group),
-        }
-    }
-}
-
-/// Filter values based on the given condition
-#[derive(Debug, Default)]
-pub(crate) enum AggFilterFn {
-    /// Keeps only distinct values in each group
-    Distinct(AggFilterDistinct),
-    /// Keeps all values
-    #[default]
-    All,
-}
-
-impl AggFilterFn {
-    /// Returns true if and only if for the given `group`, `input_value` should be processed
-    /// by the aggregation function
-    fn filter_value(&mut self, input_value: Value, group: &Tuple) -> bool {
-        match self {
-            AggFilterFn::Distinct(d) => d.filter_value(input_value, group),
-            AggFilterFn::All => true,
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) struct AggFilterDistinct {
-    seen_vals: HashMap<Tuple, HashSet<Value>>,
-}
-
-impl AggFilterDistinct {
-    pub(crate) fn new() -> Self {
-        AggFilterDistinct {
-            seen_vals: HashMap::new(),
-        }
-    }
-}
-
-impl Default for AggFilterDistinct {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl AggFilterDistinct {
-    fn filter_value(&mut self, input_value: Value, group: &Tuple) -> bool {
-        if let Some(seen_vals_in_group) = self.seen_vals.get_mut(group) {
-            seen_vals_in_group.insert(input_value)
-        } else {
-            let mut new_seen_vals = HashSet::new();
-            new_seen_vals.insert(input_value);
-            self.seen_vals
-                .insert(group.clone(), new_seen_vals)
-                .is_none()
-        }
-    }
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError>;
 }
 
 /// Represents SQL's `AVG` aggregation function
 #[derive(Debug)]
-pub(crate) struct Avg {
-    avgs: HashMap<Tuple, (usize, Value)>,
-    aggregator: AggFilterFn,
-}
-
-impl Avg {
-    pub(crate) fn new_distinct() -> Self {
-        Avg {
-            avgs: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Avg {
-            avgs: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Avg {}
 
 impl AggregateFunction for Avg {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.avgs.get_mut(group) {
-                None => {
-                    self.avgs.insert(group.clone(), (1, input_value.clone()));
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => *state = Some(Value::from(list![Value::from(1), input_value.clone()])),
+            Some(Value::List(list)) => {
+                if let Some(count) = list.get_mut(0) {
+                    *count += &Value::from(1);
                 }
-                Some((count, sum)) => {
-                    *count += 1;
-                    *sum = &sum.clone() + input_value;
+                if let Some(sum) = list.get_mut(1) {
+                    *sum += input_value;
                 }
             }
-        }
+            _ => unreachable!(),
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        match self.avgs.get(group).unwrap_or(&(0, Null)) {
-            (0, _) => Ok(Null),
-            (c, s) => Ok(s / &Value::from(rust_decimal::Decimal::from(*c))),
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        match state {
+            None => Ok(Null),
+            Some(Value::List(list)) => {
+                let vals = list.to_vec();
+                if let [count, sum] = &vals[..] {
+                    if let Value::Integer(n) = sum {
+                        // Avg does not do integer divison; convert to decimal
+                        let sum = Value::from(rust_decimal::Decimal::from(*n));
+                        Ok(&sum / count)
+                    } else {
+                        Ok(sum / count)
+                    }
+                } else {
+                    Err(EvaluationError::IllegalState(
+                        "Bad finalize state for Avg".to_string(),
+                    ))
+                }
+            }
+            _ => unreachable!(),
         }
     }
 }
 
 /// Represents SQL's `COUNT` aggregation function
 #[derive(Debug)]
-pub(crate) struct Count {
-    counts: HashMap<Tuple, usize>,
-    aggregator: AggFilterFn,
-}
-
-impl Count {
-    pub(crate) fn new_distinct() -> Self {
-        Count {
-            counts: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Count {
-            counts: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Count {}
 
 impl AggregateFunction for Count {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.counts.get_mut(group) {
-                None => {
-                    self.counts.insert(group.clone(), 1);
-                }
-                Some(count) => {
-                    *count += 1;
-                }
-            };
-        }
+    fn next_value(&self, _: &Value, state: &mut Option<Value>) {
+        match state {
+            None => *state = Some(Value::from(1)),
+            Some(Value::Integer(i)) => {
+                *i += 1;
+            }
+            _ => unreachable!(),
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(Value::from(self.counts.get(group).unwrap_or(&0)))
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Value::from(0)))
     }
 }
 
 /// Represents SQL's `MAX` aggregation function
 #[derive(Debug)]
-pub(crate) struct Max {
-    maxes: HashMap<Tuple, Value>,
-    aggregator: AggFilterFn,
-}
-
-impl Max {
-    pub(crate) fn new_distinct() -> Self {
-        Max {
-            maxes: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Max {
-            maxes: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Max {}
 
 impl AggregateFunction for Max {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.maxes.get_mut(group) {
-                None => {
-                    self.maxes.insert(group.clone(), input_value.clone());
-                }
-                Some(m) => {
-                    *m = max(m.clone(), input_value.clone());
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => *state = Some(input_value.clone()),
+            Some(max) => {
+                if &*max < input_value {
+                    *max = input_value.clone();
                 }
             }
-        }
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(self.maxes.get(group).unwrap_or(&Null).clone())
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Null))
     }
 }
 
 /// Represents SQL's `MIN` aggregation function
 #[derive(Debug)]
-pub(crate) struct Min {
-    mins: HashMap<Tuple, Value>,
-    aggregator: AggFilterFn,
-}
-
-impl Min {
-    pub(crate) fn new_distinct() -> Self {
-        Min {
-            mins: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Min {
-            mins: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Min {}
 
 impl AggregateFunction for Min {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.mins.get_mut(group) {
-                None => {
-                    self.mins.insert(group.clone(), input_value.clone());
-                }
-                Some(m) => {
-                    *m = min(m.clone(), input_value.clone());
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => *state = Some(input_value.clone()),
+            Some(min) => {
+                if &*min > input_value {
+                    *min = input_value.clone();
                 }
             }
-        }
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(self.mins.get(group).unwrap_or(&Null).clone())
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Null))
     }
 }
 
 /// Represents SQL's `SUM` aggregation function
 #[derive(Debug)]
-pub(crate) struct Sum {
-    sums: HashMap<Tuple, Value>,
-    aggregator: AggFilterFn,
-}
-
-impl Sum {
-    pub(crate) fn new_distinct() -> Self {
-        Sum {
-            sums: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Sum {
-            sums: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Sum {}
 
 impl AggregateFunction for Sum {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.sums.get_mut(group) {
-                None => {
-                    self.sums.insert(group.clone(), input_value.clone());
-                }
-                Some(s) => {
-                    *s = &s.clone() + input_value;
-                }
-            }
-        }
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => *state = Some(input_value.clone()),
+            Some(ref mut sum) => *sum += input_value,
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(self.sums.get(group).unwrap_or(&Null).clone())
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Null))
     }
 }
 
 /// Represents SQL's `ANY`/`SOME` aggregation function
 #[derive(Debug)]
-pub(crate) struct Any {
-    anys: HashMap<Tuple, Value>,
-    aggregator: AggFilterFn,
-}
-
-impl Any {
-    pub(crate) fn new_distinct() -> Self {
-        Any {
-            anys: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Any {
-            anys: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Any {}
 
 impl AggregateFunction for Any {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.anys.get_mut(group) {
-                None => {
-                    match input_value {
-                        Boolean(_) => self.anys.insert(group.clone(), input_value.clone()),
-                        _ => self.anys.insert(group.clone(), Missing),
-                    };
-                }
-                Some(acc) => {
-                    *acc = match (acc.clone(), input_value) {
-                        (Boolean(l), Value::Boolean(r)) => Value::Boolean(l || *r),
-                        (_, _) => Missing,
-                    };
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => {
+                *state = Some(match input_value {
+                    Boolean(b) => Value::Boolean(*b),
+                    _ => Missing,
+                })
+            }
+            Some(ref mut acc) => {
+                *acc = match (&acc, input_value) {
+                    (Boolean(acc), Boolean(new)) => Boolean(*acc || *new),
+                    _ => Missing,
                 }
             }
-        }
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(self.anys.get(group).unwrap_or(&Null).clone())
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Null))
     }
 }
 
 /// Represents SQL's `EVERY` aggregation function
 #[derive(Debug)]
-pub(crate) struct Every {
-    everys: HashMap<Tuple, Value>,
-    aggregator: AggFilterFn,
-}
-
-impl Every {
-    pub(crate) fn new_distinct() -> Self {
-        Every {
-            everys: HashMap::new(),
-            aggregator: AggFilterFn::Distinct(AggFilterDistinct::new()),
-        }
-    }
-
-    pub(crate) fn new_all() -> Self {
-        Every {
-            everys: HashMap::new(),
-            aggregator: AggFilterFn::default(),
-        }
-    }
-}
+pub(crate) struct Every {}
 
 impl AggregateFunction for Every {
-    fn next_value(&mut self, input_value: &Value, group: &Tuple) {
-        if input_value.is_present() && self.aggregator.filter_value(input_value.clone(), group) {
-            match self.everys.get_mut(group) {
-                None => {
-                    match input_value {
-                        Boolean(_) => self.everys.insert(group.clone(), input_value.clone()),
-                        _ => self.everys.insert(group.clone(), Missing),
-                    };
-                }
-                Some(acc) => {
-                    *acc = match (acc.clone(), input_value) {
-                        (Boolean(l), Value::Boolean(r)) => Value::Boolean(l && *r),
-                        (_, _) => Missing,
-                    };
+    fn next_value(&self, input_value: &Value, state: &mut Option<Value>) {
+        match state {
+            None => {
+                *state = Some(match input_value {
+                    Boolean(b) => Value::Boolean(*b),
+                    _ => Missing,
+                })
+            }
+            Some(ref mut acc) => {
+                *acc = match (&acc, input_value) {
+                    (Boolean(acc), Boolean(new)) => Boolean(*acc && *new),
+                    _ => Missing,
                 }
             }
-        }
+        };
     }
 
-    fn compute(&self, group: &Tuple) -> Result<Value, EvaluationError> {
-        Ok(self.everys.get(group).unwrap_or(&Null).clone())
+    fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
+        Ok(state.unwrap_or_else(|| Null))
     }
 }
 
@@ -776,11 +597,19 @@ impl AggregateFunction for Every {
 #[derive(Debug)]
 pub(crate) struct EvalGroupBy {
     pub(crate) strategy: EvalGroupingStrategy,
-    pub(crate) exprs: HashMap<String, Box<dyn EvalExpr>>,
-    pub(crate) aggregate_exprs: Vec<AggregateExpression>,
+    pub(crate) group: Vec<Box<dyn EvalExpr>>,
+    pub(crate) aliases: Vec<String>,
+    pub(crate) aggs: Vec<AggregateExpression>,
+    pub(crate) distinct_aggs: Vec<AggregateExpression>,
     pub(crate) group_as_alias: Option<String>,
     pub(crate) input: Option<Value>,
 }
+
+type GroupKey = Vec<Value>;
+type AggState = Vec<Option<Value>>;
+type DAggState = Vec<(Option<Value>, FxHashMap<Value, ()>)>;
+#[derive(Clone)]
+struct CombinedState(AggState, DAggState, Option<Vec<Value>>);
 
 /// Represents the grouping qualifier: ALL or PARTIAL.
 #[derive(Debug)]
@@ -791,16 +620,34 @@ pub(crate) enum EvalGroupingStrategy {
 
 impl EvalGroupBy {
     #[inline]
-    fn eval_group(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> Tuple {
-        self.exprs
+    pub(crate) fn new(
+        strategy: EvalGroupingStrategy,
+        group: Vec<Box<dyn EvalExpr>>,
+        aliases: Vec<String>,
+        aggs: Vec<AggregateExpression>,
+        distinct_aggs: Vec<AggregateExpression>,
+        group_as_alias: Option<String>,
+    ) -> Self {
+        Self {
+            strategy,
+            group,
+            aliases,
+            aggs,
+            distinct_aggs,
+            group_as_alias,
+            input: None,
+        }
+    }
+
+    #[inline]
+    fn group_key(&self, bindings: &Tuple, ctx: &dyn EvalContext) -> GroupKey {
+        self.group
             .iter()
-            .map(
-                |(alias, expr)| match expr.evaluate(bindings, ctx).into_owned() {
-                    Missing => (alias.as_str(), Value::Null),
-                    val => (alias.as_str(), val),
-                },
-            )
-            .collect::<Tuple>()
+            .map(|expr| match expr.evaluate(bindings, ctx).as_ref() {
+                Missing => Value::Null,
+                val => val.clone(),
+            })
+            .collect()
     }
 }
 
@@ -817,54 +664,82 @@ impl Evaluable for EvalGroupBy {
                 Missing
             }
             EvalGroupingStrategy::GroupFull => {
-                let mut groups: HashMap<Tuple, Vec<Value>> = HashMap::new();
+                let mut grouped: FxHashMap<GroupKey, CombinedState> = FxHashMap::default();
+                let state = std::iter::repeat(None).take(self.aggs.len()).collect_vec();
+                let distinct_state = std::iter::repeat_with(|| (None, FxHashMap::default()))
+                    .take(self.distinct_aggs.len())
+                    .collect_vec();
+                let group_as = group_as_alias.as_ref().map(|_| vec![]);
+
+                let combined = CombinedState(state, distinct_state, group_as);
+
                 for v in input_value.into_iter() {
                     let v_as_tuple = v.coerce_into_tuple();
-                    let group = self.eval_group(&v_as_tuple, ctx);
+                    let group_key = self.group_key(&v_as_tuple, ctx);
+                    let CombinedState(state, distinct_state, group_as) =
+                        grouped.entry(group_key).or_insert_with(|| combined.clone());
+
                     // Compute next aggregation result for each of the aggregation expressions
-                    for aggregate_expr in self.aggregate_exprs.iter_mut() {
-                        let evaluated_val =
-                            aggregate_expr.expr.evaluate(&v_as_tuple, ctx).into_owned();
-                        aggregate_expr.func.next_value(&evaluated_val, &group);
+                    for (agg_expr, state) in self.aggs.iter().zip(state.iter_mut()) {
+                        let evaluated = agg_expr.expr.evaluate(&v_as_tuple, ctx);
+                        agg_expr.next_value(evaluated.as_ref(), state);
                     }
-                    groups
-                        .entry(group)
-                        .or_default()
-                        .push(Value::Tuple(Box::new(v_as_tuple.clone())));
+
+                    // Compute next aggregation result for each of the distinct aggregation expressions
+                    for (distinct_expr, (state, seen)) in
+                        self.distinct_aggs.iter().zip(distinct_state.iter_mut())
+                    {
+                        let evaluated = distinct_expr.expr.evaluate(&v_as_tuple, ctx);
+                        distinct_expr.next_distinct(evaluated.as_ref(), state, seen);
+                    }
+
+                    // Add tuple to `GROUP AS` if applicable
+                    if let Some(ref mut tuples) = group_as {
+                        tuples.push(Value::from(v_as_tuple));
+                    }
                 }
 
-                let bag = groups
+                let vals = grouped
                     .into_iter()
-                    .map(|(mut k, v)| {
-                        // Finalize aggregation computation and include result in output binding
-                        // tuple
-                        let mut agg_results: Vec<(&str, Value)> = vec![];
-                        for aggregate_expr in &self.aggregate_exprs {
-                            match aggregate_expr.func.compute(&k) {
-                                Ok(agg_result) => {
-                                    agg_results.push((aggregate_expr.name.as_str(), agg_result))
-                                }
-                                Err(err) => {
-                                    ctx.add_error(err);
-                                    return Missing;
-                                }
-                            }
-                        }
-                        agg_results
-                            .into_iter()
-                            .for_each(|(agg_name, agg_result)| k.insert(agg_name, agg_result));
+                    .map(|(group_key, state)| {
+                        let CombinedState(agg_state, distinct_state, group_as) = state;
+                        let group = self.aliases.iter().cloned().zip(group_key);
 
-                        match group_as_alias {
-                            None => Value::from(k),
-                            Some(alias) => {
-                                let mut tuple_with_group = k;
-                                tuple_with_group.insert(alias, Value::Bag(Box::new(Bag::from(v))));
-                                Value::from(tuple_with_group)
-                            }
+                        // finalize all aggregates
+                        let aggs_with_state = self.aggs.iter().zip(agg_state);
+                        let daggs_with_state = self
+                            .distinct_aggs
+                            .iter()
+                            .zip(distinct_state.into_iter().map(|(state, _)| state));
+                        let agg_data = aggs_with_state.chain(daggs_with_state).map(
+                            |(aggregate_expr, state)| {
+                                let val = match aggregate_expr.finalize(state) {
+                                    Ok(agg_result) => agg_result,
+                                    Err(err) => {
+                                        ctx.add_error(err);
+                                        Missing
+                                    }
+                                };
+
+                                (aggregate_expr.name.to_string(), val)
+                            },
+                        );
+
+                        let mut tuple = Tuple::from_iter(group.chain(agg_data));
+
+                        // insert `GROUP AS` if applicable
+                        if let Some(tuples) = group_as {
+                            tuple.insert(
+                                group_as_alias.as_ref().unwrap(),
+                                Value::from(Bag::from(tuples)),
+                            );
                         }
+
+                        Value::from(tuple)
                     })
-                    .collect::<Bag>();
-                Value::from(bag)
+                    .collect_vec();
+
+                Value::from(Bag::from(vals))
             }
         }
     }

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -44,7 +44,7 @@ impl Bag {
     }
 
     #[inline]
-    pub(crate) fn values(self) -> Vec<Value> {
+    pub fn to_vec(self) -> Vec<Value> {
         self.0
     }
 }
@@ -76,7 +76,7 @@ impl From<HashSet<Value>> for Bag {
 impl From<List> for Bag {
     #[inline]
     fn from(list: List) -> Self {
-        Bag(list.values())
+        Bag(list.to_vec())
     }
 }
 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -56,7 +56,7 @@ impl List {
     }
 
     #[inline]
-    pub(crate) fn values(self) -> Vec<Value> {
+    pub fn to_vec(self) -> Vec<Value> {
         self.0
     }
 }
@@ -81,7 +81,7 @@ impl From<Vec<Value>> for List {
 impl From<Bag> for List {
     #[inline]
     fn from(bag: Bag) -> Self {
-        List(bag.values())
+        List(bag.to_vec())
     }
 }
 

--- a/partiql/benches/bench_agg.rs
+++ b/partiql/benches/bench_agg.rs
@@ -56,7 +56,7 @@ pub(crate) fn evaluate(mut eval: EvalPlan, bindings: MapBindings<Value>) -> Valu
     }
 }
 
-fn create_query(aggs: &Vec<(&'static str, bool)>, group: bool, group_as: bool) -> (String, String) {
+fn create_query(aggs: &[(&'static str, bool)], group: bool, group_as: bool) -> (String, String) {
     let agg_fns = aggs
         .iter()
         .map(|(name, distinct)| {
@@ -111,7 +111,7 @@ fn create_tests() -> Vec<(String, String)> {
 
     let simple = all_aggs
         .clone()
-        .map(|(a, d)| create_query(&vec![(a, *d)], false, false));
+        .map(|(&a, d)| create_query(vec![(a, *d)].as_slice(), false, false));
 
     let aggs_all = aggs
         .into_iter()

--- a/partiql/benches/bench_agg.rs
+++ b/partiql/benches/bench_agg.rs
@@ -14,7 +14,7 @@ use partiql_parser::{Parser, ParserResult};
 use partiql_value::{tuple, Bag, Value};
 
 fn numbers() -> impl Iterator<Item = Value> {
-    (0..1000i64).into_iter().map(|n| Value::from(n))
+    (0..1000i64).map(Value::from)
 }
 
 fn data() -> MapBindings<Value> {
@@ -26,7 +26,6 @@ fn data() -> MapBindings<Value> {
     .into_iter()
     .cycle();
     let numbers: Bag = numbers()
-        .into_iter()
         .map(|n| tuple![("shard", shards.next().unwrap()), ("n", n)])
         .collect();
     let data = tuple![("numbers", numbers)];
@@ -115,12 +114,10 @@ fn create_tests() -> Vec<(String, String)> {
         .map(|(a, d)| create_query(&vec![(a, *d)], false, false));
 
     let aggs_all = aggs
-        .clone()
         .into_iter()
         .cartesian_product([false].into_iter())
         .collect_vec();
     let aggs_distinct = aggs
-        .clone()
         .into_iter()
         .cartesian_product([true].into_iter())
         .collect_vec();


### PR DESCRIPTION
## Description

This rewrite removes duplicate effort by moving grouping state management in the EvalGroupBy rather than each individual aggregation function.

The group data is stored hashed by the values of the grouping expression (not yet bound to into a tuple, as the names don't add any discrimination to the grouping). 

The value stored at each group is:
- `state` for 'normal' aggregates
- `distinct_state` for distinct aggregates
- an extra `group_as` tuple if a `GROUP AS` clause is included.

Then, for each 'row' state is accumulated for aggregations, distinct aggregations, and group-as as appropriate.

After all 'rows' have been dealt with, then each group's aggregations, distinct aggregations, and group-as are finalized and every thing is wrapped up into a binding tuple.


## Results

- ~2x speedup on the simple aggregation benchmarks 
- ~2.5-3.3x speedup on distinct aggregation with  group by /group as

```terminal
Benchmarking arith_agg-avg: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, enable flat sampling, or reduce sample count to 50.
arith_agg-avg           time:   [1.3847 ms 1.3920 ms 1.4008 ms]
                        change: [-50.832% -50.476% -50.124%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking arith_agg-avg_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, enable flat sampling, or reduce sample count to 50.
arith_agg-avg_distinct  time:   [1.4143 ms 1.4192 ms 1.4244 ms]
                        change: [-55.424% -54.894% -54.316%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

Benchmarking arith_agg-count: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.9s, enable flat sampling, or reduce sample count to 50.
arith_agg-count         time:   [1.3637 ms 1.3719 ms 1.3812 ms]
                        change: [-51.790% -51.405% -51.030%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

Benchmarking arith_agg-count_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
arith_agg-count_distinct
                        time:   [1.3910 ms 1.3948 ms 1.3988 ms]
                        change: [-60.995% -60.202% -59.403%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking arith_agg-min: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.9s, enable flat sampling, or reduce sample count to 50.
arith_agg-min           time:   [1.3633 ms 1.3687 ms 1.3746 ms]
                        change: [-51.644% -51.431% -51.164%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking arith_agg-min_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
arith_agg-min_distinct  time:   [1.4245 ms 1.4347 ms 1.4452 ms]
                        change: [-55.721% -55.317% -54.865%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Benchmarking arith_agg-max: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.0s, enable flat sampling, or reduce sample count to 50.
arith_agg-max           time:   [1.3775 ms 1.3822 ms 1.3872 ms]
                        change: [-51.927% -51.361% -50.873%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Benchmarking arith_agg-max_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s, enable flat sampling, or reduce sample count to 50.
arith_agg-max_distinct  time:   [1.4104 ms 1.4173 ms 1.4257 ms]
                        change: [-55.676% -55.187% -54.710%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

Benchmarking arith_agg-sum: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.9s, enable flat sampling, or reduce sample count to 60.
arith_agg-sum           time:   [1.3610 ms 1.3668 ms 1.3730 ms]
                        change: [-52.164% -51.828% -51.396%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Benchmarking arith_agg-sum_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
arith_agg-sum_distinct  time:   [1.4147 ms 1.4234 ms 1.4355 ms]
                        change: [-57.267% -56.182% -55.154%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking arith_agg-avg-count-min-max-sum: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, enable flat sampling, or reduce sample count to 50.
arith_agg-avg-count-min-max-sum
                        time:   [1.5858 ms 1.5956 ms 1.6061 ms]
                        change: [-62.152% -61.767% -61.391%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

arith_agg-avg-count-min-max-sum-group_by
                        time:   [2.0591 ms 2.0654 ms 2.0721 ms]
                        change: [-60.691% -60.528% -60.364%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild

arith_agg-avg-count-min-max-sum-group_by-group_as
                        time:   [2.9250 ms 2.9448 ms 2.9687 ms]
                        change: [-51.769% -51.256% -50.695%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

Benchmarking arith_agg-avg_distinct-count_distinct-min_distinct-max_distinct-sum_distinct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.9s, enable flat sampling, or reduce sample count to 50.
arith_agg-avg_distinct-count_distinct-min_distinct-max_distinct-sum_distinct
                        time:   [1.7651 ms 1.7696 ms 1.7746 ms]
                        change: [-69.516% -69.370% -69.197%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

arith_agg-avg_distinct-count_distinct-min_distinct-max_distinct-sum_distinct-group_by
                        time:   [2.2809 ms 2.2989 ms 2.3194 ms]
                        change: [-68.972% -68.685% -68.400%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

arith_agg-avg_distinct-count_distinct-min_distinct-max_distinct-sum_distinct-group_by-group_as
                        time:   [3.1840 ms 3.2369 ms 3.2969 ms]
                        change: [-61.184% -60.483% -59.792%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  9 (9.00%) high mild
  7 (7.00%) high severe
```