### PR TITLE
Fix clippy warnings/errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ to be the crate that exports all the relevant `partiql-*` sub-crate functionalit
 to make applications needing only some sub-component of the PartiQL implementation possible (e.g. an application
 that only requires the PartiQL parser can depend on `partiql-parser` directly).
 
+
 ## Development
 This project uses a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to pull in 
 [partiql-tests](https://github.com/partiql/partiql-tests). The easiest way to pull everything in is to clone the 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ to be the crate that exports all the relevant `partiql-*` sub-crate functionalit
 to make applications needing only some sub-component of the PartiQL implementation possible (e.g. an application
 that only requires the PartiQL parser can depend on `partiql-parser` directly).
 
-
 ## Development
 This project uses a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to pull in 
 [partiql-tests](https://github.com/partiql/partiql-tests). The easiest way to pull everything in is to clone the 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -183,22 +183,7 @@ impl PartialEq for List {
 
 impl PartialOrd for List {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let mut l = self.0.iter();
-        let mut r = other.0.iter();
-
-        loop {
-            match (l.next(), r.next()) {
-                (None, None) => return Some(Ordering::Equal),
-                (Some(_), None) => return Some(Ordering::Greater),
-                (None, Some(_)) => return Some(Ordering::Less),
-                (Some(lv), Some(rv)) => match lv.partial_cmp(rv) {
-                    None => return None,
-                    Some(Ordering::Less) => return Some(Ordering::Less),
-                    Some(Ordering::Greater) => return Some(Ordering::Greater),
-                    Some(Ordering::Equal) => continue,
-                },
-            }
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/partiql/benches/bench_agg.rs
+++ b/partiql/benches/bench_agg.rs
@@ -115,11 +115,11 @@ fn create_tests() -> Vec<(String, String)> {
 
     let aggs_all = aggs
         .into_iter()
-        .cartesian_product([false].into_iter())
+        .cartesian_product([false])
         .collect_vec();
     let aggs_distinct = aggs
         .into_iter()
-        .cartesian_product([true].into_iter())
+        .cartesian_product([true])
         .collect_vec();
 
     let full_aggs_all = groups

--- a/partiql/benches/bench_agg.rs
+++ b/partiql/benches/bench_agg.rs
@@ -113,14 +113,8 @@ fn create_tests() -> Vec<(String, String)> {
         .clone()
         .map(|(&a, d)| create_query(vec![(a, *d)].as_slice(), false, false));
 
-    let aggs_all = aggs
-        .into_iter()
-        .cartesian_product([false])
-        .collect_vec();
-    let aggs_distinct = aggs
-        .into_iter()
-        .cartesian_product([true])
-        .collect_vec();
+    let aggs_all = aggs.into_iter().cartesian_product([false]).collect_vec();
+    let aggs_distinct = aggs.into_iter().cartesian_product([true]).collect_vec();
 
     let full_aggs_all = groups
         .clone()


### PR DESCRIPTION
Seems like GH Actions CI has been failing since a recent clippy change turned a warning into an error. PR also fixes a different clippy warning.

This should fix the GitHub Actions failure seen in https://github.com/partiql/partiql-lang-rust/pull/435.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
