### PR TITLE
Switch `.gitmodules` to use `https`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "partiql-conformance-tests/partiql-tests"]
 	path = partiql-conformance-tests/partiql-tests
-	url = git@github.com:partiql/partiql-tests.git
+	url = https://github.com/partiql/partiql-tests.git


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I would like to be able to use PartiQL crates directly from git. When I tried to do the following in my `Cargo.toml`

```toml
[dependencies]
partiql-parser = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-catalog = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-source-map = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-ast = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-logical-planner = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-logical = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-value = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
partiql-eval = { git = "https://github.com/partiql/partiql-lang-rust.git", rev = "fbaac0fe03"}
```

`cargo update` gives the following error.

```sh
$ cargo update
    Updating crates.io index
    Updating git repository `https://github.com/partiql/partiql-lang-rust.git`
error: failed to get `partiql-ast` as a dependency of package `fdb-rl v0.1.0 (/home/rajiv/zfs/foundation-db/dev-env/fdb-rl/fdb-rl)`

Caused by:
  failed to load source for dependency `partiql-ast`

Caused by:
  Unable to update https://github.com/partiql/partiql-lang-rust.git?rev=fbaac0fe03

Caused by:
  failed to update submodule `partiql-conformance-tests/partiql-tests`

Caused by:
  failed to parse url for submodule `partiql-conformance-tests/partiql-tests`: `git@github.com:partiql/partiql-tests.git`

Caused by:
  relative URL without a base
```

By switching the git protocol to use `https` this error can be resolved. [Here](https://github.com/rajivr/fdb-rl-wip/blob/9422d4ed9687893160891a2440f09411c0fff231/fdb-rl/Cargo.toml#L24-L31) is a working version using a repository where this commit is available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
