### PR TITLE
Add Catalog to resolve_varref in lowering

### DIFF
--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -43,3 +43,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 partiql-eval = { path = "../partiql-eval", version = "0.5.*" }
+partiql-types = { path = "../partiql-types", version = "0.5.*" }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -361,6 +361,18 @@ impl<'a> AstToLogical<'a> {
                                                     lookups.push(expr);
                                                 }
                                                 continue;
+                                            } else if let Some(_type_entry) = self
+                                                .catalog
+                                                .resolve_type(name_ref.sym.value.as_ref())
+                                            {
+                                                let expr = ValueExpr::VarRef(
+                                                    var_binding.clone(),
+                                                    VarRefType::Global,
+                                                );
+                                                if !lookups.contains(&expr) {
+                                                    lookups.push(expr);
+                                                }
+                                                continue;
                                             } else {
                                                 let path = logical::ValueExpr::Path(
                                                     Box::new(ValueExpr::VarRef(

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1943,7 +1943,10 @@ fn parse_embedded_ion_str(contents: &str) -> Result<Value, AstTransformError> {
 mod tests {
     use super::*;
     use crate::LogicalPlanner;
-    use partiql_catalog::PartiqlCatalog;
+    use partiql_catalog::{PartiqlCatalog, TypeEnvEntry};
+    use partiql_logical::BindingsOp::Project;
+    use partiql_logical::ValueExpr;
+    use partiql_types::any;
 
     #[test]
     fn test_plan_non_existent_fns() {
@@ -1991,5 +1994,67 @@ mod tests {
                 "mod".to_string()
             ))
         );
+    }
+
+    #[test]
+    fn test_plan_type_entry_in_catalog() {
+        // Expected Logical Plan
+        let mut expected_logical = LogicalPlan::new();
+        let my_id = ValueExpr::Path(
+            Box::new(ValueExpr::DynamicLookup(Box::new(vec![
+                ValueExpr::VarRef(
+                    BindingsName::CaseInsensitive("c".to_string().into()),
+                    VarRefType::Local,
+                ),
+                ValueExpr::VarRef(
+                    BindingsName::CaseInsensitive("c".to_string().into()),
+                    VarRefType::Global,
+                ),
+            ]))),
+            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                "id".to_string().into(),
+            ))],
+        );
+
+        let my_name = ValueExpr::Path(
+            Box::new(ValueExpr::DynamicLookup(Box::new(vec![ValueExpr::VarRef(
+                BindingsName::CaseInsensitive("customers".to_string().into()),
+                VarRefType::Global,
+            )]))),
+            vec![PathComponent::Key(BindingsName::CaseInsensitive(
+                "name".to_string().into(),
+            ))],
+        );
+
+        let project = expected_logical.add_operator(Project(logical::Project {
+            exprs: Vec::from([
+                ("my_id".to_string(), my_id),
+                ("my_name".to_string(), my_name),
+            ]),
+        }));
+
+        let scan = expected_logical.add_operator(BindingsOp::Scan(logical::Scan {
+            expr: ValueExpr::DynamicLookup(Box::new(vec![ValueExpr::VarRef(
+                BindingsName::CaseInsensitive("customers".to_string().into()),
+                VarRefType::Global,
+            )])),
+            as_key: "c".to_string(),
+            at_key: None,
+        }));
+        let sink = expected_logical.add_operator(BindingsOp::Sink);
+        expected_logical.add_flow_with_branch_num(scan, project, 0);
+        expected_logical.add_flow_with_branch_num(project, sink, 0);
+
+        let mut catalog = PartiqlCatalog::default();
+        let _oid = catalog.add_type_entry(TypeEnvEntry::new("customers", &[], any!()));
+        let statement = "SELECT c.id AS my_id, customers.name AS my_name FROM customers AS c";
+        let parsed = partiql_parser::Parser::default()
+            .parse(statement)
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let logical = planner.lower(&parsed).expect("Expect successful lowering");
+        assert_eq!(expected_logical, logical);
+
+        println!("logical: {:?}", &logical);
     }
 }


### PR DESCRIPTION
*Description of changes:*

