### PR TITLE
Add #![deny(rust_2018_idioms)] to all crates

### DIFF
--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -103,7 +103,7 @@ pub(crate) struct EvalFnReadIon {}
 impl BaseTableExpr for EvalFnReadIon {
     fn evaluate<'c>(
         &self,
-        args: &[Cow<Value>],
+        args: &[Cow<'_, Value>],
         _ctx: &'c dyn SessionContext<'c>,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
@@ -155,7 +155,7 @@ fn parse_ion_buff<'a, I: 'a + ToIonDataSource>(input: I) -> BaseTableExprResult<
     let decoder =
         IonDecoderBuilder::new(IonDecoderConfig::default().with_mode(Encoding::Ion)).build(reader);
     let decoder = decoder.map_err(err_map)?.map(move |it| it.map_err(err_map));
-    Ok(Box::new(decoder) as BaseTableExprResultValueIter)
+    Ok(Box::new(decoder) as BaseTableExprResultValueIter<'_>)
 }
 
 #[cfg(test)]
@@ -172,7 +172,7 @@ mod tests {
 
     #[track_caller]
     #[inline]
-    pub(crate) fn parse(statement: &str) -> ParserResult {
+    pub(crate) fn parse(statement: &str) -> ParserResult<'_> {
         partiql_parser::Parser::default().parse(statement)
     }
 
@@ -180,7 +180,7 @@ mod tests {
     #[inline]
     pub(crate) fn lower(
         catalog: &dyn Catalog,
-        parsed: &Parsed,
+        parsed: &Parsed<'_>,
     ) -> partiql_logical::LogicalPlan<partiql_logical::BindingsOp> {
         let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
         planner.lower(parsed).expect("lower")

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use ion_rs::data_source::ToIonDataSource;
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
 use partiql_catalog::TableFunction;

--- a/extension/partiql-extension-ion/src/encode.rs
+++ b/extension/partiql-extension-ion/src/encode.rs
@@ -179,7 +179,6 @@ where
 
 struct SimpleIonValueEncoder<'a, W, I>
 where
-    W: 'a,
     I: IonWriter<Output = W>,
 {
     pub(crate) writer: &'a mut I,
@@ -311,7 +310,6 @@ where
 
 struct PartiqlEncodedIonValueEncoder<'a, W, I>
 where
-    W: 'a,
     I: IonWriter<Output = W>,
 {
     inner: SimpleIonValueEncoder<'a, W, I>,

--- a/extension/partiql-extension-ion/src/lib.rs
+++ b/extension/partiql-extension-ion/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 mod common;
 pub mod decode;
 pub mod encode;

--- a/extension/partiql-extension-visualize/src/ast_to_dot.rs
+++ b/extension/partiql-extension-visualize/src/ast_to_dot.rs
@@ -43,11 +43,11 @@ impl<'d, 'w> ScopeExt<'d, 'w> for Scope<'d, 'w> {
 }
 
 trait ChildEdgeExt {
-    fn edges(self, out: &mut Scope, from: &NodeId, lbl: &str) -> Targets;
+    fn edges(self, out: &mut Scope<'_, '_>, from: &NodeId, lbl: &str) -> Targets;
 }
 
 impl ChildEdgeExt for Targets {
-    fn edges(self, out: &mut Scope, from: &NodeId, lbl: &str) -> Targets {
+    fn edges(self, out: &mut Scope<'_, '_>, from: &NodeId, lbl: &str) -> Targets {
         for target in &self {
             out.edge(from, target).attributes().set_label(lbl);
         }
@@ -96,14 +96,14 @@ where
 }
 
 trait ToDot<T> {
-    fn to_dot(&mut self, out: &mut Scope, ast: &T) -> Targets;
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &T) -> Targets;
 }
 
 impl<T> ToDot<Box<T>> for AstToDot
 where
     AstToDot: ToDot<T>,
 {
-    fn to_dot(&mut self, out: &mut Scope, ast: &Box<T>) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &Box<T>) -> Targets {
         self.to_dot(out, &**ast)
     }
 }
@@ -112,7 +112,7 @@ impl<T> ToDot<Vec<T>> for AstToDot
 where
     AstToDot: ToDot<T>,
 {
-    fn to_dot(&mut self, out: &mut Scope, asts: &Vec<T>) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, asts: &Vec<T>) -> Targets {
         let mut res = Vec::with_capacity(asts.len());
         for ast in asts {
             res.extend(self.to_dot(out, ast));
@@ -125,7 +125,7 @@ impl<T> ToDot<Option<T>> for AstToDot
 where
     AstToDot: ToDot<T>,
 {
-    fn to_dot(&mut self, out: &mut Scope, ast: &Option<T>) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &Option<T>) -> Targets {
         match ast {
             None => vec![],
             Some(ast) => self.to_dot(out, ast),
@@ -137,13 +137,13 @@ impl<T> ToDot<ast::AstNode<T>> for AstToDot
 where
     AstToDot: ToDot<T>,
 {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::AstNode<T>) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::AstNode<T>) -> Targets {
         self.to_dot(out, &ast.node)
     }
 }
 
 impl ToDot<ast::Expr> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Expr) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Expr) -> Targets {
         let mut expr_subgraph = out.subgraph();
 
         use ast::Expr;
@@ -240,7 +240,7 @@ fn type_to_str(ty: &ast::Type) -> String {
 }
 
 impl ToDot<ast::Lit> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Lit) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Lit) -> Targets {
         let lbl = lit_to_str(ast);
 
         let mut node = out.node_auto();
@@ -251,7 +251,7 @@ impl ToDot<ast::Lit> for AstToDot {
 }
 
 impl ToDot<ast::BinOp> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::BinOp) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::BinOp) -> Targets {
         use ast::BinOpKind;
         let lbl = match ast.kind {
             BinOpKind::Add => "+",
@@ -281,7 +281,7 @@ impl ToDot<ast::BinOp> for AstToDot {
 }
 
 impl ToDot<ast::UniOp> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::UniOp) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::UniOp) -> Targets {
         use ast::UniOpKind;
         let lbl = match ast.kind {
             UniOpKind::Pos => "+",
@@ -297,7 +297,7 @@ impl ToDot<ast::UniOp> for AstToDot {
 }
 
 impl ToDot<ast::Like> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Like) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Like) -> Targets {
         let id = out.node_auto_labelled("LIKE").id();
 
         self.to_dot(out, &ast.value).edges(out, &id, "value");
@@ -309,7 +309,7 @@ impl ToDot<ast::Like> for AstToDot {
 }
 
 impl ToDot<ast::Between> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Between) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Between) -> Targets {
         let id = out.node_auto_labelled("BETWEEN").id();
 
         self.to_dot(out, &ast.value).edges(out, &id, "value");
@@ -321,7 +321,7 @@ impl ToDot<ast::Between> for AstToDot {
 }
 
 impl ToDot<ast::In> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::In) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::In) -> Targets {
         let id = out.node_auto_labelled("IN").id();
 
         self.to_dot(out, &ast.lhs).edges(out, &id, "");
@@ -332,7 +332,7 @@ impl ToDot<ast::In> for AstToDot {
 }
 
 impl ToDot<ast::Query> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Query) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Query) -> Targets {
         let id = out.node_auto_labelled("Query").id();
 
         self.to_dot(out, &ast.set).edges(out, &id, "");
@@ -343,7 +343,7 @@ impl ToDot<ast::Query> for AstToDot {
     }
 }
 impl ToDot<ast::QuerySet> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::QuerySet) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::QuerySet) -> Targets {
         use ast::QuerySet;
         match &ast {
             QuerySet::BagOp(_) => todo!(),
@@ -356,7 +356,7 @@ impl ToDot<ast::QuerySet> for AstToDot {
 }
 
 impl ToDot<ast::Select> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Select) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Select) -> Targets {
         let id = out.node_auto_labelled("Select").id();
 
         out.with_cluster("PROJECT", |mut cl| self.to_dot(&mut cl, &ast.project))
@@ -377,19 +377,19 @@ impl ToDot<ast::Select> for AstToDot {
 }
 
 impl ToDot<ast::WhereClause> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::WhereClause) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::WhereClause) -> Targets {
         self.to_dot(out, &ast.expr)
     }
 }
 
 impl ToDot<ast::HavingClause> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::HavingClause) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::HavingClause) -> Targets {
         self.to_dot(out, &ast.expr)
     }
 }
 
 impl ToDot<ast::LimitOffsetClause> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::LimitOffsetClause) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::LimitOffsetClause) -> Targets {
         let mut list = self.to_dot(out, &ast.limit);
         list.extend(self.to_dot(out, &ast.offset));
         list
@@ -397,7 +397,7 @@ impl ToDot<ast::LimitOffsetClause> for AstToDot {
 }
 
 impl ToDot<ast::Projection> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Projection) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Projection) -> Targets {
         let lbl = match &ast.setq {
             Some(ast::SetQuantifier::Distinct) => "Projection | Distinct",
             _ => "Projection | All",
@@ -429,7 +429,7 @@ impl ToDot<ast::Projection> for AstToDot {
 }
 
 impl ToDot<ast::ProjectItem> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::ProjectItem) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::ProjectItem) -> Targets {
         match ast {
             ast::ProjectItem::ProjectAll(all) => {
                 let id = out.node_auto_labelled("ProjectAll").id();
@@ -455,7 +455,7 @@ fn symbol_primitive_to_label(sym: &ast::SymbolPrimitive) -> String {
 }
 
 impl ToDot<ast::SymbolPrimitive> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::SymbolPrimitive) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::SymbolPrimitive) -> Targets {
         let lbl = symbol_primitive_to_label(ast);
         let id = out.node_auto_labelled(&lbl).id();
         vec![id]
@@ -463,7 +463,7 @@ impl ToDot<ast::SymbolPrimitive> for AstToDot {
 }
 
 impl ToDot<ast::VarRef> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::VarRef) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::VarRef) -> Targets {
         let lbl = symbol_primitive_to_label(&ast.name);
         let lbl = match &ast.qualifier {
             ast::ScopeQualifier::Unqualified => lbl,
@@ -476,25 +476,25 @@ impl ToDot<ast::VarRef> for AstToDot {
 }
 
 impl ToDot<ast::OrderByExpr> for AstToDot {
-    fn to_dot(&mut self, _out: &mut Scope, _ast: &ast::OrderByExpr) -> Targets {
+    fn to_dot(&mut self, _out: &mut Scope<'_, '_>, _ast: &ast::OrderByExpr) -> Targets {
         todo!("OrderByExpr");
     }
 }
 
 impl ToDot<ast::GroupByExpr> for AstToDot {
-    fn to_dot(&mut self, _out: &mut Scope, _ast: &ast::GroupByExpr) -> Targets {
+    fn to_dot(&mut self, _out: &mut Scope<'_, '_>, _ast: &ast::GroupByExpr) -> Targets {
         todo!("GroupByExpr");
     }
 }
 
 impl ToDot<ast::FromClause> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::FromClause) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::FromClause) -> Targets {
         self.to_dot(out, &ast.source)
     }
 }
 
 impl ToDot<ast::FromSource> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::FromSource) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::FromSource) -> Targets {
         match &ast {
             ast::FromSource::FromLet(fl) => self.to_dot(out, fl),
             ast::FromSource::Join(j) => self.to_dot(out, j),
@@ -503,7 +503,7 @@ impl ToDot<ast::FromSource> for AstToDot {
 }
 
 impl ToDot<ast::FromLet> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::FromLet) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::FromLet) -> Targets {
         let lbl = match &ast.kind {
             ast::FromLetKind::Scan => "Scan",
             ast::FromLetKind::Unpivot => "Unpivot",
@@ -520,7 +520,7 @@ impl ToDot<ast::FromLet> for AstToDot {
 }
 
 impl ToDot<ast::Join> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Join) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Join) -> Targets {
         let lbl = match &ast.kind {
             ast::JoinKind::Inner => "Inner Join",
             ast::JoinKind::Left => "Left Join",
@@ -540,7 +540,7 @@ impl ToDot<ast::Join> for AstToDot {
 }
 
 impl ToDot<ast::JoinSpec> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::JoinSpec) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::JoinSpec) -> Targets {
         match &ast {
             ast::JoinSpec::On(fl) => {
                 let id = out.node_auto_labelled("On").id();
@@ -558,7 +558,7 @@ impl ToDot<ast::JoinSpec> for AstToDot {
 }
 
 impl ToDot<ast::Call> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Call) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Call) -> Targets {
         let id = out.node_auto_labelled("Call").id();
 
         self.to_dot(out, &ast.func_name).edges(out, &id, "name");
@@ -569,7 +569,7 @@ impl ToDot<ast::Call> for AstToDot {
 }
 
 impl ToDot<ast::CallArg> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::CallArg) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::CallArg) -> Targets {
         use ast::CallArg;
         match ast {
             ast::CallArg::Star() => vec![out.node_auto_labelled("*").id()],
@@ -606,7 +606,7 @@ impl ToDot<ast::CallArg> for AstToDot {
 }
 
 impl ToDot<ast::CallAgg> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::CallAgg) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::CallAgg) -> Targets {
         // Set quantifier is defined in `CallAgg.args`
         let id = out.node_auto_labelled("CallAgg").id();
 
@@ -618,7 +618,7 @@ impl ToDot<ast::CallAgg> for AstToDot {
 }
 
 impl ToDot<ast::Path> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::Path) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::Path) -> Targets {
         let id = out.node_auto_labelled("Path").id();
 
         self.to_dot(out, &ast.root).edges(out, &id, "root");
@@ -629,7 +629,7 @@ impl ToDot<ast::Path> for AstToDot {
 }
 
 impl ToDot<ast::PathStep> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::PathStep) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::PathStep) -> Targets {
         match &ast {
             ast::PathStep::PathExpr(e) => self.to_dot(out, e),
             ast::PathStep::PathWildCard => vec![out.node_auto_labelled("*").id()],
@@ -639,7 +639,7 @@ impl ToDot<ast::PathStep> for AstToDot {
 }
 
 impl ToDot<ast::PathExpr> for AstToDot {
-    fn to_dot(&mut self, out: &mut Scope, ast: &ast::PathExpr) -> Targets {
+    fn to_dot(&mut self, out: &mut Scope<'_, '_>, ast: &ast::PathExpr) -> Targets {
         let id = out.node_auto_labelled("PathExpr").id();
 
         self.to_dot(out, &ast.index).edges(out, &id, "index");
@@ -649,7 +649,7 @@ impl ToDot<ast::PathExpr> for AstToDot {
 }
 
 impl ToDot<ast::Let> for AstToDot {
-    fn to_dot(&mut self, _out: &mut Scope, _ast: &ast::Let) -> Targets {
+    fn to_dot(&mut self, _out: &mut Scope<'_, '_>, _ast: &ast::Let) -> Targets {
         todo!("Let");
     }
 }

--- a/extension/partiql-extension-visualize/src/lib.rs
+++ b/extension/partiql-extension-visualize/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[cfg(feature = "visualize-dot")]
 mod ast_to_dot;
 

--- a/extension/partiql-extension-visualize/src/plan_to_dot.rs
+++ b/extension/partiql-extension-visualize/src/plan_to_dot.rs
@@ -12,7 +12,7 @@ use crate::common::{ToDotGraph, FG_COLOR};
 pub struct PlanToDot {}
 
 impl PlanToDot {
-    pub(crate) fn to_dot(&self, scope: &mut Scope, plan: &LogicalPlan<BindingsOp>) {
+    pub(crate) fn to_dot(&self, scope: &mut Scope<'_, '_>, plan: &LogicalPlan<BindingsOp>) {
         let mut graph_nodes = HashMap::new();
         for (opid, op) in plan.operators_by_id() {
             graph_nodes.insert(opid, self.op_to_dot(scope, op));
@@ -29,7 +29,7 @@ impl PlanToDot {
         }
     }
 
-    fn op_to_dot(&self, scope: &mut Scope, op: &BindingsOp) -> NodeId {
+    fn op_to_dot(&self, scope: &mut Scope<'_, '_>, op: &BindingsOp) -> NodeId {
         let mut node = scope.node_auto();
         let label = match op {
             BindingsOp::Scan(s) => {

--- a/partiql-ast-passes/src/lib.rs
+++ b/partiql-ast-passes/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! The PartiQL Abstract Syntax Tree (AST) passes.
 //!
 //! # Note

--- a/partiql-ast/partiql-ast-macros/src/lib.rs
+++ b/partiql-ast/partiql-ast-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use darling::{FromDeriveInput, FromField, FromVariant};
 use inflector::Inflector;
 use proc_macro2::TokenStream;

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! The PartiQL Abstract Syntax Tree (AST).
 //!
 //! # Note

--- a/partiql-catalog/src/context.rs
+++ b/partiql-catalog/src/context.rs
@@ -3,11 +3,11 @@ use std::any::Any;
 use std::fmt::Debug;
 
 pub trait Bindings<T>: Debug {
-    fn get(&self, name: &BindingsName) -> Option<&T>;
+    fn get(&self, name: &BindingsName<'_>) -> Option<&T>;
 }
 
 impl Bindings<Value> for Tuple {
-    fn get(&self, name: &BindingsName) -> Option<&Value> {
+    fn get(&self, name: &BindingsName<'_>) -> Option<&Value> {
         self.get(name)
     }
 }

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -57,7 +57,7 @@ pub type BaseTableExprResult<'a> =
 pub trait BaseTableExpr: Debug {
     fn evaluate<'c>(
         &self,
-        args: &[Cow<Value>],
+        args: &[Cow<'_, Value>],
         ctx: &'c dyn SessionContext<'c>,
     ) -> BaseTableExprResult<'c>;
 }
@@ -114,9 +114,9 @@ pub enum CatalogErrorKind {
 pub trait Catalog: Debug {
     fn add_table_function(&mut self, info: TableFunction) -> Result<ObjectId, CatalogError>;
 
-    fn add_type_entry(&mut self, entry: TypeEnvEntry) -> Result<ObjectId, CatalogError>;
+    fn add_type_entry(&mut self, entry: TypeEnvEntry<'_>) -> Result<ObjectId, CatalogError>;
 
-    fn get_function(&self, name: &str) -> Option<FunctionEntry>;
+    fn get_function(&self, name: &str) -> Option<FunctionEntry<'_>>;
 
     fn resolve_type(&self, name: &str) -> Option<TypeEntry>;
 }
@@ -224,7 +224,7 @@ impl Catalog for PartiqlCatalog {
         }
     }
 
-    fn add_type_entry(&mut self, entry: TypeEnvEntry) -> Result<ObjectId, CatalogError> {
+    fn add_type_entry(&mut self, entry: TypeEnvEntry<'_>) -> Result<ObjectId, CatalogError> {
         let id = self
             .types
             .add(entry.name.as_ref(), entry.aliases.as_slice(), entry.ty);
@@ -238,7 +238,7 @@ impl Catalog for PartiqlCatalog {
         }
     }
 
-    fn get_function(&self, name: &str) -> Option<FunctionEntry> {
+    fn get_function(&self, name: &str) -> Option<FunctionEntry<'_>> {
         self.functions
             .find_by_name(name)
             .map(|(eid, entry)| FunctionEntry {

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use crate::call_defs::CallDef;
 
 use partiql_types::PartiqlType;

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use crate::generator::{Generator, GeneratorConfig};
 use crate::reader::read_schema;
 use crate::writer::Writer;

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[inline]
 pub(crate) fn lower(
     catalog: &dyn Catalog,
-    parsed: &Parsed,
+    parsed: &Parsed<'_>,
 ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
     let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
     planner.lower(parsed)

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -44,7 +44,7 @@ pub mod basic {
         T: Debug,
     {
         #[inline]
-        fn get(&self, name: &BindingsName) -> Option<&T> {
+        fn get(&self, name: &BindingsName<'_>) -> Option<&T> {
             let idx = match name {
                 BindingsName::CaseSensitive(s) => self.sensitive.get(s.as_ref()),
                 BindingsName::CaseInsensitive(s) => {

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -65,7 +65,7 @@ impl Evaluable for ErrorNode {
         panic!("ErrorNode will not be evaluated")
     }
 
-    fn update_input(&mut self, _input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, _input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         panic!("ErrorNode will not be evaluated")
     }
 }

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -247,7 +247,7 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
     }
 
     /// Evaluate the input argument expressions in [`self.args`] in the environment, type check them,
-    /// and convert them into an array of `N` `Cow<Value>`s.
+    /// and convert them into an array of `N` `Cow<'_, Value>`s.
     ///
     /// If type-checking fails, the appropriate failure case of [`ArgCheckControlFlow`] is returned,
     /// else [`ArgCheckControlFlow::Continue`] is returned containing the `N` values.
@@ -255,7 +255,7 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
         &'a self,
         bindings: &'a Tuple,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> ControlFlow<Value, [Cow<Value>; N]>
+    ) -> ControlFlow<Value, [Cow<'_, Value>; N]>
     where
         'c: 'a,
     {

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -41,7 +41,7 @@ pub enum EvalType {
 /// `Evaluable` represents each evaluation operator in the evaluation plan as an evaluable entity.
 pub trait Evaluable: Debug {
     fn evaluate<'c>(&mut self, ctx: &'c dyn EvalContext<'c>) -> Value;
-    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext);
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext<'_>);
     fn get_vars(&self) -> Option<&[String]> {
         None
     }
@@ -140,7 +140,7 @@ impl Evaluable for EvalScan {
         Value::Bag(Box::new(value))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 
@@ -337,7 +337,7 @@ impl Evaluable for EvalJoin {
         Value::Bag(Box::new(output_bag))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 
@@ -744,7 +744,7 @@ impl Evaluable for EvalGroupBy {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -789,7 +789,7 @@ impl Evaluable for EvalPivot {
         Value::from(tuple)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -847,7 +847,7 @@ impl Evaluable for EvalUnpivot {
         Value::from(unpivoted)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 
@@ -894,7 +894,7 @@ impl Evaluable for EvalFilter {
         Value::from(filtered.collect::<Bag>())
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -939,7 +939,7 @@ impl Evaluable for EvalHaving {
         Value::from(filtered.collect::<Bag>())
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1013,7 +1013,7 @@ impl Evaluable for EvalOrderBy {
         Value::from(List::from(values))
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1075,7 +1075,7 @@ impl Evaluable for EvalLimitOffset {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1112,7 +1112,7 @@ impl Evaluable for EvalSelectValue {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1173,7 +1173,7 @@ impl Evaluable for EvalSelect {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1210,7 +1210,7 @@ impl Evaluable for EvalSelectAll {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1237,7 +1237,7 @@ impl Evaluable for EvalExprQuery {
         self.expr.evaluate(&input_value, ctx).into_owned()
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1266,7 +1266,7 @@ impl Evaluable for EvalDistinct {
         }
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1281,7 +1281,7 @@ impl Evaluable for EvalSink {
         self.input.take().unwrap_or_else(|| Missing)
     }
 
-    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
         self.input = Some(input);
     }
 }
@@ -1318,7 +1318,7 @@ impl EvalExpr for EvalSubQueryExpr {
     {
         let bindings = MapBindings::from(bindings);
         let value = {
-            let nested_ctx: NestedContext = NestedContext::new(bindings, ctx);
+            let nested_ctx: NestedContext<'_, '_> = NestedContext::new(bindings, ctx);
 
             let mut plan = self.plan.borrow_mut();
             if let Ok(evaluated) = plan.execute_mut(&nested_ctx) {
@@ -1377,7 +1377,7 @@ impl Evaluable for EvalOuterUnion {
         Value::from(Bag::from(vals))
     }
 
-    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext<'_>) {
         match branch_num {
             0 => self.l_input = Some(input),
             1 => self.r_input = Some(input),
@@ -1433,7 +1433,7 @@ impl Evaluable for EvalOuterIntersect {
         Value::from(bag)
     }
 
-    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext<'_>) {
         match branch_num {
             0 => self.l_input = Some(input),
             1 => self.r_input = Some(input),
@@ -1482,7 +1482,7 @@ impl Evaluable for EvalOuterExcept {
         Value::from(Bag::from(vals))
     }
 
-    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext) {
+    fn update_input(&mut self, input: Value, branch_num: u8, ctx: &dyn EvalContext<'_>) {
         match branch_num {
             0 => self.l_input = Some(input),
             1 => self.r_input = Some(input),

--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -43,7 +43,7 @@ impl BindEvalExpr for EvalCollFn {
             f: F,
         ) -> Result<Box<dyn EvalExpr>, BindError>
         where
-            F: Fn(ValueIter) -> Value + 'static,
+            F: Fn(ValueIter<'_>) -> Value + 'static,
         {
             UnaryValueExpr::create_typed::<{ STRICT }, _>(types, args, move |value| {
                 value.sequence_iter().map(&f).unwrap_or(Missing)

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -65,7 +65,7 @@ fn as_str(v: &Value) -> Option<&str> {
 }
 
 #[inline]
-fn as_name(v: &Value) -> Option<BindingsName> {
+fn as_name(v: &Value) -> Option<BindingsName<'_>> {
     as_str(v).map(|key| BindingsName::CaseInsensitive(Cow::Borrowed(key)))
 }
 
@@ -189,7 +189,7 @@ impl BindEvalExpr for EvalVarRef {
 }
 
 #[inline]
-fn borrow_or_missing(value: Option<&Value>) -> Cow<Value> {
+fn borrow_or_missing(value: Option<&Value>) -> Cow<'_, Value> {
     value.map_or_else(|| Cow::Owned(Missing), Cow::Borrowed)
 }
 

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 pub mod env;
 pub mod error;
 pub mod eval;

--- a/partiql-ir/src/lib.rs
+++ b/partiql-ir/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/partiql-irgen/src/lib.rs
+++ b/partiql-irgen/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -25,7 +25,7 @@ impl<'c> LogicalPlanner<'c> {
     #[inline]
     pub fn lower(
         &self,
-        parsed: &Parsed,
+        parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         let q = &parsed.ast;
         let catalog = PartiqlCatalog::default();
@@ -56,13 +56,13 @@ mod tests {
     use partiql_value::{bag, tuple, DateTime, Value};
 
     #[track_caller]
-    fn parse(text: &str) -> Parsed {
+    fn parse(text: &str) -> Parsed<'_> {
         Parser::default().parse(text).unwrap()
     }
 
     #[track_caller]
     fn lower(
-        parsed: &Parsed,
+        parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         let catalog = PartiqlCatalog::default();
         let planner = LogicalPlanner::new(&catalog);

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use crate::lower::AstToLogical;
 
 use partiql_ast_passes::error::AstTransformationError;

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -257,7 +257,7 @@ impl<'c> PlanTyper<'c> {
     }
 
     fn type_vexpr(&mut self, v: &ValueExpr, lookup_order: LookupOrder) {
-        fn binding_to_sym(binding: &BindingsName) -> SymbolPrimitive {
+        fn binding_to_sym(binding: &BindingsName<'_>) -> SymbolPrimitive {
             match binding {
                 BindingsName::CaseSensitive(s) => SymbolPrimitive {
                     value: s.to_string(),
@@ -893,7 +893,7 @@ mod tests {
     fn type_query(
         mode: TypingMode,
         query: &str,
-        type_env_entry: TypeEnvEntry,
+        type_env_entry: TypeEnvEntry<'_>,
     ) -> Result<PartiqlType, TypeErr> {
         let mut catalog = PartiqlCatalog::default();
         let _oid = catalog.add_type_entry(type_env_entry);
@@ -910,13 +910,13 @@ mod tests {
     }
 
     #[track_caller]
-    fn parse(text: &str) -> Parsed {
+    fn parse(text: &str) -> Parsed<'_> {
         Parser::default().parse(text).unwrap()
     }
 
     #[track_caller]
     fn lower(
-        parsed: &Parsed,
+        parsed: &Parsed<'_>,
         catalog: &dyn Catalog,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         let planner = LogicalPlanner::new(catalog);

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! A PartiQL logical plan.
 //!
 //! This module contains the structures for a PartiQL logical plan. Three main entities in the

--- a/partiql-parser/src/error.rs
+++ b/partiql-parser/src/error.rs
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn illegal_state() {
-        let e1: ParseError<BytePosition> = ParseError::IllegalState("uh oh".to_string());
+        let e1: ParseError<'_, BytePosition> = ParseError::IllegalState("uh oh".to_string());
 
         let e2 = e1.map_loc(|x| x);
         assert_eq!(e2.to_string(), "Illegal State: uh oh")

--- a/partiql-parser/src/lexer.rs
+++ b/partiql-parser/src/lexer.rs
@@ -983,7 +983,7 @@ mod tests {
 
         let mut offset_tracker = LineOffsetTracker::default();
         let nonnested_lex = CommentLexer::new(comments, &mut offset_tracker);
-        let toks: Result<Vec<_>, Spanned<LexError, ByteOffset>> = nonnested_lex.collect();
+        let toks: Result<Vec<_>, Spanned<LexError<'_>, ByteOffset>> = nonnested_lex.collect();
         assert!(toks.is_err());
         let error = toks.unwrap_err();
         assert!(matches!(
@@ -1299,7 +1299,7 @@ mod tests {
         let query = r#" `/*12345678`"#;
         let mut offset_tracker = LineOffsetTracker::default();
         let ion_lexer = EmbeddedIonLexer::new(query, &mut offset_tracker);
-        let toks: Result<Vec<_>, Spanned<LexError, ByteOffset>> = ion_lexer.collect();
+        let toks: Result<Vec<_>, Spanned<LexError<'_>, ByteOffset>> = ion_lexer.collect();
         assert!(toks.is_err());
         let error = toks.unwrap_err();
         assert!(matches!(

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(rust_2018_idioms)]
 // Copyright Amazon.com, Inc. or its affiliates.
 
 //! Provides a parser for the [PartiQL][partiql] query language.

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -27,6 +27,7 @@ use partiql_source_map::metadata::LocationMap;
 #[allow(clippy::unused_unit)]
 #[allow(unused_variables)]
 #[allow(dead_code)]
+#[allow(rust_2018_idioms)]
 mod grammar {
     include!(concat!(env!("OUT_DIR"), "/partiql.rs"));
 }
@@ -53,7 +54,7 @@ pub(crate) struct ErrorData<'input> {
 pub(crate) type AstResult<'input> = Result<AstData, ErrorData<'input>>;
 
 /// Parse PartiQL query text into an AST.
-pub(crate) fn parse_partiql(s: &str) -> AstResult {
+pub(crate) fn parse_partiql(s: &str) -> AstResult<'_> {
     parse_partiql_with_state(s, ParserState::default())
 }
 
@@ -65,7 +66,7 @@ fn parse_partiql_with_state<'input, Id: IdGenerator>(
     let lexer = PreprocessingPartiqlLexer::new(s, &mut offsets, &BUILT_INS);
     let lexer = CommentSkippingLexer::new(lexer);
 
-    let result: LalrpopResult = grammar::TopLevelQueryParser::new().parse(s, &mut state, lexer);
+    let result: LalrpopResult<'_> = grammar::TopLevelQueryParser::new().parse(s, &mut state, lexer);
 
     let ParserState {
         locations, errors, ..
@@ -143,7 +144,7 @@ impl<'input> From<LalrpopError<'input>> for ParseError<'input, BytePosition> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn parse_partiql(s: &str) -> AstResult {
+    fn parse_partiql(s: &str) -> AstResult<'_> {
         super::parse_partiql(s)
     }
 
@@ -559,7 +560,7 @@ mod tests {
             }
         }
 
-        fn parse_partiql_null_id(s: &str) -> AstResult {
+        fn parse_partiql_null_id(s: &str) -> AstResult<'_> {
             super::parse_partiql_with_state(s, ParserState::new_null_id())
         }
 

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -104,7 +104,7 @@ pub(crate) fn strip_query(q: ast::AstNode<ast::Query>) -> ast::AstNode<ast::Quer
 // in a `Query` with `None` as the `OrderBy` and `LimitOffset`
 pub(crate) fn strip_query_set<Id>(
     qs: ast::AstNode<ast::QuerySet>,
-    state: &mut ParserState<Id>,
+    state: &mut ParserState<'_, Id>,
     lo: ByteOffset,
     hi: ByteOffset,
 ) -> ast::AstNode<ast::Query>

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -349,7 +349,7 @@ where
         self.parser.expect(&Token::OpenParen)?;
 
         let fn_expr_args = &fn_expr.patterns;
-        let mut patterns: Vec<(&[FnExprArgMatch], Substitutions)> = fn_expr_args
+        let mut patterns: Vec<(&[FnExprArgMatch<'_>], Substitutions<'_>)> = fn_expr_args
             .iter()
             .map(|args| (args.as_slice(), vec![]))
             .collect();
@@ -711,12 +711,12 @@ mod tests {
                 .map(|result| result.map(|(_, t, _)| t))
                 .collect::<Result<Vec<_>, _>>()
         }
-        fn lex(query: &str) -> Result<Vec<Token>, ParseError> {
+        fn lex(query: &str) -> Result<Vec<Token<'_>>, ParseError<'_>> {
             let mut offset_tracker = LineOffsetTracker::default();
             let lexer = PartiqlLexer::new(query, &mut offset_tracker);
             to_tokens(lexer)
         }
-        fn preprocess(query: &str) -> Result<Vec<Token>, ParseError> {
+        fn preprocess(query: &str) -> Result<Vec<Token<'_>>, ParseError<'_>> {
             let mut offset_tracker = LineOffsetTracker::default();
             let lexer = PreprocessingPartiqlLexer::new(query, &mut offset_tracker, &BUILT_INS);
             to_tokens(lexer)

--- a/partiql-parser/src/token_parser.rs
+++ b/partiql-parser/src/token_parser.rs
@@ -78,7 +78,10 @@ impl<'input, 'tracker> TokenParser<'input, 'tracker> {
     ///
     /// If there are no tokens to buffer or the match fails, returns [`Err`].
     #[inline]
-    pub fn expect(&mut self, target: &Token) -> Result<(), Spanned<LexError<'input>, ByteOffset>> {
+    pub fn expect(
+        &mut self,
+        target: &Token<'_>,
+    ) -> Result<(), Spanned<LexError<'input>, ByteOffset>> {
         match self.peek_n(0) {
             Some(((_, tok, _), _)) if target == tok => {
                 self.consumed_c += 1;

--- a/partiql-rewriter/src/lib.rs
+++ b/partiql-rewriter/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/partiql-source-map/src/lib.rs
+++ b/partiql-source-map/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 //! Source offset & position types and mapping-related helpers.
 
 pub mod line_offset_tracker;

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use itertools::Itertools;
 use std::collections::BTreeSet;
 use std::fmt::{Debug, Display, Formatter};

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -34,7 +34,7 @@ impl Bag {
     }
 
     #[inline]
-    pub fn iter(&self) -> BagIter {
+    pub fn iter(&self) -> BagIter<'_> {
         BagIter(self.0.iter())
     }
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -636,7 +636,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn as_tuple_ref(&self) -> Cow<Tuple> {
+    pub fn as_tuple_ref(&self) -> Cow<'_, Tuple> {
         if let Value::Tuple(t) = self {
             Cow::Borrowed(t)
         } else {
@@ -645,7 +645,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn as_bindings(&self) -> BindingIter {
+    pub fn as_bindings(&self) -> BindingIter<'_> {
         match self {
             Value::Tuple(t) => BindingIter::Tuple(t.pairs()),
             Value::Missing => BindingIter::Empty,
@@ -672,7 +672,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn as_bag_ref(&self) -> Cow<Bag> {
+    pub fn as_bag_ref(&self) -> Cow<'_, Bag> {
         if let Value::Bag(b) = self {
             Cow::Borrowed(b)
         } else {
@@ -690,7 +690,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn as_list_ref(&self) -> Cow<List> {
+    pub fn as_list_ref(&self) -> Cow<'_, List> {
         if let Value::List(l) = self {
             Cow::Borrowed(l)
         } else {
@@ -699,7 +699,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn iter(&self) -> ValueIter {
+    pub fn iter(&self) -> ValueIter<'_> {
         match self {
             Value::Null | Value::Missing => ValueIter::Single(None),
             Value::List(list) => ValueIter::List(list.iter()),
@@ -709,7 +709,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn sequence_iter(&self) -> Option<ValueIter> {
+    pub fn sequence_iter(&self) -> Option<ValueIter<'_>> {
         if self.is_sequence() {
             Some(self.iter())
         } else {
@@ -1213,15 +1213,15 @@ mod tests {
             "Rc<RefCell<Tuple>> size: {}",
             mem::size_of::<Rc<RefCell<Tuple>>>()
         );
-        println!("Cow<&Tuple> size: {}", mem::size_of::<Cow<&Tuple>>());
+        println!("Cow<&Tuple> size: {}", mem::size_of::<Cow<'_, &Tuple>>());
         println!("Value size: {}", mem::size_of::<Value>());
         println!("Option<Value> size: {}", mem::size_of::<Option<Value>>());
         println!(
             "Option<Option<Value>> size: {}",
             mem::size_of::<Option<Option<Value>>>()
         );
-        println!("Cow<Value> size: {}", mem::size_of::<Cow<Value>>());
-        println!("Cow<&Value> size: {}", mem::size_of::<Cow<&Value>>());
+        println!("Cow<'_, Value> size: {}", mem::size_of::<Cow<'_, Value>>());
+        println!("Cow<&Value> size: {}", mem::size_of::<Cow<'_, &Value>>());
 
         assert_eq!(mem::size_of::<Value>(), 16);
         assert_eq!(mem::size_of::<Option<Option<Value>>>(), 16);

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -46,7 +46,7 @@ impl List {
     }
 
     #[inline]
-    pub fn iter(&self) -> ListIter {
+    pub fn iter(&self) -> ListIter<'_> {
         ListIter(self.0.iter())
     }
 

--- a/partiql-value/src/tuple.rs
+++ b/partiql-value/src/tuple.rs
@@ -60,18 +60,18 @@ impl Tuple {
     }
 
     #[inline]
-    pub fn get(&self, attr: &BindingsName) -> Option<&Value> {
+    pub fn get(&self, attr: &BindingsName<'_>) -> Option<&Value> {
         self.find_value(attr).map(|i| &self.vals[i])
     }
 
     #[inline]
-    pub fn take_val(self, attr: &BindingsName) -> Option<Value> {
+    pub fn take_val(self, attr: &BindingsName<'_>) -> Option<Value> {
         self.find_value(attr)
             .and_then(|i| self.vals.into_iter().nth(i))
     }
 
     #[inline(always)]
-    fn find_value(&self, attr: &BindingsName) -> Option<usize> {
+    fn find_value(&self, attr: &BindingsName<'_>) -> Option<usize> {
         match attr {
             BindingsName::CaseSensitive(s) => {
                 self.attrs.iter().position(|a| a.as_str() == s.as_ref())
@@ -84,7 +84,7 @@ impl Tuple {
     }
 
     #[inline]
-    pub fn remove(&mut self, attr: &BindingsName) -> Option<Value> {
+    pub fn remove(&mut self, attr: &BindingsName<'_>) -> Option<Value> {
         match self.find_value(attr) {
             Some(i) => {
                 self.attrs.remove(i);
@@ -95,7 +95,7 @@ impl Tuple {
     }
 
     #[inline]
-    pub fn pairs(&self) -> PairsIter {
+    pub fn pairs(&self) -> PairsIter<'_> {
         PairsIter(zip(self.attrs.iter(), self.vals.iter()))
     }
 

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -53,7 +53,7 @@ mod tests {
 
     #[track_caller]
     #[inline]
-    fn parse(statement: &str) -> ParserResult {
+    fn parse(statement: &str) -> ParserResult<'_> {
         partiql_parser::Parser::default().parse(statement)
     }
 
@@ -61,7 +61,7 @@ mod tests {
     #[inline]
     fn lower(
         catalog: &dyn Catalog,
-        parsed: &Parsed,
+        parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
         planner.lower(parsed)

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[cfg(test)]
 mod tests {
     use partiql_ast_passes::error::AstTransformationError;

--- a/partiql/tests/extension_error.rs
+++ b/partiql/tests/extension_error.rs
@@ -87,7 +87,7 @@ pub(crate) struct EvalTestCtxTable {}
 impl BaseTableExpr for EvalTestCtxTable {
     fn evaluate<'c>(
         &self,
-        args: &[Cow<Value>],
+        args: &[Cow<'_, Value>],
         _ctx: &'c dyn SessionContext<'c>,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
@@ -124,7 +124,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[inline]
 pub(crate) fn lower(
     catalog: &dyn Catalog,
-    parsed: &Parsed,
+    parsed: &Parsed<'_>,
 ) -> partiql_logical::LogicalPlan<partiql_logical::BindingsOp> {
     let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
     planner.lower(parsed).expect("lower")

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -85,7 +85,7 @@ pub(crate) struct EvalTestCtxTable {}
 impl BaseTableExpr for EvalTestCtxTable {
     fn evaluate<'c>(
         &self,
-        args: &[Cow<Value>],
+        args: &[Cow<'_, Value>],
         ctx: &'c dyn SessionContext<'c>,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
@@ -150,7 +150,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
 #[inline]
 pub(crate) fn lower(
     catalog: &dyn Catalog,
-    parsed: &Parsed,
+    parsed: &Parsed<'_>,
 ) -> partiql_logical::LogicalPlan<partiql_logical::BindingsOp> {
     let planner = partiql_logical_planner::LogicalPlanner::new(catalog);
     planner.lower(parsed).expect("lower")


### PR DESCRIPTION
Add `#![deny(rust_2018_idioms)]` to all crates

The wording is a bit confusing for this, but this will result in an error for any code that uses *pre-rust 2018* idioms (for this codebase, most notably the `elided_lifetimes_in_paths` lint).

> Elided lifetime parameters can make it difficult to see at a glance that borrowing is occurring. This lint ensures that lifetime parameters are always explicitly stated, even if it is the '_ [placeholder lifetime](https://doc.rust-lang.org/reference/lifetime-elision.html#lifetime-elision-in-functions).
>
> This lint is “allow” by default because it has some known issues, and may require a significant transition for old code.

  -- from: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.ELIDED_LIFETIMES_IN_PATHS.html

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
