### PR TITLE
partiql-value: single quote tuple attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Adds quotes to the attributes of PartiQL tuple's debug output so it can be read and transformed using Kotlin `partiql-cli`
 
 ### Added
 - Add `partiql-extension-visualize` for visualizing AST and logical plan

--- a/partiql-value/src/tuple.rs
+++ b/partiql-value/src/tuple.rs
@@ -238,9 +238,9 @@ impl Debug for Tuple {
         let mut iter = self.pairs().peekable();
         while let Some((k, v)) = iter.next() {
             if iter.peek().is_some() {
-                write!(f, " {k}: {v:?},")?;
+                write!(f, " '{k}': {v:?},")?;
             } else {
-                write!(f, " {k}: {v:?} ")?;
+                write!(f, " '{k}': {v:?} ")?;
             }
         }
         write!(f, "}}")


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

This PR adds quotes to the attributes of a tuple to make the output compatible with Kotlin's `partiql-cli`.

Since some of the code is now ready, please allow me to also share with you our first use-case for PartiQL Rust.

In our case, our storage system would be FoundationDB (FDB). You can think of FDB as a distributed B-tree, similar to DynamoDB but with strict [ACID](https://apple.github.io/foundationdb/developer-guide.html#transactions-in-foundationdb) semantics. Similar to how DynamoDB provides attribute types, in FDB we have something called [Tuple layer](https://apple.github.io/foundationdb/data-modeling.html#data-modeling-tuples) (Note: FDB Tuple is semantically closer to PartiQL Array, and not a  PartiQL Tuple) .

The Tuple Layer is still considered to be a lower level primitive. FDB users use Tuple layer to build higher level abstractions and also use other serialization formats such as [protobuf](https://foundationdb.github.io/fdb-record-layer/) and [avro](https://www.youtube.com/watch?v=KkeyjFMmIf8&t=622s).

PartiQL tenet of format independence and data store independence has been really helpful for us. In our case, we have defined a stricter subset of [`proto3`](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl/src/protobuf/well_formed_message_descriptor.rs#L455-L624) that is compatible with SQL and PartiQL and also supports [schema evolution](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl/src/protobuf/well_formed_message_descriptor.rs#L72-L85).

Consider the following protobuf [message](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl-proto/proto-test/fdb_rl_test/protobuf/well_formed_dynamic_message/v1/proto_3.proto#L98-L101) from one of our tests.

```proto
message HelloWorldString {
  optional string hello = 1;
  optional string world = 2;
}
```

You can think of this as a representing a domain specific record/entity/item definition.

In Rust we can create an [instance](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl/src/protobuf/well_formed_dynamic_message.rs#L2243-L2246) by doing the following.

```rust
let hello_world_string = HelloWorldString {
    hello: Some("hello".to_string()),
    world: None,
};
```

By using protobuf reflection, any value of protobuf message (that conforms to our stricter `proto3` subset) can be canonicalized and [converted](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl/src/protobuf/well_formed_dynamic_message.rs#L574-L584) into a PartiQL value.

The above instance would be [converted](https://github.com/rajivr/fdb-rl-wip/blob/b275f2825990ead84c66ba3a377b06860458ea54/fdb-rl/src/protobuf/well_formed_dynamic_message.rs#L2258-L2273) into the following PartiQL value.

```rust
tuple![
    ("fdb_rl_type", "message_HelloWorldString"),
    (
        "fdb_rl_value",
        tuple![
            (
                "hello",
                tuple![("fdb_rl_type", "string"), ("fdb_rl_value", "hello"),]
            ),
            (
                "world",
                tuple![("fdb_rl_type", "string"), ("fdb_rl_value", Value::Null),]
            ),
        ]
    ),
]
```  

Something that you will notice is that we are preserving protobuf type information within the PartiQL value. This is to allow for any type specific transformations in PartiQL SQL or UDF.

We can now generate the "debug" output of this instance to understand the shape of our data. This PR basically makes this "debug" output compatible with PartiQL Kotlin CLI.

```
{ 'fdb_rl_type': 'message_HelloWorldString', 'fdb_rl_value': { 
'hello':  { 'fdb_rl_type': 'string', 'fdb_rl_value': 'hello' }, 
'world': { 'fdb_rl_type': 'string', 'fdb_rl_value': NULL } } }
```

We can take this information and build a `.env` file.

```
{
'record': { 'fdb_rl_type': 'message_HelloWorldString', 'fdb_rl_value': { 
  'hello': { 'fdb_rl_type': 'string', 'fdb_rl_value': 'hello' }, 
  'world': { 'fdb_rl_type': 'string', 'fdb_rl_value': NULL } } }
}
```

Then using Kotlin CLI, we can write the appropriate Partiql SQL to do any data transformation.

For example, we can extract the primary key by doing the following.

```sh
$ ./bin/partiql --typing-mode=PERMISSIVE --environment ../fdb_rl.env                           
Welcome to the PartiQL shell!
Typing mode: PERMISSIVE
Using version: 0.14.1-ba19d1e9
PartiQL> SELECT VALUE [ { 'fdb_tuple_string': r.fdb_rl_value.hello.fdb_rl_value } ] 
   | FROM record AS r                                                                        
   | 
===' 
<<
  [
    {
      'fdb_tuple_string': 'hello'
    }
  ]
>>
--- 
OK!
```

If we want to generate an entry for a compound/composite index, we can apply the following query.

```sh
PartiQL> SELECT VALUE [ 
   | { 'fdb_tuple_maybe_string': r.fdb_rl_value.world.fdb_rl_value}, 
   | { 'fdb_tuple_string': r.fdb_rl_value.hello.fdb_rl_value } 
   | ] FROM record AS r
   | 
===' 
<<
  [
    {
      'fdb_tuple_maybe_string': NULL
    },
    {
      'fdb_tuple_string': 'hello'
    }
  ]
>>
--- 
OK!
```

The PartiQL generated array value can then be converted back to FDB Tuple to build the primary key or the secondary index. The generated array value also has FDB Tuple Schema [information](https://rajivr.github.io/fdb-rl-wip/fdb/tuple/enum.TupleSchemaElement.html). This provides another layer of safety and allows us to ensure that only correctly typed entries are sent to the storage layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
