### PR TITLE
Allow ORDER BY to 'see' projection names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `partiql-extension-visualize` for visualizing AST and logical plan
 
 ### Fixed
+- Fixed `ORDER BY`'s ability to see into projection aliases
 
 ## [0.6.0] - 2023-10-31
 ### Changed

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -1,6 +1,6 @@
 use crate::env::Bindings;
 
-pub use core::borrow::{Borrow, BorrowMut};
+pub use core::borrow::Borrow;
 
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -32,8 +32,11 @@ partiql-logical = { path = "../partiql-logical" }
 partiql-logical-planner = { path = "../partiql-logical-planner" }
 partiql-eval = { path = "../partiql-eval" }
 
-itertools = "0.10"
-criterion = "0.4"
+
+thiserror = "1.0"
+
+itertools = "0.12"
+criterion = "0.5"
 rand = "0.8"
 
 [[bench]]

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -25,6 +25,7 @@ bench = false
 [dev-dependencies]
 partiql-parser = { path = "../partiql-parser" }
 partiql-ast = { path = "../partiql-ast" }
+partiql-ast-passes = { path = "../partiql-ast-passes" }
 partiql-catalog = { path = "../partiql-catalog"}
 partiql-value = { path = "../partiql-value" }
 partiql-logical = { path = "../partiql-logical" }

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -1,5 +1,112 @@
 #[cfg(test)]
 mod tests {
+    use partiql_ast_passes::error::AstTransformationError;
+    use partiql_catalog::{Catalog, PartiqlCatalog};
+    use partiql_eval as eval;
+    use partiql_eval::env::basic::MapBindings;
+    use partiql_eval::error::{EvalErr, PlanErr};
+    use partiql_eval::eval::{EvalPlan, EvalResult, Evaluated};
+    use partiql_eval::plan::EvaluationMode;
+    use partiql_logical as logical;
+    use partiql_parser::{Parsed, ParserError, ParserResult};
+    use partiql_value::Value;
+    use thiserror::Error;
+
+    #[derive(Error, Debug)]
+    enum TestError<'a> {
+        #[error("Parse error: {0:?}")]
+        Parse(ParserError<'a>),
+        #[error("Lower error: {0:?}")]
+        Lower(AstTransformationError),
+        #[error("Plan error: {0:?}")]
+        Plan(PlanErr),
+        #[error("Evaluation error: {0:?}")]
+        Eval(EvalErr),
+    }
+
+    impl<'a> From<ParserError<'a>> for TestError<'a> {
+        fn from(err: ParserError<'a>) -> Self {
+            TestError::Parse(err)
+        }
+    }
+
+    impl From<AstTransformationError> for TestError<'_> {
+        fn from(err: AstTransformationError) -> Self {
+            TestError::Lower(err)
+        }
+    }
+
+    impl From<PlanErr> for TestError<'_> {
+        fn from(err: PlanErr) -> Self {
+            TestError::Plan(err)
+        }
+    }
+
+    impl From<EvalErr> for TestError<'_> {
+        fn from(err: EvalErr) -> Self {
+            TestError::Eval(err)
+        }
+    }
+
+    #[track_caller]
+    #[inline]
+    fn parse(statement: &str) -> ParserResult {
+        partiql_parser::Parser::default().parse(statement)
+    }
+
+    #[track_caller]
+    #[inline]
+    fn lower(
+        catalog: &dyn Catalog,
+        parsed: &Parsed,
+    ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
+        let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
+        planner.lower(parsed)
+    }
+
+    #[track_caller]
+    #[inline]
+    fn compile(
+        mode: EvaluationMode,
+        catalog: &dyn Catalog,
+        logical: logical::LogicalPlan<logical::BindingsOp>,
+    ) -> Result<EvalPlan, PlanErr> {
+        let mut planner = eval::plan::EvaluatorPlanner::new(mode, catalog);
+        planner.compile(&logical)
+    }
+
+    #[track_caller]
+    #[inline]
+    fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
+        plan.execute_mut(bindings)
+    }
+
+    #[track_caller]
+    #[inline]
+    fn eval(statement: &str, mode: EvaluationMode) -> Result<Evaluated, TestError<'_>> {
+        let catalog = PartiqlCatalog::default();
+
+        let parsed = parse(statement)?;
+        let lowered = lower(&catalog, &parsed)?;
+        let bindings = Default::default();
+        let plan = compile(mode, &catalog, lowered)?;
+        Ok(evaluate(plan, bindings)?)
+    }
+
     #[test]
-    fn todo() {}
+    fn order_by_count() {
+        let query = "select foo, count(1) as n from
+            <<
+            { 'foo': 'foo' },
+        { 'foo': 'bar' },
+        { 'foo': 'qux' },
+        { 'foo': 'bar' },
+        { 'foo': 'baz' },
+        { 'foo': 'bar' },
+        { 'foo': 'baz' }
+        >>  group by foo order by n desc";
+
+        let res = eval(query, EvaluationMode::Permissive);
+        assert!(res.is_ok());
+    }
 }


### PR DESCRIPTION
In certain cases (e.g., when `ORDER`ing by aggregates) `ORDER BY` couldn't access the fields created by projection.

For the command:
```
cargo run --release --all-features eval -f table "select foo, count(1) as n from
 <<
 { 'foo': 'foo' },
 { 'foo': 'bar' },
 { 'foo': 'qux' },
 { 'foo': 'bar' },
 { 'foo': 'baz' },
 { 'foo': 'bar' },
 { 'foo': 'baz' }
 >>  as data group by foo order by n asc"
 ```

Before:
```
+-----+---+
| foo | n |
+=========+
| bar | 3 |
|-----+---|
| qux | 1 |
|-----+---|
| foo | 1 |
|-----+---|
| baz | 2 |
+-----+---+

```

After:
```
+-----+---+
| foo | n |
+=========+
| qux | 1 |
|-----+---|
| foo | 1 |
|-----+---|
| baz | 2 |
|-----+---|
| bar | 3 |
+-----+---+
```

Fixes https://github.com/partiql/partiql-rust-cli/issues/25

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