Currently during lowering, when we want to resolve a variable name we do the following:

1. If there are any `KeySchema`s  in `KeyRegistry` for the current `id` in the stack (lookup from bottom of the stack to the top)
2. Retrieve the `KeySchema`.
3. Lookup the `scopes` in `KeyRegistry` and see which `NodeId` this `Node` is within the scope of.
4. Get the `KeySchema` of the found `Node`.
5. If the variable name is equal to the `KeySchema`'s produce OR lowered case variable name is equal to `produce`'s lowered case and variable name is case-insensitive, then create a new `VarRef` with `Local` lookup and push it to the lookups (for `DynamicLookup`)
6. else create a `Path` with the `produce` name as `VarRef` and variable name as the key component.


This PR adds a step between 5 and 6 to check to see if there is a type for the variable in the global and if so, adds a `VarRef` resolve global to the lookups.

### Example
**Query**: `SELECT c.id, customers.name FROM customers AS c`;
**Global Typing Environment (in Catalog)**:  <<`customers`: any>>

**KeyRegistry**:

``` rust
{
    in_scope: {
        NodeId(
            12, // From
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
        NodeId(
            13, // Select
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
        NodeId(
            14, // QuerySet
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
        NodeId(
            15, // Query
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
        NodeId(
            16, // TopLevel
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
    },
    schema: {
        NodeId(
            11,
        ): KeySchema {
            consume: {
                NameRef {
                    sym: SymbolPrimitive {
                        value: "customers",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Global,
                        Local,
                    ],
                },
            },
            produce: {
                Known(
                    SymbolPrimitive {
                        value: "c",
                        case: CaseInsensitive,
                    },
                ),
            },
        },
        NodeId(
            15,
        ): KeySchema {
            consume: {
                NameRef {
                    sym: SymbolPrimitive {
                        value: "c",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "id",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "customers",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "name",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
            },
            produce: {
                Known(
                    SymbolPrimitive {
                        value: "my_id",
                        case: CaseInsensitive,
                    },
                ),
                Known(
                    SymbolPrimitive {
                        value: "my_name",
                        case: CaseInsensitive,
                    },
                ),
            },
        },
    },
    aliases: {
        NodeId(
            4,
        ): Known(
            SymbolPrimitive {
                value: "my_id",
                case: CaseInsensitive,
            },
        ),
        NodeId(
            8,
        ): Known(
            SymbolPrimitive {
                value: "my_name",
                case: CaseInsensitive,
            },
        ),
        NodeId(
            11,
        ): Known(
            SymbolPrimitive {
                value: "c",
                case: CaseInsensitive,
            },
        ),
    },
}
```


For resolving `customers` in the projection, we find `NodeId` `15` (`Query` in the `AST`) and get the following `KeySchema` from the `KeyRegistry`:

```rust
KeySchema {
            consume: {
                NameRef {
                    sym: SymbolPrimitive {
                        value: "c",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "id",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "customers",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
                NameRef {
                    sym: SymbolPrimitive {
                        value: "name",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Local,
                        Global,
                    ],
                },
            },
            produce: {
                Known(
                    SymbolPrimitive {
                        value: "my_id",
                        case: CaseInsensitive,
                    },
                ),
                Known(
                    SymbolPrimitive {
                        value: "my_name",
                        case: CaseInsensitive,
                    },
                ),
            },
        },

```

We retrieve the following `scope` which says `15` is in the scope of `11`:

```rust
        NodeId(
            15, // Query
        ): [
            NodeId(
                11, // FromLet
            ),
        ],
```

We get the following `KeySchema` for `11`:

```rust
KeySchema {
            consume: {
                NameRef {
                    sym: SymbolPrimitive {
                        value: "customers",
                        case: CaseInsensitive,
                    },
                    lookup: [
                        Global,
                        Local,
                    ],
                },
            },
            produce: {
                Known(
                    SymbolPrimitive {
                        value: "c",
                        case: CaseInsensitive,
                    },
                ),
            },
        }
```

We check the `produce` and it is unequal to `customers`. We then check the global catalog and we find an entry for `customers`, hence we add a `VarRef` with a `Global` lookup to the look-ups.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
