### PR TITLE
Add session context to evaluation

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-09
+          toolchain: nightly-2023-06-09
       - uses: actions/cache@v3
         id: restore-build
         with:
@@ -132,7 +132,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-03-09
+          toolchain: nightly-2023-06-09
       - uses: actions/cache@v3
         id: restore-build-and-conformance
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Adds quotes to the attributes of PartiQL tuple's debug output so it can be read and transformed using Kotlin `partiql-cli`
-- Changes the interface to `EvalPlan` to accept an `EvalContext`
+- [breaking] Changes the interface to `EvalPlan` to accept an `EvalContext`
 
 ### Added
 - Add `partiql-extension-visualize` for visualizing AST and logical plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Adds quotes to the attributes of PartiQL tuple's debug output so it can be read and transformed using Kotlin `partiql-cli`
+- Changes the interface to `EvalPlan` to accept an `EvalContext`
 
 ### Added
 - Add `partiql-extension-visualize` for visualizing AST and logical plan
+- Add a `SessionContext` containing both a system-level and a user-level context object usable by expression evaluation 
 
 ### Fixed
 - Fixed `ORDER BY`'s ability to see into projection aliases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 version = "0.6.0"
 edition = "2021"
-resolver = 2
 
 [workspace]
+resolver = "2"
 
 members = [
   "partiql",

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -11,6 +11,7 @@ use partiql_logical as logical;
 use partiql_value::Value;
 use std::borrow::Cow;
 
+use partiql_catalog::context::SessionContext;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fs::File;
@@ -98,7 +99,11 @@ impl BaseTableFunctionInfo for ReadIonFunction {
 pub(crate) struct EvalFnReadIon {}
 
 impl BaseTableExpr for EvalFnReadIon {
-    fn evaluate(&self, args: &[Cow<Value>]) -> BaseTableExprResult {
+    fn evaluate<'c>(
+        &self,
+        args: &[Cow<Value>],
+        _ctx: &'c dyn SessionContext<'c>,
+    ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {
                 Value::String(path) => parse_ion_file(path),
@@ -155,9 +160,10 @@ fn parse_ion_buff<'a, I: 'a + ToIonDataSource>(input: I) -> BaseTableExprResult<
 mod tests {
     use super::*;
 
+    use partiql_catalog::context::SystemContext;
     use partiql_catalog::{Catalog, Extension, PartiqlCatalog};
     use partiql_eval::env::basic::MapBindings;
-    use partiql_eval::eval::{BasicContext, SystemContext};
+    use partiql_eval::eval::BasicContext;
     use partiql_eval::plan::EvaluationMode;
     use partiql_parser::{Parsed, ParserResult};
     use partiql_value::{bag, tuple, DateTime, Value};

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -157,9 +157,10 @@ mod tests {
 
     use partiql_catalog::{Catalog, Extension, PartiqlCatalog};
     use partiql_eval::env::basic::MapBindings;
+    use partiql_eval::eval::{BasicContext, SystemContext};
     use partiql_eval::plan::EvaluationMode;
     use partiql_parser::{Parsed, ParserResult};
-    use partiql_value::{bag, tuple, Value};
+    use partiql_value::{bag, tuple, DateTime, Value};
 
     #[track_caller]
     #[inline]
@@ -189,7 +190,11 @@ mod tests {
 
         let mut plan = planner.compile(&logical).expect("Expect no plan error");
 
-        if let Ok(out) = plan.execute_mut(bindings) {
+        let sys = SystemContext {
+            now: DateTime::from_system_now_utc(),
+        };
+        let ctx = BasicContext::new(bindings, sys);
+        if let Ok(out) = plan.execute_mut(&ctx) {
             out.result
         } else {
             Value::Missing

--- a/partiql-catalog/src/context.rs
+++ b/partiql-catalog/src/context.rs
@@ -1,0 +1,27 @@
+use partiql_value::{BindingsName, DateTime, Tuple, Value};
+use std::any::Any;
+use std::fmt::Debug;
+
+pub trait Bindings<T>: Debug {
+    fn get(&self, name: &BindingsName) -> Option<&T>;
+}
+
+impl Bindings<Value> for Tuple {
+    fn get(&self, name: &BindingsName) -> Option<&Value> {
+        self.get(name)
+    }
+}
+
+#[derive(Debug)]
+pub struct SystemContext {
+    pub now: DateTime,
+}
+
+/// Represents a session context that is used during evaluation of a plan.
+pub trait SessionContext<'a>: Debug {
+    fn bindings(&self) -> &dyn Bindings<Value>;
+
+    fn system_context(&self) -> &SystemContext;
+
+    fn user_context(&self, name: &str) -> Option<&(dyn Any)>;
+}

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -4,6 +4,7 @@ use partiql_types::PartiqlType;
 use partiql_value::Value;
 use std::borrow::Cow;
 
+use crate::context::SessionContext;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Debug;
@@ -12,6 +13,8 @@ use thiserror::Error;
 use unicase::UniCase;
 
 pub mod call_defs;
+
+pub mod context;
 
 pub trait Extension: Debug {
     fn name(&self) -> String;
@@ -49,7 +52,11 @@ pub type BaseTableExprResult<'a> =
     Result<BaseTableExprResultValueIter<'a>, BaseTableExprResultError>;
 
 pub trait BaseTableExpr: Debug {
-    fn evaluate(&self, args: &[Cow<Value>]) -> BaseTableExprResult;
+    fn evaluate<'c>(
+        &self,
+        args: &[Cow<Value>],
+        ctx: &'c dyn SessionContext<'c>,
+    ) -> BaseTableExprResult<'c>;
 }
 
 pub trait BaseTableFunctionInfo: Debug {

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -3,13 +3,12 @@ use partiql_catalog::{Catalog, PartiqlCatalog};
 use partiql_eval as eval;
 
 use partiql_eval::error::{EvalErr, PlanErr};
-use partiql_eval::eval::{
-    BasicContext, EvalContext, EvalPlan, EvalResult, Evaluated, SystemContext,
-};
+use partiql_eval::eval::{BasicContext, EvalContext, EvalPlan, EvalResult, Evaluated};
 use partiql_logical as logical;
 use partiql_parser::{Parsed, ParserError, ParserResult};
 use partiql_value::DateTime;
 
+use partiql_catalog::context::SystemContext;
 use thiserror::Error;
 
 mod test_value;
@@ -60,7 +59,7 @@ pub(crate) fn compile(
 
 #[track_caller]
 #[inline]
-pub(crate) fn evaluate<'a, 'c>(mut plan: EvalPlan, ctx: &'c dyn EvalContext<'c>) -> EvalResult {
+pub(crate) fn evaluate<'c>(mut plan: EvalPlan, ctx: &'c dyn EvalContext<'c>) -> EvalResult {
     plan.execute_mut(ctx)
 }
 

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -36,6 +36,7 @@ assert_matches = "1.5.*"
 regex = "1.7"
 regex-syntax = "0.6"
 rustc-hash = "1"
+delegate = "0.12"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -1,16 +1,7 @@
+use partiql_catalog::context::Bindings;
 use partiql_value::{BindingsName, Tuple, Value};
 use std::fmt::Debug;
 use unicase::UniCase;
-
-pub trait Bindings<T>: Debug {
-    fn get(&self, name: &BindingsName) -> Option<&T>;
-}
-
-impl Bindings<Value> for Tuple {
-    fn get(&self, name: &BindingsName) -> Option<&Value> {
-        self.get(name)
-    }
-}
 
 pub mod basic {
     use super::*;

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -56,7 +56,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate(&mut self, _ctx: &dyn EvalContext) -> Value {
+    fn evaluate<'a, 'c>(&mut self, _ctx: &'c dyn EvalContext<'c>) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 
@@ -66,7 +66,14 @@ impl Evaluable for ErrorNode {
 }
 
 impl EvalExpr for ErrorNode {
-    fn evaluate<'a>(&'a self, _bindings: &'a Tuple, _ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        _bindings: &'a Tuple,
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         panic!("ErrorNode will not be evaluated")
     }
 }

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -66,11 +66,13 @@ pub(crate) fn unwrap_args<const N: usize>(
 /// An expression that is evaluated over `N` input arguments
 pub(crate) trait ExecuteEvalExpr<const N: usize>: Debug {
     /// Evaluate the expression
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; N],
-        ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value>;
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a;
 }
 
 /// Used to tell argument checking whether it should exit early or go on as usual.
@@ -249,11 +251,14 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
     ///
     /// If type-checking fails, the appropriate failure case of [`ArgCheckControlFlow`] is returned,
     /// else [`ArgCheckControlFlow::Continue`] is returned containing the `N` values.
-    pub fn evaluate_args<'a>(
+    pub fn evaluate_args<'a, 'c>(
         &'a self,
         bindings: &'a Tuple,
-        ctx: &'a dyn EvalContext,
-    ) -> ControlFlow<Value, [Cow<Value>; N]> {
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> ControlFlow<Value, [Cow<Value>; N]>
+    where
+        'c: 'a,
+    {
         let err_arg_count_mismatch = |args: Vec<_>| {
             if STRICT {
                 ctx.add_error(EvaluationError::IllegalState(format!(
@@ -326,7 +331,14 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
 impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker> EvalExpr
     for ArgCheckEvalExpr<STRICT, N, E, ArgC>
 {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         if STRICT && ctx.has_errors() {
             return Cow::Owned(Missing);
         }
@@ -379,11 +391,14 @@ where
     F: Fn(&Value) -> Value,
 {
     #[inline]
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; 1],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let [arg] = args;
         Cow::Owned((self.f)(arg.borrow()))
     }
@@ -440,11 +455,14 @@ where
     F: Fn(&Value, &Value) -> Value,
 {
     #[inline]
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; 2],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let [arg1, arg2] = args;
         Cow::Owned((self.f)(arg1.borrow(), arg2.borrow()))
     }
@@ -501,11 +519,14 @@ where
     F: Fn(&Value, &Value, &Value) -> Value,
 {
     #[inline]
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; 3],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let [arg1, arg2, arg3] = args;
         Cow::Owned((self.f)(arg1.borrow(), arg2.borrow(), arg3.borrow()))
     }
@@ -562,11 +583,14 @@ where
     F: Fn(&Value, &Value, &Value, &Value) -> Value,
 {
     #[inline]
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; 4],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let [arg1, arg2, arg3, arg4] = args;
         Cow::Owned((self.f)(
             arg1.borrow(),

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -40,7 +40,7 @@ pub enum EvalType {
 
 /// `Evaluable` represents each evaluation operator in the evaluation plan as an evaluable entity.
 pub trait Evaluable: Debug {
-    fn evaluate<'a, 'c>(&mut self, ctx: &'c dyn EvalContext<'c>) -> Value;
+    fn evaluate<'c>(&mut self, ctx: &'c dyn EvalContext<'c>) -> Value;
     fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext);
     fn get_vars(&self) -> Option<&[String]> {
         None

--- a/partiql-eval/src/eval/expr/base_table.rs
+++ b/partiql-eval/src/eval/expr/base_table.rs
@@ -18,7 +18,14 @@ pub(crate) struct EvalFnBaseTableExpr {
 
 impl EvalExpr for EvalFnBaseTableExpr {
     #[inline]
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let args = self
             .args
             .iter()

--- a/partiql-eval/src/eval/expr/base_table.rs
+++ b/partiql-eval/src/eval/expr/base_table.rs
@@ -31,7 +31,7 @@ impl EvalExpr for EvalFnBaseTableExpr {
             .iter()
             .map(|arg| arg.evaluate(bindings, ctx))
             .collect_vec();
-        let results = self.expr.evaluate(&args);
+        let results = self.expr.evaluate(&args, ctx.as_session());
         let result = match results {
             Ok(it) => {
                 let bag: Result<Bag, _> = it.collect();

--- a/partiql-eval/src/eval/expr/control_flow.rs
+++ b/partiql-eval/src/eval/expr/control_flow.rs
@@ -13,7 +13,14 @@ pub(crate) struct EvalSearchedCaseExpr {
 }
 
 impl EvalExpr for EvalSearchedCaseExpr {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         for (when_expr, then_expr) in &self.cases {
             let when_expr_evaluated = when_expr.evaluate(bindings, ctx);
             if when_expr_evaluated.as_ref() == &Value::Boolean(true) {

--- a/partiql-eval/src/eval/expr/data_types.rs
+++ b/partiql-eval/src/eval/expr/data_types.rs
@@ -20,7 +20,14 @@ pub(crate) struct EvalTupleExpr {
 }
 
 impl EvalExpr for EvalTupleExpr {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let tuple = self
             .attrs
             .iter()
@@ -52,7 +59,14 @@ pub(crate) struct EvalListExpr {
 }
 
 impl EvalExpr for EvalListExpr {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let values = self
             .elements
             .iter()
@@ -70,7 +84,14 @@ pub(crate) struct EvalBagExpr {
 }
 
 impl EvalExpr for EvalBagExpr {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let values = self
             .elements
             .iter()
@@ -89,7 +110,14 @@ pub(crate) struct EvalIsTypeExpr {
 }
 
 impl EvalExpr for EvalIsTypeExpr {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let expr = self.expr.evaluate(bindings, ctx);
         let expr = expr.as_ref();
         let result = match self.is_type {

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -26,7 +26,13 @@ use thiserror::Error;
 
 /// A trait for expressions that require evaluation, e.g. `a + b` or `c > 2`.
 pub trait EvalExpr: Debug {
-    fn evaluate<'a>(&'a self, bindings: &'a Tuple, ctx: &'a dyn EvalContext) -> Cow<'a, Value>;
+    fn evaluate<'a, 'c>(
+        &'a self,
+        bindings: &'a Tuple,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a;
 }
 
 #[derive(Error, Debug, Clone, PartialEq)]

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -42,17 +42,27 @@ impl BindEvalExpr for EvalLitExpr {
 }
 
 impl EvalExpr for EvalLitExpr {
-    fn evaluate<'a>(&'a self, _: &'a Tuple, _: &'a dyn EvalContext) -> Cow<'a, Value> {
+    fn evaluate<'a, 'c>(
+        &'a self,
+        _bindings: &'a Tuple,
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         Cow::Borrowed(&self.lit)
     }
 }
 
 impl ExecuteEvalExpr<0> for Value {
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         _args: [Cow<'a, Value>; 0],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         Cow::Borrowed(self)
     }
 }

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -1,5 +1,3 @@
-use crate::env::Bindings;
-
 pub use core::borrow::Borrow;
 
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
@@ -8,6 +6,7 @@ use crate::eval::EvalContext;
 use partiql_value::Value::Missing;
 use partiql_value::{BindingsName, Tuple, Value};
 
+use partiql_catalog::context::Bindings;
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 

--- a/partiql-eval/src/eval/expr/strings.rs
+++ b/partiql-eval/src/eval/expr/strings.rs
@@ -66,11 +66,14 @@ where
     R: Into<Value>,
 {
     #[inline]
-    fn evaluate<'a>(
+    fn evaluate<'a, 'c>(
         &'a self,
         args: [Cow<'a, Value>; 1],
-        _ctx: &'a dyn EvalContext,
-    ) -> Cow<'a, Value> {
+        _ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'a, Value>
+    where
+        'c: 'a,
+    {
         let [value] = args;
         Cow::Owned(match value.borrow() {
             Value::String(s) => ((self.f)(s)).into(),

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -1,6 +1,9 @@
 use itertools::Itertools;
+use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashMap;
 
+use delegate::delegate;
 use std::fmt::Debug;
 
 use petgraph::algo::toposort;
@@ -8,7 +11,7 @@ use petgraph::dot::Dot;
 use petgraph::prelude::StableGraph;
 use petgraph::{Directed, Outgoing};
 
-use partiql_value::Value;
+use partiql_value::{DateTime, Value};
 
 use crate::env::basic::MapBindings;
 use crate::env::Bindings;
@@ -62,8 +65,9 @@ impl EvalPlan {
 
     /// Executes the plan while mutating its state by changing the inputs and outputs of plan
     /// operators.
-    pub fn execute_mut(&mut self, bindings: MapBindings<Value>) -> Result<Evaluated, EvalErr> {
-        let ctx: Box<dyn EvalContext> = Box::new(BasicContext::new(bindings));
+    pub fn execute_mut<'c>(&mut self, ctx: &'c dyn EvalContext<'c>) -> Result<Evaluated, EvalErr> {
+        //let ctx: Box<dyn EvalContext> = Box::new(BasicContext::new(bindings));
+
         // We are only interested in DAGs that can be used as execution plans, which leads to the
         // following definition.
         // A DAG is a directed, cycle-free graph G = (V, E) with a denoted root node v0 ∈ V such
@@ -95,7 +99,7 @@ impl EvalPlan {
                 });
             if graph_managed {
                 let src = self.get_node(idx)?;
-                result = Some(src.evaluate(&*ctx));
+                result = Some(src.evaluate(ctx));
 
                 // return on first evaluation error
                 if ctx.has_errors() {
@@ -114,7 +118,7 @@ impl EvalPlan {
 
                     let res =
                         res.ok_or_else(|| err_illegal_state("Error in retrieving source value"))?;
-                    self.get_node(dst_id)?.update_input(res, branch_num, &*ctx);
+                    self.get_node(dst_id)?.update_input(res, branch_num, ctx);
                 }
             }
         }
@@ -139,32 +143,55 @@ pub struct Evaluated {
     pub result: Value,
 }
 
+#[derive(Debug)]
+pub struct SystemContext {
+    pub now: DateTime,
+}
+
 /// Represents an evaluation context that is used during evaluation of a plan.
-pub trait EvalContext {
+pub trait EvalContext<'a>: Debug {
     fn bindings(&self) -> &dyn Bindings<Value>;
+
+    fn system_context(&self) -> &SystemContext;
+    fn user_context(&self, name: &str) -> Option<&'a (dyn Any + 'a)>;
+
     fn add_error(&self, error: EvaluationError);
     fn has_errors(&self) -> bool;
     fn errors(&self) -> Vec<EvaluationError>;
 }
 
-#[derive(Default, Debug)]
-pub struct BasicContext {
-    bindings: MapBindings<Value>,
-    errors: RefCell<Vec<EvaluationError>>,
+#[derive(Debug)]
+pub struct BasicContext<'a> {
+    pub bindings: MapBindings<Value>,
+
+    pub sys: SystemContext,
+    pub user: HashMap<String, &'a (dyn Any)>, // TODO: Unicase the keys?
+
+    pub errors: RefCell<Vec<EvaluationError>>,
 }
 
-impl BasicContext {
-    pub fn new(bindings: MapBindings<Value>) -> Self {
+impl<'a> BasicContext<'a> {
+    pub fn new(bindings: MapBindings<Value>, sys: SystemContext) -> Self {
         BasicContext {
             bindings,
+            sys,
+            user: Default::default(),
             errors: RefCell::new(vec![]),
         }
     }
 }
 
-impl EvalContext for BasicContext {
+impl<'a> EvalContext<'a> for BasicContext<'a> {
     fn bindings(&self) -> &dyn Bindings<Value> {
         &self.bindings
+    }
+
+    fn system_context(&self) -> &SystemContext {
+        &self.sys
+    }
+
+    fn user_context(&self, name: &str) -> Option<&'a (dyn Any + 'a)> {
+        self.user.get(name).copied()
     }
 
     fn add_error(&self, error: EvaluationError) {
@@ -177,5 +204,34 @@ impl EvalContext for BasicContext {
 
     fn errors(&self) -> Vec<EvaluationError> {
         self.errors.take()
+    }
+}
+
+#[derive(Debug)]
+pub struct NestedContext<'a, 'c> {
+    pub bindings: MapBindings<Value>,
+    pub parent: &'a dyn EvalContext<'c>,
+}
+
+impl<'a, 'c> NestedContext<'a, 'c> {
+    pub fn new(bindings: MapBindings<Value>, parent: &'a dyn EvalContext<'c>) -> Self {
+        NestedContext { bindings, parent }
+    }
+}
+
+impl<'a, 'c> EvalContext<'a> for NestedContext<'a, 'c> {
+    fn bindings(&self) -> &dyn Bindings<Value> {
+        &self.bindings
+    }
+
+    delegate! {
+        to self.parent {
+            fn system_context(&self) -> &SystemContext;
+            fn user_context(&self, name: &str) -> Option<&'a (dyn Any + 'a)>;
+
+            fn add_error(&self, error: EvaluationError);
+            fn has_errors(&self) -> bool;
+            fn errors(&self) -> Vec<EvaluationError>;
+        }
     }
 }

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -9,13 +9,14 @@ mod tests {
 
     use crate::env::basic::MapBindings;
     use crate::plan;
+    use partiql_catalog::context::SystemContext;
     use partiql_catalog::PartiqlCatalog;
     use rust_decimal_macros::dec;
 
     use partiql_logical as logical;
     use partiql_logical::BindingsOp::{Distinct, Project, ProjectAll, ProjectValue};
 
-    use crate::eval::{BasicContext, SystemContext};
+    use crate::eval::BasicContext;
     use crate::plan::EvaluationMode;
     use partiql_logical::{
         BagExpr, BetweenExpr, BinaryOp, BindingsOp, CoalesceExpr, ExprQuery, IsTypeExpr, JoinKind,
@@ -2215,7 +2216,8 @@ mod tests {
     mod clause_from {
         use crate::eval::evaluable::{EvalScan, Evaluable};
         use crate::eval::expr::{EvalGlobalVarRef, EvalPath, EvalPathComponent};
-        use crate::eval::{BasicContext, SystemContext};
+        use crate::eval::BasicContext;
+        use partiql_catalog::context::SystemContext;
         use partiql_value::{bag, list, BindingsName, DateTime};
 
         use super::*;
@@ -2354,7 +2356,7 @@ mod tests {
 
         use crate::eval::evaluable::{EvalUnpivot, Evaluable};
         use crate::eval::expr::EvalGlobalVarRef;
-        use crate::eval::{BasicContext, SystemContext};
+        use crate::eval::BasicContext;
 
         use super::*;
 

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -15,6 +15,7 @@ mod tests {
     use partiql_logical as logical;
     use partiql_logical::BindingsOp::{Distinct, Project, ProjectAll, ProjectValue};
 
+    use crate::eval::{BasicContext, SystemContext};
     use crate::plan::EvaluationMode;
     use partiql_logical::{
         BagExpr, BetweenExpr, BinaryOp, BindingsOp, CoalesceExpr, ExprQuery, IsTypeExpr, JoinKind,
@@ -22,14 +23,17 @@ mod tests {
     };
     use partiql_value as value;
     use partiql_value::Value::{Missing, Null};
-    use partiql_value::{bag, list, tuple, Bag, BindingsName, List, Tuple, Value};
+    use partiql_value::{bag, list, tuple, Bag, BindingsName, DateTime, List, Tuple, Value};
 
     fn evaluate(logical: LogicalPlan<BindingsOp>, bindings: MapBindings<Value>) -> Value {
         let catalog = PartiqlCatalog::default();
         let mut planner = plan::EvaluatorPlanner::new(EvaluationMode::Permissive, &catalog);
         let mut plan = planner.compile(&logical).expect("Expect no plan error");
-
-        if let Ok(out) = plan.execute_mut(bindings) {
+        let sys = SystemContext {
+            now: DateTime::from_system_now_utc(),
+        };
+        let ctx = BasicContext::new(bindings, sys);
+        if let Ok(out) = plan.execute_mut(&ctx) {
             out.result
         } else {
             Missing
@@ -2211,8 +2215,8 @@ mod tests {
     mod clause_from {
         use crate::eval::evaluable::{EvalScan, Evaluable};
         use crate::eval::expr::{EvalGlobalVarRef, EvalPath, EvalPathComponent};
-        use crate::eval::BasicContext;
-        use partiql_value::{bag, list, BindingsName};
+        use crate::eval::{BasicContext, SystemContext};
+        use partiql_value::{bag, list, BindingsName, DateTime};
 
         use super::*;
 
@@ -2230,7 +2234,10 @@ mod tests {
             let mut p0: MapBindings<Value> = MapBindings::default();
             p0.insert("someOrderedTable", some_ordered_table().into());
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
 
             let mut scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
@@ -2256,7 +2263,10 @@ mod tests {
             let mut p0: MapBindings<Value> = MapBindings::default();
             p0.insert("someUnorderedTable", some_unordered_table().into());
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
 
             let mut scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
@@ -2300,7 +2310,10 @@ mod tests {
             };
             let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
             let scan_res = scan.evaluate(&ctx);
 
             let expected = bag![tuple![("x", 0)]];
@@ -2325,7 +2338,10 @@ mod tests {
             };
             let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
             let res = scan.evaluate(&ctx);
 
             let expected = bag![tuple![("x", value::Value::Missing)]];
@@ -2334,11 +2350,11 @@ mod tests {
     }
 
     mod clause_unpivot {
-        use partiql_value::{bag, BindingsName, Tuple};
+        use partiql_value::{bag, BindingsName, DateTime, Tuple};
 
         use crate::eval::evaluable::{EvalUnpivot, Evaluable};
         use crate::eval::expr::EvalGlobalVarRef;
-        use crate::eval::BasicContext;
+        use crate::eval::{BasicContext, SystemContext};
 
         use super::*;
 
@@ -2360,7 +2376,10 @@ mod tests {
                 Some("symbol".into()),
             );
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
             let res = unpivot.evaluate(&ctx);
 
             let expected = bag![
@@ -2384,7 +2403,10 @@ mod tests {
                 Some("y".into()),
             );
 
-            let ctx = BasicContext::new(p0);
+            let sys = SystemContext {
+                now: DateTime::from_system_now_utc(),
+            };
+            let ctx = BasicContext::new(p0, sys);
             let res = unpivot.evaluate(&ctx);
 
             let expected = bag![tuple![("x", 1), ("y", "_1")]];

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -38,10 +38,11 @@ impl<'c> LogicalPlanner<'c> {
 mod tests {
     use assert_matches::assert_matches;
     use partiql_ast_passes::error::AstTransformationError;
+    use partiql_catalog::context::SystemContext;
     use partiql_catalog::PartiqlCatalog;
 
     use partiql_eval::env::basic::MapBindings;
-    use partiql_eval::eval::{BasicContext, SystemContext};
+    use partiql_eval::eval::BasicContext;
 
     use partiql_eval::plan;
     use partiql_eval::plan::EvaluationMode;

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1160,7 +1160,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                 not_yet_implemented_fault!(self, "PositionalType call argument".to_string());
             }
             CallArg::NamedType(_) => {
-                not_yet_implemented_fault!(self, "PositionalType call argument".to_string());
+                not_yet_implemented_fault!(self, "NamedType call argument".to_string());
             }
         }
         Traverse::Continue

--- a/partiql-value/src/datetime.rs
+++ b/partiql-value/src/datetime.rs
@@ -17,6 +17,10 @@ pub enum DateTime {
 }
 
 impl DateTime {
+    pub fn from_system_now_utc() -> Self {
+        DateTime::TimestampWithTz(time::OffsetDateTime::now_utc())
+    }
+
     pub fn from_hms(hour: u8, minute: u8, second: u8) -> Self {
         DateTime::Time(time::Time::from_hms(hour, minute, second).expect("valid time value"))
     }

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -5,11 +5,11 @@ mod tests {
     use partiql_eval as eval;
     use partiql_eval::env::basic::MapBindings;
     use partiql_eval::error::{EvalErr, PlanErr};
-    use partiql_eval::eval::{EvalPlan, EvalResult, Evaluated};
+    use partiql_eval::eval::{BasicContext, EvalPlan, EvalResult, Evaluated, SystemContext};
     use partiql_eval::plan::EvaluationMode;
     use partiql_logical as logical;
     use partiql_parser::{Parsed, ParserError, ParserResult};
-    use partiql_value::Value;
+    use partiql_value::{DateTime, Value};
     use thiserror::Error;
 
     #[derive(Error, Debug)]
@@ -78,7 +78,11 @@ mod tests {
     #[track_caller]
     #[inline]
     fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
-        plan.execute_mut(bindings)
+        let sys = SystemContext {
+            now: DateTime::from_system_now_utc(),
+        };
+        let ctx = BasicContext::new(bindings, sys);
+        plan.execute_mut(&ctx)
     }
 
     #[track_caller]

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -1,11 +1,12 @@
 #[cfg(test)]
 mod tests {
     use partiql_ast_passes::error::AstTransformationError;
+    use partiql_catalog::context::SystemContext;
     use partiql_catalog::{Catalog, PartiqlCatalog};
     use partiql_eval as eval;
     use partiql_eval::env::basic::MapBindings;
     use partiql_eval::error::{EvalErr, PlanErr};
-    use partiql_eval::eval::{BasicContext, EvalPlan, EvalResult, Evaluated, SystemContext};
+    use partiql_eval::eval::{BasicContext, EvalPlan, EvalResult, Evaluated};
     use partiql_eval::plan::EvaluationMode;
     use partiql_logical as logical;
     use partiql_parser::{Parsed, ParserError, ParserResult};
@@ -101,14 +102,14 @@ mod tests {
     fn order_by_count() {
         let query = "select foo, count(1) as n from
             <<
-            { 'foo': 'foo' },
-        { 'foo': 'bar' },
-        { 'foo': 'qux' },
-        { 'foo': 'bar' },
-        { 'foo': 'baz' },
-        { 'foo': 'bar' },
-        { 'foo': 'baz' }
-        >>  group by foo order by n desc";
+                { 'foo': 'foo' },
+                { 'foo': 'bar' },
+                { 'foo': 'qux' },
+                { 'foo': 'bar' },
+                { 'foo': 'baz' },
+                { 'foo': 'bar' },
+                { 'foo': 'baz' }
+            >>  group by foo order by n desc";
 
         let res = eval(query, EvaluationMode::Permissive);
         assert!(res.is_ok());

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -174,7 +174,7 @@ pub(crate) fn evaluate(
     };
     let mut ctx = BasicContext::new(bindings, sys);
     for (k, v) in ctx_vals {
-        ctx.user.insert(k.to_string(), *v);
+        ctx.user.insert(k.as_str().into(), *v);
     }
     if let Ok(out) = plan.execute_mut(&ctx) {
         out.result

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -1,0 +1,215 @@
+use std::any::Any;
+use std::borrow::Cow;
+use std::cell::RefCell;
+
+use std::error::Error;
+
+use thiserror::Error;
+
+use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
+use partiql_catalog::context::{SessionContext, SystemContext};
+use partiql_catalog::{
+    BaseTableExpr, BaseTableExprResult, BaseTableExprResultError, BaseTableFunctionInfo, Catalog,
+    Extension, PartiqlCatalog, TableFunction,
+};
+use partiql_eval::env::basic::MapBindings;
+use partiql_eval::eval::BasicContext;
+use partiql_eval::plan::EvaluationMode;
+use partiql_parser::{Parsed, ParserResult};
+use partiql_value::{bag, tuple, DateTime, Value};
+
+use partiql_logical as logical;
+
+#[derive(Debug)]
+pub struct UserCtxTestExtension {}
+
+impl partiql_catalog::Extension for UserCtxTestExtension {
+    fn name(&self) -> String {
+        "ion".into()
+    }
+
+    fn load(&self, catalog: &mut dyn Catalog) -> Result<(), Box<dyn Error>> {
+        match catalog
+            .add_table_function(TableFunction::new(Box::new(TestUserContextFunction::new())))
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(Box::new(e) as Box<dyn Error>),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TestUserContextFunction {
+    call_def: CallDef,
+}
+
+impl TestUserContextFunction {
+    pub fn new() -> Self {
+        TestUserContextFunction {
+            call_def: CallDef {
+                names: vec!["test_user_context"],
+                overloads: vec![CallSpec {
+                    input: vec![CallSpecArg::Positional],
+                    output: Box::new(|args| {
+                        logical::ValueExpr::Call(logical::CallExpr {
+                            name: logical::CallName::ByName("test_user_context".to_string()),
+                            arguments: args,
+                        })
+                    }),
+                }],
+            },
+        }
+    }
+}
+
+impl BaseTableFunctionInfo for TestUserContextFunction {
+    fn call_def(&self) -> &CallDef {
+        &self.call_def
+    }
+
+    fn plan_eval(&self) -> Box<dyn BaseTableExpr> {
+        Box::new(EvalTestCtxTable {})
+    }
+}
+
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum UserCtxError {
+    #[error("unknown error")]
+    Unknown,
+}
+
+#[derive(Debug)]
+pub(crate) struct EvalTestCtxTable {}
+
+impl BaseTableExpr for EvalTestCtxTable {
+    fn evaluate<'c>(
+        &self,
+        args: &[Cow<Value>],
+        ctx: &'c dyn SessionContext<'c>,
+    ) -> BaseTableExprResult<'c> {
+        if let Some(arg1) = args.first() {
+            match arg1.as_ref() {
+                Value::String(name) => generated_data(name.to_string(), ctx),
+                _ => {
+                    let error = UserCtxError::Unknown;
+                    Err(Box::new(error) as BaseTableExprResultError)
+                }
+            }
+        } else {
+            let error = UserCtxError::Unknown;
+            Err(Box::new(error) as BaseTableExprResultError)
+        }
+    }
+}
+
+struct TestDataGen<'a> {
+    ctx: &'a dyn SessionContext<'a>,
+    name: String,
+}
+
+impl<'a> Iterator for TestDataGen<'a> {
+    type Item = Result<Value, BaseTableExprResultError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(cv) = self.ctx.user_context(&self.name) {
+            if let Some(counter) = cv.downcast_ref::<Counter>() {
+                let mut n = counter.data.borrow_mut();
+
+                if *n > 0 {
+                    *n -= 1;
+
+                    let idx: u8 = (5 - *n) as u8;
+                    let id = format!("id_{idx}");
+                    let m = idx % 2;
+
+                    return Some(Ok(tuple![("foo", m), ("bar", id)].into()));
+                }
+            }
+        }
+        None
+    }
+}
+
+fn generated_data<'a>(name: String, ctx: &'a dyn SessionContext<'a>) -> BaseTableExprResult<'a> {
+    Ok(Box::new(TestDataGen { ctx, name }))
+}
+
+#[derive(Debug)]
+pub struct Counter {
+    data: RefCell<u32>,
+}
+
+#[track_caller]
+#[inline]
+pub(crate) fn parse(statement: &str) -> ParserResult {
+    partiql_parser::Parser::default().parse(statement)
+}
+
+#[track_caller]
+#[inline]
+pub(crate) fn lower(
+    catalog: &dyn Catalog,
+    parsed: &Parsed,
+) -> partiql_logical::LogicalPlan<partiql_logical::BindingsOp> {
+    let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
+    planner.lower(parsed).expect("lower")
+}
+
+#[track_caller]
+#[inline]
+pub(crate) fn evaluate(
+    catalog: &dyn Catalog,
+    logical: partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+    bindings: MapBindings<Value>,
+    ctx_vals: &[(String, &(dyn Any))],
+) -> Value {
+    let mut planner =
+        partiql_eval::plan::EvaluatorPlanner::new(EvaluationMode::Permissive, catalog);
+
+    let mut plan = planner.compile(&logical).expect("Expect no plan error");
+
+    let sys = SystemContext {
+        now: DateTime::from_system_now_utc(),
+    };
+    let mut ctx = BasicContext::new(bindings, sys);
+    for (k, v) in ctx_vals {
+        ctx.user.insert(k.to_string(), *v);
+    }
+    if let Ok(out) = plan.execute_mut(&ctx) {
+        out.result
+    } else {
+        Value::Missing
+    }
+}
+#[test]
+fn test_context() {
+    let expected: Value = bag![
+        tuple![("foo", 1), ("bar", "id_1")],
+        tuple![("foo", 0), ("bar", "id_2")],
+        tuple![("foo", 1), ("bar", "id_3")],
+        tuple![("foo", 0), ("bar", "id_4")],
+        tuple![("foo", 1), ("bar", "id_5")],
+    ]
+    .into();
+
+    let query = "SELECT foo, bar from test_user_context('counter') as data";
+
+    let mut catalog = PartiqlCatalog::default();
+    let ext = UserCtxTestExtension {};
+    ext.load(&mut catalog).expect("extension load to succeed");
+
+    let parsed = parse(query);
+    let lowered = lower(&catalog, &parsed.expect("parse"));
+    let bindings = Default::default();
+
+    let counter = Counter {
+        data: RefCell::new(5),
+    };
+    let ctx: [(String, &dyn Any); 1] = [("counter".to_string(), &counter)];
+    let out = evaluate(&catalog, lowered, bindings, &ctx);
+
+    assert!(out.is_bag());
+    assert_eq!(&out, &expected);
+    assert_eq!(*counter.data.borrow(), 0);
+}


### PR DESCRIPTION
Fixes #388 

Adds both a system-level and a user-level session context to the evaluation context. Also plumbs the context through to `BaseTableExpr` used in `partiql_catalog::Extension`s.

There is a lot of fiddly lifetime management and testing changes, as well as some slight trait refactors.

It's probably easiest to start with 
- the new integration test in `partiql/tests/user_context.rs` to see what kinds of things are possible,
- `partiql-catalog/src/context.rs` for the new context traits, and
- `partiql-eval/src/eval/mod.rs` for how it's used in evaluation.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
