### PR TITLE
partiql-logical: add method to visualize logical plan

### DIFF
--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 
 [dependencies]
 partiql-value = { path = "../partiql-value", version = "0.5.*" }
+petgraph = "0.6.*"
 ordered-float = "3.*"
 itertools = "0.10.*"
 unicase = "2.6"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a simple method to create a dot graph of the logical plan. It is modeled after a similar method in `partiql_eval::eval::EvalPlan` (physical plan).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
