### PR TITLE
Write custom `Debug` for some parts of evaluator for better readability.

### DIFF
--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -200,7 +200,6 @@ impl ArgChecker for NullArgChecker {
 /// Bridges between [`EvalExpr`] and [`ExecuteEvalExpr`]
 ///
 ///
-#[derive(Debug)]
 pub(crate) struct ArgCheckEvalExpr<
     const STRICT: bool,
     const N: usize,
@@ -214,6 +213,23 @@ pub(crate) struct ArgCheckEvalExpr<
     /// the expression
     pub(crate) expr: E,
     pub(crate) arg_check: PhantomData<ArgC>,
+}
+
+impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker> Debug
+    for ArgCheckEvalExpr<STRICT, N, E, ArgC>
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.expr.fmt(f)?;
+        write!(f, "(")?;
+        let mut sep = "";
+        for arg in &self.args {
+            write!(f, "{sep}")?;
+            arg.fmt(f)?;
+            sep = ", ";
+        }
+        write!(f, ")")?;
+        Ok(())
+    }
 }
 
 impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker>
@@ -332,9 +348,7 @@ where
     E: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EvalExprWrapper")
-            .field("ident", &self.ident)
-            .finish()
+        self.ident.fmt(f)
     }
 }
 

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 use std::fmt::Debug;
 
 use petgraph::algo::toposort;
-use petgraph::dot::{Config, Dot};
+use petgraph::dot::Dot;
 use petgraph::prelude::StableGraph;
 use petgraph::{Directed, Outgoing};
 
@@ -124,7 +124,7 @@ impl EvalPlan {
     }
 
     pub fn to_dot_graph(&self) -> String {
-        format!("{:?}", Dot::with_config(&self.0, &[Config::EdgeNoLabel]))
+        format!("{:?}", Dot::with_config(&self.0, &[]))
     }
 }
 


### PR DESCRIPTION
Rendered Dot Graph Before:
![before](https://github.com/partiql/partiql-lang-rust/assets/36067/ccef8500-d59f-47db-82c3-b9ef8bbf0404)

Rendered Dot Graph After:
![after](https://github.com/partiql/partiql-lang-rust/assets/36067/1bd5e59f-b36e-4a60-af96-15bcb177d9c3)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
