### PR TITLE
Add `#![deny(clippy::all)]` to all `lib.rs`

### DIFF
--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use ion_rs::data_source::ToIonDataSource;
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -221,7 +221,10 @@ mod tests {
 
         let parsed = parse(statement);
         let lowered = lower(&catalog, &parsed.expect("parse"));
-        let bindings = env.as_ref().map(|e| (e).into()).unwrap_or_default();
+        let bindings = env
+            .as_ref()
+            .map(std::convert::Into::into)
+            .unwrap_or_default();
         let out = evaluate(&catalog, lowered, bindings);
 
         assert!(out.is_bag());

--- a/extension/partiql-extension-ion/src/common.rs
+++ b/extension/partiql-extension-ion/src/common.rs
@@ -1,4 +1,4 @@
-/// The encoding to use when decoding/encoding Ion to/from PartiQL [`partiql_value::Value`]
+/// The encoding to use when decoding/encoding Ion to/from `PartiQL` [`partiql_value::Value`]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Encoding {
     /// 'Unlifted'/'Unlowered' Ion to/from PartiQL [`partiql_value::Value`]. [`partiql_value::Value`]s that do not have a direct

--- a/extension/partiql-extension-ion/src/decode.rs
+++ b/extension/partiql-extension-ion/src/decode.rs
@@ -11,7 +11,10 @@ use std::str::FromStr;
 use thiserror::Error;
 use time::Duration;
 
-use crate::common::*;
+use crate::common::{
+    Encoding, BAG_ANNOT, DATE_ANNOT, MISSING_ANNOT, RE_SET_TIME_PARTS, TIME_ANNOT, TIME_PARTS_HOUR,
+    TIME_PARTS_MINUTE, TIME_PARTS_SECOND, TIME_PARTS_TZ_HOUR, TIME_PARTS_TZ_MINUTE,
+};
 
 /// Errors in ion decoding.
 ///
@@ -63,6 +66,7 @@ pub struct IonDecoderConfig {
 
 impl IonDecoderConfig {
     /// Set the mode to `mode`
+    #[must_use]
     pub fn with_mode(mut self, mode: crate::Encoding) -> Self {
         self.mode = mode;
         self
@@ -84,6 +88,7 @@ pub struct IonDecoderBuilder {
 
 impl IonDecoderBuilder {
     /// Create the builder from 'config'
+    #[must_use]
     pub fn new(config: IonDecoderConfig) -> Self {
         Self { config }
     }

--- a/extension/partiql-extension-ion/src/encode.rs
+++ b/extension/partiql-extension-ion/src/encode.rs
@@ -45,6 +45,7 @@ pub struct IonEncoderConfig {
 
 impl IonEncoderConfig {
     /// Set the mode to `mode`
+    #[must_use]
     pub fn with_mode(mut self, mode: crate::Encoding) -> Self {
         self.mode = mode;
         self
@@ -66,6 +67,7 @@ pub struct IonEncoderBuilder {
 
 impl IonEncoderBuilder {
     /// Create the builder from 'config'
+    #[must_use]
     pub fn new(config: IonEncoderConfig) -> Self {
         Self { config }
     }
@@ -214,7 +216,7 @@ where
     }
 
     fn encode_decimal(&mut self, val: &Decimal) -> IonEncodeResult {
-        let scale = val.scale() as i64;
+        let scale = i64::from(val.scale());
         let mantissa = val.mantissa();
         let dec = ion_rs::Decimal::new(mantissa, -scale);
         Ok(self.writer.write_decimal(&dec)?)
@@ -234,9 +236,13 @@ where
                 let ts = ion_rs::Timestamp::with_ymd(
                     ts.year() as u32,
                     ts.month() as u32,
-                    ts.day() as u32,
+                    u32::from(ts.day()),
                 )
-                .with_hms(ts.hour() as u32, ts.minute() as u32, ts.second() as u32)
+                .with_hms(
+                    u32::from(ts.hour()),
+                    u32::from(ts.minute()),
+                    u32::from(ts.second()),
+                )
                 .with_nanoseconds(ts.nanosecond())
                 .build_at_unknown_offset()?;
 
@@ -246,11 +252,15 @@ where
                 let ts = ion_rs::Timestamp::with_ymd(
                     ts.year() as u32,
                     ts.month() as u32,
-                    ts.day() as u32,
+                    u32::from(ts.day()),
                 )
-                .with_hms(ts.hour() as u32, ts.minute() as u32, ts.second() as u32)
+                .with_hms(
+                    u32::from(ts.hour()),
+                    u32::from(ts.minute()),
+                    u32::from(ts.second()),
+                )
                 .with_nanoseconds(ts.nanosecond())
-                .build_at_offset(ts.offset().whole_minutes() as i32)?;
+                .build_at_offset(i32::from(ts.offset().whole_minutes()))?;
 
                 Ok(self.writer.write_timestamp(&ts)?)
             }
@@ -324,9 +334,12 @@ where
         self.inner
             .writer
             .set_annotations(std::iter::once(DATE_ANNOT));
-        let ts =
-            ion_rs::Timestamp::with_ymd(date.year() as u32, date.month() as u32, date.day() as u32)
-                .build()?;
+        let ts = ion_rs::Timestamp::with_ymd(
+            date.year() as u32,
+            date.month() as u32,
+            u32::from(date.day()),
+        )
+        .build()?;
 
         Ok(self.inner.writer.write_timestamp(&ts)?)
     }
@@ -336,19 +349,19 @@ where
         writer.set_annotations(std::iter::once(TIME_ANNOT));
         writer.step_in(IonType::Struct)?;
         writer.set_field_name(TIME_PART_HOUR_KEY);
-        writer.write_i64(time.hour() as i64)?;
+        writer.write_i64(i64::from(time.hour()))?;
         writer.set_field_name(TIME_PART_MINUTE_KEY);
-        writer.write_i64(time.minute() as i64)?;
+        writer.write_i64(i64::from(time.minute()))?;
         writer.set_field_name(TIME_PART_SECOND_KEY);
 
-        let seconds = Duration::new(time.second() as i64, time.nanosecond() as i32);
+        let seconds = Duration::new(i64::from(time.second()), time.nanosecond() as i32);
         writer.write_f64(seconds.as_seconds_f64())?;
 
         if let Some(offset) = offset {
             writer.set_field_name(TIME_PART_TZ_HOUR_KEY);
-            writer.write_i64(offset.whole_hours() as i64)?;
+            writer.write_i64(i64::from(offset.whole_hours()))?;
             writer.set_field_name(TIME_PART_TZ_MINUTE_KEY);
-            writer.write_i64(offset.minutes_past_hour() as i64)?;
+            writer.write_i64(i64::from(offset.minutes_past_hour()))?;
         }
 
         writer.step_out()?;

--- a/extension/partiql-extension-ion/src/lib.rs
+++ b/extension/partiql-extension-ion/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 mod common;
 pub mod decode;

--- a/extension/partiql-extension-ion/src/lib.rs
+++ b/extension/partiql-extension-ion/src/lib.rs
@@ -181,7 +181,7 @@ mod tests {
                 1,
                 2,
                 3,
-                400000000,
+                400_000_000,
                 Some(30),
             ),
         );
@@ -199,7 +199,7 @@ mod tests {
                 1,
                 2,
                 3,
-                400000000,
+                400_000_000,
                 None,
             ),
         );
@@ -297,7 +297,7 @@ mod tests {
                 1,
                 2,
                 3,
-                400000000,
+                400_000_000,
                 Some(30),
             ),
         );
@@ -315,7 +315,7 @@ mod tests {
                 1,
                 2,
                 3,
-                400000000,
+                400_000_000,
                 None,
             ),
         );
@@ -331,7 +331,7 @@ mod tests {
                     .build(),
             )
             .with_annotations(["$time"]),
-            DateTime::from_hms_nano(12, 11, 10, 80000000),
+            DateTime::from_hms_nano(12, 11, 10, 80_000_000),
         );
         assert_partiql_encoded_ion(
             "$time::{ hour: 12, minute: 11, second: 10.08, timezone_hour: 0, timezone_minute: 30}",
@@ -347,7 +347,7 @@ mod tests {
                     .build(),
             )
             .with_annotations(["$time"]),
-            DateTime::from_hms_nano_tz(12, 11, 10, 80000000, None, Some(30)),
+            DateTime::from_hms_nano_tz(12, 11, 10, 80_000_000, None, Some(30)),
         );
         assert_partiql_encoded_ion(
             "$date::1957-05-25T",

--- a/extension/partiql-extension-visualize/src/lib.rs
+++ b/extension/partiql-extension-visualize/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 #[cfg(feature = "visualize-dot")]
 mod ast_to_dot;

--- a/partiql-ast-passes/src/lib.rs
+++ b/partiql-ast-passes/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-//! The PartiQL Abstract Syntax Tree (AST) passes.
+//! The `PartiQL` Abstract Syntax Tree (AST) passes.
 //!
 //! # Note
 //!

--- a/partiql-ast-passes/src/lib.rs
+++ b/partiql-ast-passes/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 //! The PartiQL Abstract Syntax Tree (AST) passes.
 //!

--- a/partiql-ast-passes/src/partiql_typer.rs
+++ b/partiql-ast-passes/src/partiql_typer.rs
@@ -125,7 +125,7 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
         let ty = PartiqlType::new(kind);
         let id = *self.current_node();
         if let Some(c) = self.container_stack.last_mut() {
-            c.push(ty.clone())
+            c.push(ty.clone());
         }
         self.type_map.insert(id, ty);
         Traverse::Continue
@@ -165,7 +165,7 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
         self.type_map.insert(id, ty.clone());
 
         if let Some(c) = self.container_stack.last_mut() {
-            c.push(ty)
+            c.push(ty);
         }
 
         Traverse::Continue
@@ -188,7 +188,7 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
 
         self.type_map.insert(id, ty.clone());
         if let Some(s) = self.container_stack.last_mut() {
-            s.push(ty)
+            s.push(ty);
         }
         Traverse::Continue
     }
@@ -210,7 +210,7 @@ impl<'c, 'ast> Visitor<'ast> for AstPartiqlTyper<'c> {
 
         self.type_map.insert(id, ty.clone());
         if let Some(s) = self.container_stack.last_mut() {
-            s.push(ty)
+            s.push(ty);
         }
         Traverse::Continue
     }

--- a/partiql-ast/partiql-ast-macros/src/lib.rs
+++ b/partiql-ast/partiql-ast-macros/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use darling::{FromDeriveInput, FromField, FromVariant};
 use inflector::Inflector;

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -1,8 +1,8 @@
-//! A PartiQL abstract syntax tree (AST).
+//! A `PartiQL` abstract syntax tree (AST).
 //!
 //! This module contains the structures for the language AST.
 //! Two main entities in the module are [`Item`] and [`AstNode`]. `AstNode` represents an AST node
-//! and `Item` represents a PartiQL statement type, e.g. query, data definition language (DDL)
+//! and `Item` represents a `PartiQL` statement type, e.g. query, data definition language (DDL)
 //! data manipulation language (DML).
 
 // As more changes to this AST are expected, unless explicitly advised, using the structures exposed
@@ -409,10 +409,10 @@ pub enum Expr {
     Error,
 }
 
-/// `Lit` is mostly inspired by SQL-92 Literals standard and PartiQL specification.
+/// `Lit` is mostly inspired by SQL-92 Literals standard and `PartiQL` specification.
 /// See section 5.3 in the following:
 /// <https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt>
-/// and Section 2 of the following (Figure 1: BNF Grammar for PartiQL Values):
+/// and Section 2 of the following (Figure 1: BNF Grammar for `PartiQL` Values):
 /// <https://partiql.org/assets/PartiQL-Specification.pdf>
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -745,7 +745,7 @@ pub struct FromLet {
     pub by_alias: Option<SymbolPrimitive>,
 }
 
-/// Indicates the type of FromLet, see the following for more details:
+/// Indicates the type of `FromLet`, see the following for more details:
 /// https:///github.com/partiql/partiql-lang-kotlin/issues/242
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -784,7 +784,7 @@ pub enum JoinSpec {
     Natural,
 }
 
-/// GROUP BY <grouping_strategy> <group_key>[, <group_key>]... \[AS <symbol>\]
+/// GROUP BY <`grouping_strategy`> <`group_key`>[, <`group_key`>]... \[AS <symbol>\]
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupByExpr {
@@ -813,7 +813,7 @@ pub struct GroupKey {
     pub as_alias: Option<SymbolPrimitive>,
 }
 
-/// ORDER BY <sort_spec>...
+/// ORDER BY <`sort_spec`>...
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OrderByExpr {
@@ -852,7 +852,7 @@ pub enum NullOrderingSpec {
     Last,
 }
 
-/// Represents all possible PartiQL data types.
+/// Represents all possible `PartiQL` data types.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Type {

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 //! The PartiQL Abstract Syntax Tree (AST).
 //!

--- a/partiql-ast/src/lib.rs
+++ b/partiql-ast/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-//! The PartiQL Abstract Syntax Tree (AST).
+//! The `PartiQL` Abstract Syntax Tree (AST).
 //!
 //! # Note
 //!

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -556,9 +556,9 @@ mod tests {
         impl<'ast> Visitor<'ast> for Accum {
             fn enter_lit(&mut self, literal: &'ast Lit) -> Traverse {
                 match literal {
-                    Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
-                    Lit::Int16Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
-                    Lit::Int32Lit(l) => self.val.get_or_insert(0i64).add_assign(*l as i64),
+                    Lit::Int8Lit(l) => self.val.get_or_insert(0i64).add_assign(i64::from(*l)),
+                    Lit::Int16Lit(l) => self.val.get_or_insert(0i64).add_assign(i64::from(*l)),
+                    Lit::Int32Lit(l) => self.val.get_or_insert(0i64).add_assign(i64::from(*l)),
                     Lit::Int64Lit(l) => self.val.get_or_insert(0i64).add_assign(l),
                     _ => {}
                 }

--- a/partiql-catalog/src/call_defs.rs
+++ b/partiql-catalog/src/call_defs.rs
@@ -29,11 +29,7 @@ pub struct CallDef {
 }
 
 impl CallDef {
-    pub fn lookup(
-        &self,
-        args: &Vec<CallArgument>,
-        name: &str,
-    ) -> Result<ValueExpr, CallLookupError> {
+    pub fn lookup(&self, args: &[CallArgument], name: &str) -> Result<ValueExpr, CallLookupError> {
         'overload: for overload in &self.overloads {
             let formals = &overload.input;
             if formals.len() != args.len() {

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -74,6 +74,7 @@ pub struct TableFunction {
 }
 
 impl TableFunction {
+    #[must_use]
     pub fn new(info: Box<dyn BaseTableFunctionInfo>) -> Self {
         TableFunction { info }
     }
@@ -87,6 +88,7 @@ pub struct CatalogError {
 }
 
 impl CatalogError {
+    #[must_use]
     pub fn new(errors: Vec<CatalogErrorKind>) -> Self {
         CatalogError { errors }
     }
@@ -130,6 +132,7 @@ pub struct TypeEnvEntry<'a> {
 }
 
 impl<'a> TypeEnvEntry<'a> {
+    #[must_use]
     pub fn new(name: &str, aliases: &[&'a str], ty: PartiqlType) -> Self {
         TypeEnvEntry {
             name: UniCase::from(name.to_string()),
@@ -146,10 +149,12 @@ pub struct TypeEntry {
 }
 
 impl TypeEntry {
+    #[must_use]
     pub fn id(&self) -> &ObjectId {
         &self.id
     }
 
+    #[must_use]
     pub fn ty(&self) -> &PartiqlType {
         &self.ty
     }
@@ -170,6 +175,7 @@ pub enum FunctionEntryFunction {
 }
 
 impl<'a> FunctionEntry<'a> {
+    #[must_use]
     pub fn call_def(&'a self) -> &'a CallDef {
         match &self.function {
             FunctionEntryFunction::Table(tf) => tf.info.call_def(),
@@ -178,6 +184,7 @@ impl<'a> FunctionEntry<'a> {
         }
     }
 
+    #[must_use]
     pub fn plan_eval(&'a self) -> Box<dyn BaseTableExpr> {
         match &self.function {
             FunctionEntryFunction::Table(tf) => tf.info.plan_eval(),
@@ -288,14 +295,14 @@ impl<T> CatalogEntrySet<T> {
         let name = UniCase::from(name);
         let aliases: Vec<UniCase<String>> = aliases
             .iter()
-            .map(|a| UniCase::from(a.to_string()))
+            .map(|a| UniCase::from((*a).to_string()))
             .collect();
 
-        aliases.iter().for_each(|a| {
+        for a in &aliases {
             if self.by_alias.contains_key(a) {
-                errors.push(CatalogErrorKind::EntryExists(a.as_ref().to_string()))
+                errors.push(CatalogErrorKind::EntryExists(a.as_ref().to_string()));
             }
-        });
+        }
 
         if self.by_name.contains_key(&name) {
             errors.push(CatalogErrorKind::EntryExists(name.to_string()));
@@ -311,7 +318,7 @@ impl<T> CatalogEntrySet<T> {
             true => {
                 self.by_name.insert(name, id);
 
-                for a in aliases.into_iter() {
+                for a in aliases {
                     self.by_alias.insert(a, id);
                 }
 

--- a/partiql-catalog/src/lib.rs
+++ b/partiql-catalog/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use crate::call_defs::CallDef;
 

--- a/partiql-conformance-test-generator/src/lib.rs
+++ b/partiql-conformance-test-generator/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use crate::generator::{Generator, GeneratorConfig};
 use crate::reader::read_schema;

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -4,7 +4,7 @@ use std::fmt::Debug;
 use unicase::UniCase;
 
 pub mod basic {
-    use super::*;
+    use super::{Bindings, BindingsName, Debug, Tuple, UniCase, Value};
     use std::collections::HashMap;
 
     #[derive(Debug, Clone)]
@@ -59,7 +59,7 @@ pub mod basic {
         fn from(t: &Tuple) -> Self {
             let mut bindings = MapBindings::default();
             for (k, v) in t.pairs() {
-                bindings.insert(k, v.clone())
+                bindings.insert(k, v.clone());
             }
             bindings
         }

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -280,7 +280,7 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
             match ArgC::arg_check(typ, arg) {
                 ArgCheckControlFlow::Continue(v) => {
                     if propagate.is_none() {
-                        result.push(v)
+                        result.push(v);
                     }
                 }
                 ArgCheckControlFlow::Propagate(v) => {

--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -46,7 +46,7 @@ impl BindEvalExpr for EvalCollFn {
             F: Fn(ValueIter<'_>) -> Value + 'static,
         {
             UnaryValueExpr::create_typed::<{ STRICT }, _>(types, args, move |value| {
-                value.sequence_iter().map(&f).unwrap_or(Missing)
+                value.sequence_iter().map_or(Missing, &f)
             })
         }
         let boolean_elems = [PartiqlType::any_of([

--- a/partiql-eval/src/eval/expr/data_types.rs
+++ b/partiql-eval/src/eval/expr/data_types.rs
@@ -101,7 +101,7 @@ impl EvalExpr for EvalBagExpr {
     }
 }
 
-/// Represents a PartiQL evaluation `IS` operator, e.g. `a IS INT`.
+/// Represents a `PartiQL` evaluation `IS` operator, e.g. `a IS INT`.
 #[derive(Debug)]
 pub(crate) struct EvalIsTypeExpr {
     pub(crate) expr: Box<dyn EvalExpr>,

--- a/partiql-eval/src/eval/expr/datetime.rs
+++ b/partiql-eval/src/eval/expr/datetime.rs
@@ -38,7 +38,7 @@ impl BindEvalExpr for EvalExtractFn {
         #[inline]
         fn total_seconds(second: u8, nanosecond: u32) -> Value {
             const NANOSECOND_SCALE: u32 = 9;
-            let total = Duration::new(second as u64, nanosecond).as_nanos() as i128;
+            let total = Duration::new(u64::from(second), nanosecond).as_nanos() as i128;
             Decimal::from_i128_with_scale(total, NANOSECOND_SCALE).into()
         }
 

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -11,7 +11,7 @@ use partiql_types::{
     ArrayType, BagType, PartiqlType, StructType, TypeKind, TYPE_ANY, TYPE_BOOL, TYPE_NUMERIC_TYPES,
 };
 use partiql_value::Value::{Boolean, Missing, Null};
-use partiql_value::{BinaryAnd, BinaryOr, EqualityValue, NullableEq, NullableOrd, Tuple, Value};
+use partiql_value::{BinaryAnd, EqualityValue, NullableEq, NullableOrd, Tuple, Value};
 
 use std::borrow::{Borrow, Cow};
 use std::fmt::{Debug, Formatter};
@@ -86,7 +86,7 @@ impl BindEvalExpr for EvalOpUnary {
         };
 
         match self {
-            EvalOpUnary::Pos => unop([any_num], |operand| operand.clone()),
+            EvalOpUnary::Pos => unop([any_num], std::clone::Clone::clone),
             EvalOpUnary::Neg => unop([any_num], |operand| -operand),
             EvalOpUnary::Not => unop([TYPE_BOOL], |operand| !operand),
         }
@@ -184,8 +184,8 @@ impl BindEvalExpr for EvalOpBinary {
         }
 
         match self {
-            EvalOpBinary::And => logical!(AndCheck, |lhs, rhs| lhs.and(rhs)),
-            EvalOpBinary::Or => logical!(OrCheck, |lhs, rhs| lhs.or(rhs)),
+            EvalOpBinary::And => logical!(AndCheck, partiql_value::BinaryAnd::and),
+            EvalOpBinary::Or => logical!(OrCheck, partiql_value::BinaryOr::or),
             EvalOpBinary::Eq => equality!(|lhs, rhs| {
                 let wrap = EqualityValue::<false, Value>;
                 NullableEq::eq(&wrap(lhs), &wrap(rhs))
@@ -268,7 +268,7 @@ impl BindEvalExpr for EvalOpBinary {
     }
 }
 
-/// Represents an evaluation PartiQL `BETWEEN` operator, e.g. `x BETWEEN 10 AND 20`.
+/// Represents an evaluation `PartiQL` `BETWEEN` operator, e.g. `x BETWEEN 10 AND 20`.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct EvalBetweenExpr {}
 

--- a/partiql-eval/src/eval/expr/pattern_match.rs
+++ b/partiql-eval/src/eval/expr/pattern_match.rs
@@ -162,7 +162,7 @@ fn write_re_pattern<F>(
             (_, false) if Some(ch) == escape_ch => escaped = true,
             ('%', false) => {
                 if !is_any {
-                    buf.push_str(".*?")
+                    buf.push_str(".*?");
                 }
                 wildcard = true;
             }
@@ -184,35 +184,29 @@ mod tests {
 
     #[test]
     fn like() {
-        assert_eq!(like_to_re_pattern("foo", Some('\\')), r#"^foo$"#);
-        assert_eq!(like_to_re_pattern("%foo", Some('\\')), r#"^.*?foo$"#);
-        assert_eq!(like_to_re_pattern("foo%", Some('\\')), r#"^foo.*?$"#);
-        assert_eq!(like_to_re_pattern("foo%bar", Some('\\')), r#"^foo.*?bar$"#);
-        assert_eq!(like_to_re_pattern("foo%%bar", Some('\\')), r#"^foo.*?bar$"#);
-        assert_eq!(
-            like_to_re_pattern("foo%%%bar", Some('\\')),
-            r#"^foo.*?bar$"#
-        );
-        assert_eq!(
-            like_to_re_pattern("foo%%%%bar", Some('\\')),
-            r#"^foo.*?bar$"#
-        );
+        assert_eq!(like_to_re_pattern("foo", Some('\\')), r"^foo$");
+        assert_eq!(like_to_re_pattern("%foo", Some('\\')), r"^.*?foo$");
+        assert_eq!(like_to_re_pattern("foo%", Some('\\')), r"^foo.*?$");
+        assert_eq!(like_to_re_pattern("foo%bar", Some('\\')), r"^foo.*?bar$");
+        assert_eq!(like_to_re_pattern("foo%%bar", Some('\\')), r"^foo.*?bar$");
+        assert_eq!(like_to_re_pattern("foo%%%bar", Some('\\')), r"^foo.*?bar$");
+        assert_eq!(like_to_re_pattern("foo%%%%bar", Some('\\')), r"^foo.*?bar$");
         assert_eq!(
             like_to_re_pattern("%foo%%%%bar%", Some('\\')),
-            r#"^.*?foo.*?bar.*?$"#
+            r"^.*?foo.*?bar.*?$"
         );
         assert_eq!(
             like_to_re_pattern("%foo%%%%bar\\%baz%", Some('\\')),
-            r#"^.*?foo.*?bar%baz.*?$"#
+            r"^.*?foo.*?bar%baz.*?$"
         );
         assert_eq!(
             like_to_re_pattern("%foo%%%%bar*%baz%", Some('*')),
-            r#"^.*?foo.*?bar%baz.*?$"#
+            r"^.*?foo.*?bar%baz.*?$"
         );
-        assert_eq!(like_to_re_pattern("_foo", Some('\\')), r#"^.foo$"#);
-        assert_eq!(like_to_re_pattern("foo_", Some('\\')), r#"^foo.$"#);
-        assert_eq!(like_to_re_pattern("foo_bar", Some('\\')), r#"^foo.bar$"#);
-        assert_eq!(like_to_re_pattern("foo__bar", Some('\\')), r#"^foo..bar$"#);
+        assert_eq!(like_to_re_pattern("_foo", Some('\\')), r"^.foo$");
+        assert_eq!(like_to_re_pattern("foo_", Some('\\')), r"^foo.$");
+        assert_eq!(like_to_re_pattern("foo_bar", Some('\\')), r"^foo.bar$");
+        assert_eq!(like_to_re_pattern("foo__bar", Some('\\')), r"^foo..bar$");
         assert_eq!(
             like_to_re_pattern("foo_.*?_bar", Some('\\')),
             r"^foo.\.\*\?.bar$"
@@ -229,10 +223,10 @@ mod tests {
 
     #[test]
     fn similar() {
-        assert_eq!(similar_to_re_pattern("(b|c)%", Some('\\')), r#"^(b|c).*?$"#);
+        assert_eq!(similar_to_re_pattern("(b|c)%", Some('\\')), r"^(b|c).*?$");
         assert_eq!(
             similar_to_re_pattern("%(b|d)%", Some('\\')),
-            r#"^.*?(b|d).*?$"#
+            r"^.*?(b|d).*?$"
         );
     }
 

--- a/partiql-eval/src/eval/expr/strings.rs
+++ b/partiql-eval/src/eval/expr/strings.rs
@@ -139,11 +139,9 @@ impl BindEvalExpr for EvalFnPosition {
             [TYPE_STRING, TYPE_STRING],
             args,
             |needle, haystack| match (needle, haystack) {
-                (Value::String(needle), Value::String(haystack)) => haystack
-                    .find(needle.as_ref())
-                    .map(|l| l + 1)
-                    .unwrap_or(0)
-                    .into(),
+                (Value::String(needle), Value::String(haystack)) => {
+                    haystack.find(needle.as_ref()).map_or(0, |l| l + 1).into()
+                }
                 _ => Missing,
             },
         )

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod eval_expr_wrapper;
 pub mod evaluable;
 pub mod expr;
 
-/// Represents a PartiQL evaluation query plan which is a plan that can be evaluated to produce
+/// Represents a `PartiQL` evaluation query plan which is a plan that can be evaluated to produce
 /// a result. The plan uses a directed `petgraph::StableGraph`.
 #[derive(Debug)]
 pub struct EvalPlan {
@@ -52,6 +52,7 @@ fn err_illegal_state(msg: impl AsRef<str>) -> EvalErr {
 
 impl EvalPlan {
     /// Creates a new evaluation plan.
+    #[must_use]
     pub fn new(
         mode: EvaluationMode,
         plan_graph: StableGraph<Box<dyn Evaluable>, u8, Directed>,
@@ -87,7 +88,7 @@ impl EvalPlan {
         })?;
 
         let mut result = None;
-        for idx in ops.into_iter() {
+        for idx in ops {
             let destinations: Vec<(usize, (u8, NodeIndex))> = self
                 .plan_graph()
                 .edges_directed(idx, Outgoing)
@@ -133,6 +134,7 @@ impl EvalPlan {
         Ok(Evaluated { result })
     }
 
+    #[must_use]
     pub fn to_dot_graph(&self) -> String {
         format!("{:?}", Dot::with_config(&self.plan_graph, &[]))
     }
@@ -169,6 +171,7 @@ pub struct BasicContext<'a> {
 }
 
 impl<'a> BasicContext<'a> {
+    #[must_use]
     pub fn new(bindings: MapBindings<Value>, sys: SystemContext) -> Self {
         BasicContext {
             bindings,
@@ -198,7 +201,7 @@ impl<'a> EvalContext<'a> for BasicContext<'a> {
     }
 
     fn add_error(&self, error: EvaluationError) {
-        self.errors.borrow_mut().push(error)
+        self.errors.borrow_mut().push(error);
     }
 
     fn has_errors(&self) -> bool {

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 pub mod env;
 pub mod error;

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -269,7 +269,9 @@ impl<'c> EvaluatorPlanner<'c> {
                         SetQuantifier::Distinct => Either::Right(plan_agg(ae)),
                     });
 
-                let group_as_alias = group_as_alias.as_ref().map(|alias| alias.to_string());
+                let group_as_alias = group_as_alias
+                    .as_ref()
+                    .map(std::string::ToString::to_string);
                 Box::new(eval::evaluable::EvalGroupBy::new(
                     strategy,
                     exprs,

--- a/partiql-ir/src/lib.rs
+++ b/partiql-ir/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 #[cfg(test)]
 mod tests {

--- a/partiql-irgen/src/lib.rs
+++ b/partiql-irgen/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 #[cfg(test)]
 mod tests {

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use crate::lower::AstToLogical;
 

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -125,7 +125,7 @@ pub struct PlanTyper<'c> {
 
 #[allow(dead_code)]
 impl<'c> PlanTyper<'c> {
-    /// Creates a new [PlanTyper] for the given Catalog and Intermediate Representation with `Strict` Typing Mode.
+    /// Creates a new [`PlanTyper`] for the given Catalog and Intermediate Representation with `Strict` Typing Mode.
     pub fn new_strict(catalog: &'c dyn Catalog, ir: &LogicalPlan<BindingsOp>) -> Self {
         PlanTyper {
             typing_mode: TypingMode::Strict,
@@ -138,7 +138,7 @@ impl<'c> PlanTyper<'c> {
         }
     }
 
-    /// Creates a new [PlanTyper] for the given Catalog and Intermediate Representation with `Permissive` Typing Mode.
+    /// Creates a new [`PlanTyper`] for the given Catalog and Intermediate Representation with `Permissive` Typing Mode.
     pub fn new_permissive(catalog: &'c dyn Catalog, lg: &LogicalPlan<BindingsOp>) -> Self {
         PlanTyper {
             typing_mode: TypingMode::Permissive,
@@ -158,7 +158,7 @@ impl<'c> PlanTyper<'c> {
         for idx in ops {
             let graph = self.to_stable_graph()?;
             if let Some(binop) = graph.node_weight(idx) {
-                self.type_bindings_op(binop)
+                self.type_bindings_op(binop);
             }
         }
 
@@ -184,14 +184,14 @@ impl<'c> PlanTyper<'c> {
                 if let Some(_at_key) = at_key {
                     self.errors.push(TypingError::NotYetImplemented(
                         "Scan operator with AT key is not implemented yet".to_string(),
-                    ))
+                    ));
                 }
 
                 self.type_vexpr(expr, LookupOrder::Delegate);
 
                 if !as_key.is_empty() {
                     let type_ctx = &self.local_type_ctx();
-                    for (_name, ty) in type_ctx.env().iter() {
+                    for (_name, ty) in type_ctx.env() {
                         if let TypeKind::Struct(_s) = ty.kind() {
                             self.type_env_stack.push(ty_ctx![(
                                 &ty_env![(string_to_sym(as_key.as_str()), ty.clone())],
@@ -203,7 +203,7 @@ impl<'c> PlanTyper<'c> {
             }
             BindingsOp::Project(partiql_logical::Project { exprs }) => {
                 let mut fields = vec![];
-                for (k, v) in exprs.iter() {
+                for (k, v) in exprs {
                     self.type_vexpr(v, LookupOrder::LocalGlobal);
 
                     fields.push(StructField::new(
@@ -306,17 +306,17 @@ impl<'c> PlanTyper<'c> {
                         PathComponent::Index(_) => {
                             self.errors.push(TypingError::NotYetImplemented(
                                 "Typing [Index] [PathComponent]s".to_string(),
-                            ))
+                            ));
                         }
                         PathComponent::KeyExpr(_) => {
                             self.errors.push(TypingError::NotYetImplemented(
                                 "Typing [KeyExpr] [PathComponent]s".to_string(),
-                            ))
+                            ));
                         }
                         PathComponent::IndexExpr(_) => {
                             self.errors.push(TypingError::NotYetImplemented(
                                 "Typing [IndexExpr] [PathComponent]s".to_string(),
-                            ))
+                            ));
                         }
                     }
                 }
@@ -355,7 +355,7 @@ impl<'c> PlanTyper<'c> {
                 // TODO for Typing we handle multiple lookups through `[LookupOrder]` hence using
                 // the first element. Remove this workaround once we remove DynamicLookup
                 let expr = &v[0];
-                self.type_vexpr(expr, self.lookup_order(expr))
+                self.type_vexpr(expr, self.lookup_order(expr));
             }
             _ => self.errors.push(TypingError::NotYetImplemented(format!(
                 "Unsupported Value Expression: {:?}",
@@ -545,9 +545,9 @@ impl<'c> PlanTyper<'c> {
         } else {
             let mut new_type_env = LocalTypeEnv::new();
             if let TypeKind::Struct(s) = ty.kind() {
-                to_bindings(s).into_iter().for_each(|b| {
+                for b in to_bindings(s) {
                     new_type_env.insert(b.0, b.1);
-                });
+                }
 
                 let type_ctx = ty_ctx![(&new_type_env, ty)];
                 self.type_env_stack.push(type_ctx);
@@ -792,7 +792,7 @@ mod tests {
         ])];
 
         let err1 = r#"No Typing Information for SymbolPrimitive { value: "details", case: CaseInsensitive } in closed Schema PartiqlType(Struct(StructType { constraints: {Open(false), Fields([StructField { name: "age", ty: PartiqlType(Int) }])} }))"#;
-        let err2 = r#"Illegal Derive Type PartiqlType(Undefined)"#;
+        let err2 = r"Illegal Derive Type PartiqlType(Undefined)";
 
         assert_err(
             assert_query_typing(
@@ -828,7 +828,7 @@ mod tests {
         output: Option<PartiqlType>,
     ) {
         match result {
-            Ok(_) => {
+            Ok(()) => {
                 panic!("Expected Error");
             }
             Err(e) => {
@@ -838,7 +838,7 @@ mod tests {
                         errors: expected_errors,
                         output
                     }
-                )
+                );
             }
         };
     }
@@ -869,8 +869,8 @@ mod tests {
                             .collect();
                         assert!(f.is_empty());
                         assert_eq!(expected_fields.len(), fields.len());
-                        println!("query: {:?}", query);
-                        println!("actual: {:?}", actual);
+                        println!("query: {query:?}");
+                        println!("actual: {actual:?}");
                         Ok(())
                     } else {
                         Err(TypeErr {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 //! A PartiQL logical plan.
 //!

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -1,16 +1,16 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-//! A PartiQL logical plan.
+//! A `PartiQL` logical plan.
 //!
-//! This module contains the structures for a PartiQL logical plan. Three main entities in the
+//! This module contains the structures for a `PartiQL` logical plan. Three main entities in the
 //! module are [`LogicalPlan`], [`BindingsOp`], and [`ValueExpr`].
 //! `LogicalPlan` represents a graph based logical plan. `BindingsOp` represent operations that
-//! operate on binding tuples and `ValueExpr` represents PartiQL expressions that produce PartiQL
+//! operate on binding tuples and `ValueExpr` represents `PartiQL` expressions that produce `PartiQL`
 //! values; all as specified in [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 //!
 //! Plan graph nodes are called _operators_ and edges are called _flows_ re-instating the fact that
-//! the plan captures data flows for a given PartiQL statement.
+//! the plan captures data flows for a given `PartiQL` statement.
 //!
 /// # Examples
 /// ```
@@ -58,7 +58,7 @@ use std::fmt::{Debug, Display, Formatter};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Represents a PartiQL logical plan.
+/// Represents a `PartiQL` logical plan.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalPlan<T>
@@ -75,6 +75,7 @@ where
     T: Default,
 {
     /// Creates a new default logical plan.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -131,11 +132,13 @@ where
 
     /// Returns the number of operators in the plan.
     #[inline]
+    #[must_use]
     pub fn operator_count(&self) -> usize {
         self.nodes.len()
     }
 
     /// Returns the operators of the plan.
+    #[must_use]
     pub fn operators(&self) -> &Vec<T> {
         &self.nodes
     }
@@ -146,10 +149,12 @@ where
     }
 
     /// Returns the data flows of the plan.
+    #[must_use]
     pub fn flows(&self) -> &Vec<(OpId, OpId, u8)> {
         &self.edges
     }
 
+    #[must_use]
     pub fn operator(&self, id: OpId) -> Option<&T> {
         self.nodes.get(id.0 - 1)
     }
@@ -168,6 +173,7 @@ pub struct OpId(usize);
 
 impl OpId {
     /// Returns operator's index
+    #[must_use]
     pub fn index(&self) -> usize {
         self.0
     }
@@ -190,7 +196,7 @@ where
     }
 }
 
-/// Represents PartiQL binding operators; A `BindingOp` is an operator that operates on
+/// Represents `PartiQL` binding operators; A `BindingOp` is an operator that operates on
 /// binding tuples as specified by [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -278,7 +284,7 @@ pub enum SortSpecNullOrder {
     Last,
 }
 
-/// Represents a PartiQL sort specification.
+/// Represents a `PartiQL` sort specification.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SortSpec {
@@ -368,7 +374,7 @@ pub enum AggFunc {
     AggEvery,
 }
 
-/// Represents `GROUP BY` <strategy> <group_key>[, <group_key>] ... \[AS <as_alias>\]
+/// Represents `GROUP BY` <strategy> <`group_key`>[, <`group_key`>] ... \[AS <`as_alias`>\]
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GroupBy {
@@ -408,7 +414,7 @@ pub struct ExprQuery {
     pub expr: ValueExpr,
 }
 
-/// Represents a PartiQL value expression. Evaluation of a [`ValueExpr`] leads to a PartiQL value as
+/// Represents a `PartiQL` value expression. Evaluation of a [`ValueExpr`] leads to a `PartiQL` value as
 /// specified by [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -481,7 +487,7 @@ pub enum PathComponent {
     IndexExpr(Box<ValueExpr>),
 }
 
-/// Represents a PartiQL tuple expression, e.g: `{ a.b: a.c * 2, 'count': a.c + 10}`.
+/// Represents a `PartiQL` tuple expression, e.g: `{ a.b: a.c * 2, 'count': a.c + 10}`.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TupleExpr {
@@ -491,12 +497,13 @@ pub struct TupleExpr {
 
 impl TupleExpr {
     /// Creates a new default [`TupleExpr`].
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-/// Represents a PartiQL list expression, e.g. `[a.c * 2, 5]`.
+/// Represents a `PartiQL` list expression, e.g. `[a.c * 2, 5]`.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ListExpr {
@@ -505,12 +512,13 @@ pub struct ListExpr {
 
 impl ListExpr {
     /// Creates a new default [`ListExpr`].
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-/// Represents a PartiQL bag expression, e.g. `<<a.c * 2, 5>>`.
+/// Represents a `PartiQL` bag expression, e.g. `<<a.c * 2, 5>>`.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BagExpr {
@@ -519,12 +527,13 @@ pub struct BagExpr {
 
 impl BagExpr {
     /// Creates a new default [`BagExpr`].
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-/// Represents a PartiQL `BETWEEN` expression, e.g. `BETWEEN 500 AND 600`.
+/// Represents a `PartiQL` `BETWEEN` expression, e.g. `BETWEEN 500 AND 600`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BetweenExpr {
@@ -533,7 +542,7 @@ pub struct BetweenExpr {
     pub to: Box<ValueExpr>,
 }
 
-/// Represents a PartiQL Pattern Match expression, e.g. `'foo' LIKE 'foo'`.
+/// Represents a `PartiQL` Pattern Match expression, e.g. `'foo' LIKE 'foo'`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PatternMatchExpr {
@@ -574,7 +583,7 @@ pub struct SubQueryExpr {
     pub plan: LogicalPlan<BindingsOp>,
 }
 
-/// Represents a PartiQL's simple case expressions,
+/// Represents a `PartiQL`'s simple case expressions,
 /// e.g.`CASE <expr> [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -584,7 +593,7 @@ pub struct SimpleCase {
     pub default: Option<Box<ValueExpr>>,
 }
 
-/// Represents a PartiQL's searched case expressions,
+/// Represents a `PartiQL`'s searched case expressions,
 /// e.g.`CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END`.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -602,7 +611,7 @@ pub struct IsTypeExpr {
     pub is_type: Type,
 }
 
-/// Represents a PartiQL Type.
+/// Represents a `PartiQL` Type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Type {

--- a/partiql-parser/src/error.rs
+++ b/partiql-parser/src/error.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! [`Error`] and [`Result`] types for parsing PartiQL.
+//! [`Error`] and [`Result`] types for parsing `PartiQL`.
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
@@ -11,7 +11,7 @@ use thiserror::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Errors in the lexical structure of a PartiQL query.
+/// Errors in the lexical structure of a `PartiQL` query.
 ///
 /// ### Notes
 /// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
@@ -33,7 +33,7 @@ pub enum LexError<'input> {
     Unknown,
 }
 
-/// Errors in the syntactic structure of a PartiQL query.
+/// Errors in the syntactic structure of a `PartiQL` query.
 ///
 /// ### Notes
 /// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
@@ -112,7 +112,7 @@ mod tests {
         ));
 
         let e2 = e1.map_loc(|BytePosition(x)| BytePosition(x - 2));
-        assert_eq!(e2.to_string(), "Syntax Error: oops at `(b253..b510)`")
+        assert_eq!(e2.to_string(), "Syntax Error: oops at `(b253..b510)`");
     }
 
     #[test]
@@ -123,7 +123,7 @@ mod tests {
         );
 
         let e2 = e1.map_loc(|x| BytePosition(x.0 + 1));
-        assert_eq!(e2.to_string(), "Unexpected token `/` at `(b1..b2)`")
+        assert_eq!(e2.to_string(), "Unexpected token `/` at `(b1..b2)`");
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod tests {
         assert_eq!(
             e2.to_string(),
             "Lexing error: invalid input `🤷` at `(1:11..5:15)`"
-        )
+        );
     }
 
     #[test]
@@ -147,6 +147,6 @@ mod tests {
         let e1: ParseError<'_, BytePosition> = ParseError::IllegalState("uh oh".to_string());
 
         let e2 = e1.map_loc(|x| x);
-        assert_eq!(e2.to_string(), "Illegal State: uh oh")
+        assert_eq!(e2.to_string(), "Illegal State: uh oh");
     }
 }

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 // Copyright Amazon.com, Inc. or its affiliates.
 
 //! Provides a parser for the [PartiQL][partiql] query language.

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -36,22 +36,22 @@ use partiql_source_map::metadata::LocationMap;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// [`std::error::Error`] type for errors in the lexical structure for the PartiQL parser.
+/// [`std::error::Error`] type for errors in the lexical structure for the `PartiQL` parser.
 pub type LexicalError<'input> = error::LexError<'input>;
 
-/// [`std::error::Error`] type for errors in the syntactic structure for the PartiQL parser.
+/// [`std::error::Error`] type for errors in the syntactic structure for the `PartiQL` parser.
 pub type ParseError<'input> = error::ParseError<'input, BytePosition>;
 
-/// General [`Result`] type for the PartiQL [`Parser`].
+/// General [`Result`] type for the `PartiQL` [`Parser`].
 pub type ParserResult<'input> = Result<Parsed<'input>, ParserError<'input>>;
 
-/// A PartiQL parser from statement strings to AST.
+/// A `PartiQL` parser from statement strings to AST.
 #[non_exhaustive]
 #[derive(Debug, Default)]
 pub struct Parser {}
 
 impl Parser {
-    /// Parse a PartiQL statement into an AST.
+    /// Parse a `PartiQL` statement into an AST.
     pub fn parse<'input>(&self, text: &'input str) -> ParserResult<'input> {
         match parse_partiql(text) {
             Ok(AstData {
@@ -73,7 +73,7 @@ impl Parser {
     }
 }
 
-/// The output of parsing PartiQL statement strings: an AST and auxiliary data.
+/// The output of parsing `PartiQL` statement strings: an AST and auxiliary data.
 #[non_exhaustive]
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -85,7 +85,7 @@ pub struct Parsed<'input> {
     pub locations: LocationMap,
 }
 
-/// The output of errors when parsing PartiQL statement strings: an errors and auxiliary data.
+/// The output of errors when parsing `PartiQL` statement strings: an errors and auxiliary data.
 #[non_exhaustive]
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -17,17 +17,12 @@ use partiql_source_map::location::{ByteOffset, BytePosition, ToLocated};
 use partiql_source_map::metadata::LocationMap;
 
 #[allow(clippy::just_underscores_and_digits)] // LALRPOP generates a lot of names like this
-#[allow(clippy::clone_on_copy)]
-#[allow(clippy::type_complexity)]
-#[allow(clippy::needless_lifetimes)]
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::ptr_arg)]
-#[allow(clippy::vec_box)]
-#[allow(clippy::let_unit_value)]
-#[allow(clippy::unused_unit)]
+#[allow(clippy::all)]
+#[allow(clippy::pedantic)]
 #[allow(unused_variables)]
 #[allow(dead_code)]
-#[allow(rust_2018_idioms)]
+#[allow(unused_extern_crates)]
+#[allow(explicit_outlives_requirements)]
 mod grammar {
     include!(concat!(env!("OUT_DIR"), "/partiql.rs"));
 }

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Provides the [`parse_partiql`] function to parse a PartiQL query.
+//! Provides the [`parse_partiql`] function to parse a `PartiQL` query.
 
 mod parse_util;
 mod parser_state;
@@ -48,7 +48,7 @@ pub(crate) struct ErrorData<'input> {
 
 pub(crate) type AstResult<'input> = Result<AstData, ErrorData<'input>>;
 
-/// Parse PartiQL query text into an AST.
+/// Parse `PartiQL` query text into an AST.
 pub(crate) fn parse_partiql(s: &str) -> AstResult<'_> {
     parse_partiql_with_state(s, ParserState::default())
 }
@@ -234,7 +234,7 @@ mod tests {
         }
         #[test]
         fn array() {
-            parse!(r#"[]"#);
+            parse!(r"[]");
             parse!(r#"[1, 'moo', "some variable", [], 'a', MISSING]"#);
             // In the interest of compatibility to SQL, PartiQL also allows array constructors to be
             // denoted with parentheses instead of brackets, when there are at least two elements in the array
@@ -242,15 +242,15 @@ mod tests {
         }
         #[test]
         fn bag() {
-            parse!(r#"<<>>"#);
-            parse!(r#"<<1>>"#);
-            parse!(r#"<<1,2>>"#);
-            parse!(r#"<<1, <<>>, 'boo', some_variable, 'a'>>"#);
+            parse!(r"<<>>");
+            parse!(r"<<1>>");
+            parse!(r"<<1,2>>");
+            parse!(r"<<1, <<>>, 'boo', some_variable, 'a'>>");
         }
         #[test]
         fn tuple() {
-            parse!(r#"{}"#);
-            parse!(r#"{a_variable: 1, 'cow': 'moo', 'a': NULL}"#);
+            parse!(r"{}");
+            parse!(r"{a_variable: 1, 'cow': 'moo', 'a': NULL}");
         }
     }
 
@@ -259,43 +259,43 @@ mod tests {
 
         #[test]
         fn or_simple() {
-            parse!(r#"TRUE OR FALSE"#);
+            parse!(r"TRUE OR FALSE");
         }
 
         #[test]
         fn or() {
-            parse!(r#"t1.super OR test(t2.name, t1.name)"#);
+            parse!(r"t1.super OR test(t2.name, t1.name)");
         }
 
         #[test]
         fn and_simple() {
-            parse!(r#"TRUE and FALSE"#);
+            parse!(r"TRUE and FALSE");
         }
 
         #[test]
         fn and() {
-            parse!(r#"test(t2.name, t1.name) AND t1.id = t2.id"#);
+            parse!(r"test(t2.name, t1.name) AND t1.id = t2.id");
         }
 
         #[test]
         fn or_and() {
-            parse!(r#"t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#);
+            parse!(r"t1.super OR test(t2.name, t1.name) AND t1.id = t2.id");
         }
 
         #[test]
         fn infix() {
-            parse!(r#"1 + -2 * +3 % 4^5 / 6 - 7  <= 3.14 AND 'foo' || 'bar' LIKE '%oba%'"#);
+            parse!(r"1 + -2 * +3 % 4^5 / 6 - 7  <= 3.14 AND 'foo' || 'bar' LIKE '%oba%'");
         }
 
         #[test]
         fn expr_in() {
-            parse!(r#"a in (1,2,3,4)"#);
-            parse!(r#"a in [1,2,3,4]"#);
+            parse!(r"a in (1,2,3,4)");
+            parse!(r"a in [1,2,3,4]");
         }
 
         #[test]
         fn expr_between() {
-            parse!(r#"a between 2 and 3"#);
+            parse!(r"a between 2 and 3");
         }
     }
 
@@ -304,51 +304,51 @@ mod tests {
 
         #[test]
         fn nested() {
-            parse!(r#"a.b"#);
+            parse!(r"a.b");
             parse!(r#"a.b.c['item']."d"[5].e['s'].f[1+2]"#);
-            parse!(r#"a.b.*"#);
-            parse!(r#"a.b[*]"#);
-            parse!(r#"@a.b[*]"#);
+            parse!(r"a.b.*");
+            parse!(r"a.b[*]");
+            parse!(r"@a.b[*]");
             parse!(r#"@"a".b[*]"#);
-            parse!(r#"tables.items[*].product.*.nest"#);
+            parse!(r"tables.items[*].product.*.nest");
             parse!(r#"a.b.c['item']."d"[5].e['s'].f[1+2]"#);
         }
 
         #[test]
         fn tuple() {
-            parse!(r#"{'a':1 , 'data': 2}.a"#);
-            parse!(r#"{'a':1 , 'data': 2}.'a'"#);
+            parse!(r"{'a':1 , 'data': 2}.a");
+            parse!(r"{'a':1 , 'data': 2}.'a'");
             parse!(r#"{'A':1 , 'data': 2}."A""#);
-            parse!(r#"{'A':1 , 'data': 2}['a']"#);
-            parse!(r#"{'attr': 1, 'b':2}[v || w]"#);
-            parse!(r#"{'a':1, 'b':2}.*"#);
+            parse!(r"{'A':1 , 'data': 2}['a']");
+            parse!(r"{'attr': 1, 'b':2}[v || w]");
+            parse!(r"{'a':1, 'b':2}.*");
         }
 
         #[test]
         fn array() {
-            parse!(r#"[1,2,3][0]"#);
-            parse!(r#"[1,2,3][1 + 1]"#);
-            parse!(r#"[1,2,3][*]"#);
+            parse!(r"[1,2,3][0]");
+            parse!(r"[1,2,3][1 + 1]");
+            parse!(r"[1,2,3][*]");
         }
 
         #[test]
         fn query() {
-            parse!(r#"(SELECT a FROM t).a"#);
-            parse!(r#"(SELECT a FROM t).'a'"#);
+            parse!(r"(SELECT a FROM t).a");
+            parse!(r"(SELECT a FROM t).'a'");
             parse!(r#"(SELECT a FROM t)."a""#);
-            parse!(r#"(SELECT a FROM t)['a']"#);
-            parse!(r#"(SELECT a FROM t).*"#);
-            parse!(r#"(SELECT a FROM t)[*]"#);
+            parse!(r"(SELECT a FROM t)['a']");
+            parse!(r"(SELECT a FROM t).*");
+            parse!(r"(SELECT a FROM t)[*]");
         }
 
         #[test]
         fn function_call() {
-            parse!(r#"foo(x, y).a"#);
-            parse!(r#"foo(x, y).*"#);
-            parse!(r#"foo(x, y)[*]"#);
-            parse!(r#"foo(x, y)[5]"#);
-            parse!(r#"foo(x, y).a.*"#);
-            parse!(r#"foo(x, y)[*].*.b[5]"#);
+            parse!(r"foo(x, y).a");
+            parse!(r"foo(x, y).*");
+            parse!(r"foo(x, y)[*]");
+            parse!(r"foo(x, y)[5]");
+            parse!(r"foo(x, y).a.*");
+            parse!(r"foo(x, y)[*].*.b[5]");
         }
 
         #[test]
@@ -377,7 +377,7 @@ mod tests {
             } = res
             {
                 if let ast::Expr::Path(p) = &**e {
-                    assert_eq!(9, p.node.steps.len())
+                    assert_eq!(9, p.node.steps.len());
                 } else {
                     panic!("PathExpr test failed!");
                 }
@@ -389,10 +389,10 @@ mod tests {
         #[test]
         #[should_panic]
         fn erroneous() {
-            parse!(r#"a.b.['item']"#);
-            parse!(r#"a.b.{'a': 1, 'b': 2}.a"#);
-            parse!(r#"a.b.[1, 2, 3][2]"#);
-            parse!(r#"a.b.[*]"#);
+            parse!(r"a.b.['item']");
+            parse!(r"a.b.{'a': 1, 'b': 2}.a");
+            parse!(r"a.b.[1, 2, 3][2]");
+            parse!(r"a.b.[*]");
         }
     }
 
@@ -416,7 +416,7 @@ mod tests {
 
         #[test]
         fn fun_call() {
-            parse!(r#"fun_call('bar', 1,2,3,4,5,'foo')"#);
+            parse!(r"fun_call('bar', 1,2,3,4,5,'foo')");
         }
 
         #[test]
@@ -436,41 +436,39 @@ mod tests {
 
         #[test]
         fn order_by() {
-            parse!(r#"SELECT a FROM tb ORDER BY PRESERVE"#);
-            parse!(r#"SELECT a FROM tb ORDER BY rk1"#);
-            parse!(r#"SELECT a FROM tb ORDER BY rk1 ASC, rk2 DESC"#);
+            parse!(r"SELECT a FROM tb ORDER BY PRESERVE");
+            parse!(r"SELECT a FROM tb ORDER BY rk1");
+            parse!(r"SELECT a FROM tb ORDER BY rk1 ASC, rk2 DESC");
         }
 
         #[test]
         fn where_simple() {
-            parse!(r#"SELECT a FROM tb WHERE hk = 1"#);
+            parse!(r"SELECT a FROM tb WHERE hk = 1");
         }
 
         #[test]
         fn where_boolean() {
-            parse!(
-                r#"SELECT a FROM tb WHERE t1.super OR test(t2.name, t1.name) AND t1.id = t2.id"#
-            );
+            parse!(r"SELECT a FROM tb WHERE t1.super OR test(t2.name, t1.name) AND t1.id = t2.id");
         }
 
         #[test]
         fn limit() {
-            parse!(r#"SELECT * FROM a LIMIT 10"#);
+            parse!(r"SELECT * FROM a LIMIT 10");
         }
 
         #[test]
         fn offset() {
-            parse!(r#"SELECT * FROM a OFFSET 10"#);
+            parse!(r"SELECT * FROM a OFFSET 10");
         }
 
         #[test]
         fn limit_offset() {
-            parse!(r#"SELECT * FROM a LIMIT 10 OFFSET 2"#);
+            parse!(r"SELECT * FROM a LIMIT 10 OFFSET 2");
         }
 
         #[test]
         fn complex() {
-            let q = r#"
+            let q = r"
             SELECT (
                 SELECT numRec, data
                 FROM delta_full_transactions.deltas delta0,
@@ -481,20 +479,20 @@ mod tests {
                 delta2.numRec as numRec
             )
             AS deltas FROM SOURCE_VIEW_DELTA_FULL_TRANSACTIONS delta_full_transactions
-            "#;
+            ";
             parse!(q);
         }
 
         #[test]
         fn select_with_case() {
-            parse!(r#"SELECT a WHERE CASE WHEN x <> 0 THEN y/x > 1.5 ELSE false END"#);
+            parse!(r"SELECT a WHERE CASE WHEN x <> 0 THEN y/x > 1.5 ELSE false END");
             parse!(
-                r#"SELECT a,
+                r"SELECT a,
                     CASE WHEN a=1 THEN 'one'
                          WHEN a=2 THEN 'two'
                          ELSE 'other'
                     END
-                    FROM test"#
+                    FROM test"
             );
 
             parse!(
@@ -518,20 +516,20 @@ mod tests {
 
         #[test]
         fn select_with_cross_join_and_at() {
-            parse!(r#"SELECT * FROM a AS a CROSS JOIN c AS c AT q"#);
+            parse!(r"SELECT * FROM a AS a CROSS JOIN c AS c AT q");
         }
 
         #[test]
         fn select_with_at_and_cross_join_and_at() {
-            parse!(r#"SELECT * FROM a AS a AT b CROSS JOIN c AS c AT q"#);
+            parse!(r"SELECT * FROM a AS a AT b CROSS JOIN c AS c AT q");
         }
 
         #[test]
         fn multiline_with_comments() {
             parse!(
-                r#"SELECT * FROM hr.employees               -- T1
+                r"SELECT * FROM hr.employees               -- T1
                                   UNION
-                                  SELECT title FROM engineering.employees  -- T2"#
+                                  SELECT title FROM engineering.employees  -- T2"
             );
         }
     }
@@ -575,14 +573,14 @@ mod tests {
         #[test]
         fn set_ops() {
             parse!(
-                r#"(SELECT * FROM a LIMIT 10 OFFSET 2) UNION SELECT * FROM b INTERSECT c EXCEPT SELECT * FROM d"#
+                r"(SELECT * FROM a LIMIT 10 OFFSET 2) UNION SELECT * FROM b INTERSECT c EXCEPT SELECT * FROM d"
             );
         }
 
         #[test]
         fn union_prec() {
-            let l = parse_null_id!(r#"a union b union c"#);
-            let r = parse_null_id!(r#"(a union b) union c"#);
+            let l = parse_null_id!(r"a union b union c");
+            let r = parse_null_id!(r"(a union b) union c");
             assert_eq!(l, r);
         }
 
@@ -590,22 +588,22 @@ mod tests {
         #[test]
         #[ignore]
         fn intersec_prec() {
-            let l = parse_null_id!(r#"a union b intersect c"#);
-            let r = parse_null_id!(r#"a union (b intersect c)"#);
+            let l = parse_null_id!(r"a union b intersect c");
+            let r = parse_null_id!(r"a union (b intersect c)");
             assert_eq!(l, r);
         }
 
         #[test]
         fn limit() {
             let l = parse_null_id!(
-                r#"SELECT a FROM b UNION SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5"#
+                r"SELECT a FROM b UNION SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5"
             );
             let r = parse_null_id!(
-                r#"(SELECT a FROM b UNION SELECT x FROM y) ORDER BY a LIMIT 10 OFFSET 5"#
+                r"(SELECT a FROM b UNION SELECT x FROM y) ORDER BY a LIMIT 10 OFFSET 5"
             );
             assert_eq!(l, r);
             let r2 = parse_null_id!(
-                r#"SELECT a FROM b UNION (SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5)"#
+                r"SELECT a FROM b UNION (SELECT x FROM y ORDER BY a LIMIT 10 OFFSET 5)"
             );
             assert_ne!(l, r2);
             assert_ne!(r, r2);
@@ -614,32 +612,32 @@ mod tests {
         #[test]
         fn complex_set() {
             parse_null_id!(
-                r#"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+                r"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
                    OUTER UNION ALL
                    (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
-                   ORDER BY c3 LIMIT d3 OFFSET e3"#
+                   ORDER BY c3 LIMIT d3 OFFSET e3"
             );
             parse_null_id!(
-                r#"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+                r"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
                    OUTER INTERSECT ALL
                    (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
-                   ORDER BY c3 LIMIT d3 OFFSET e3"#
+                   ORDER BY c3 LIMIT d3 OFFSET e3"
             );
             parse_null_id!(
-                r#"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
+                r"(SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
                    OUTER EXCEPT ALL
                    (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
-                   ORDER BY c3 LIMIT d3 OFFSET e3"#
+                   ORDER BY c3 LIMIT d3 OFFSET e3"
             );
             parse_null_id!(
-                r#"(
+                r"(
                        (SELECT a1 FROM b1 ORDER BY c1 LIMIT d1 OFFSET e1)
                        UNION DISTINCT
                        (SELECT a2 FROM b2 ORDER BY c2 LIMIT d2 OFFSET e2)
                    )
                    OUTER UNION ALL
                    (SELECT a3 FROM b3 ORDER BY c3 LIMIT d3 OFFSET e3)
-                   ORDER BY c4 LIMIT d4 OFFSET e4"#
+                   ORDER BY c4 LIMIT d4 OFFSET e4"
             );
         }
     }
@@ -649,15 +647,15 @@ mod tests {
 
         #[test]
         fn searched_case() {
-            parse!(r#"CASE WHEN TRUE THEN 2 END"#);
-            parse!(r#"CASE WHEN id IS 1 THEN 2 WHEN titanId IS 2 THEN 3 ELSE 1 END"#);
-            parse!(r#"CASE hello WHEN id IS NOT NULL THEN (SELECT * FROM data) ELSE 1 END"#);
+            parse!(r"CASE WHEN TRUE THEN 2 END");
+            parse!(r"CASE WHEN id IS 1 THEN 2 WHEN titanId IS 2 THEN 3 ELSE 1 END");
+            parse!(r"CASE hello WHEN id IS NOT NULL THEN (SELECT * FROM data) ELSE 1 END");
         }
 
         #[test]
         #[should_panic]
         fn searched_case_failure() {
-            parse!(r#"CASE hello WHEN id IS NOT NULL THEN SELECT * FROM data ELSE 1 END"#);
+            parse!(r"CASE hello WHEN id IS NOT NULL THEN SELECT * FROM data ELSE 1 END");
         }
     }
 
@@ -666,61 +664,61 @@ mod tests {
 
         #[test]
         fn position() {
-            parse!(r#"position('oB' in 'FooBar')"#);
+            parse!(r"position('oB' in 'FooBar')");
         }
 
         #[test]
         fn substring() {
-            parse!(r#"substring('FooBar' from 2 for 3)"#);
-            parse!(r#"substring('FooBar' from 2)"#);
-            parse!(r#"substring('FooBar' for 3)"#);
+            parse!(r"substring('FooBar' from 2 for 3)");
+            parse!(r"substring('FooBar' from 2)");
+            parse!(r"substring('FooBar' for 3)");
         }
 
         #[test]
         fn trim() {
-            parse!(r#"trim(LEADING 'Foo' from 'FooBar')"#);
-            parse!(r#"trim(leading from '   Bar')"#);
-            parse!(r#"trim(TrAiLiNg 'Bar' from 'FooBar')"#);
-            parse!(r#"trim(TRAILING from 'Bar   ')"#);
-            parse!(r#"trim(BOTH 'Foo' from 'FooBarBar')"#);
-            parse!(r#"trim(botH from '   Bar   ')"#);
-            parse!(r#"trim(from '   Bar   ')"#);
+            parse!(r"trim(LEADING 'Foo' from 'FooBar')");
+            parse!(r"trim(leading from '   Bar')");
+            parse!(r"trim(TrAiLiNg 'Bar' from 'FooBar')");
+            parse!(r"trim(TRAILING from 'Bar   ')");
+            parse!(r"trim(BOTH 'Foo' from 'FooBarBar')");
+            parse!(r"trim(botH from '   Bar   ')");
+            parse!(r"trim(from '   Bar   ')");
         }
 
         #[test]
         fn cast() {
-            parse!(r#"CAST(9 AS b)"#);
-            parse!(r#"CAST(a AS VARCHAR)"#);
-            parse!(r#"CAST(a AS VARCHAR(20))"#);
-            parse!(r#"CAST(a AS TIME)"#);
-            parse!(r#"CAST(a AS TIME(20))"#);
-            parse!(r#"CAST( TRUE AS INTEGER)"#);
-            parse!(r#"CAST( (4 in (1,2,3,4)) AS INTEGER)"#);
-            parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
-            parse!(r#"CAST(a AS TIME WITH TIME ZONE)"#);
-            parse!(r#"CAST(a AS TIME(20) WITH TIME ZONE)"#);
+            parse!(r"CAST(9 AS b)");
+            parse!(r"CAST(a AS VARCHAR)");
+            parse!(r"CAST(a AS VARCHAR(20))");
+            parse!(r"CAST(a AS TIME)");
+            parse!(r"CAST(a AS TIME(20))");
+            parse!(r"CAST( TRUE AS INTEGER)");
+            parse!(r"CAST( (4 in (1,2,3,4)) AS INTEGER)");
+            parse!(r"CAST(a AS TIME WITH TIME ZONE)");
+            parse!(r"CAST(a AS TIME WITH TIME ZONE)");
+            parse!(r"CAST(a AS TIME(20) WITH TIME ZONE)");
         }
 
         #[test]
         fn extract() {
-            parse!(r#"extract(day from a)"#);
-            parse!(r#"extract(hour from a)"#);
-            parse!(r#"extract(minute from a)"#);
-            parse!(r#"extract(second from a)"#);
+            parse!(r"extract(day from a)");
+            parse!(r"extract(hour from a)");
+            parse!(r"extract(minute from a)");
+            parse!(r"extract(second from a)");
         }
 
         #[test]
         fn agg() {
-            parse!(r#"count(a)"#);
-            parse!(r#"count(distinct a)"#);
-            parse!(r#"count(all a)"#);
-            parse!(r#"count(*)"#);
+            parse!(r"count(a)");
+            parse!(r"count(distinct a)");
+            parse!(r"count(all a)");
+            parse!(r"count(*)");
         }
 
         #[test]
         fn composed() {
             parse!(
-                r#"cast(trim(LEADING 'Foo' from substring('BarFooBar' from 4 for 6)) AS VARCHAR(20))"#
+                r"cast(trim(LEADING 'Foo' from substring('BarFooBar' from 4 for 6)) AS VARCHAR(20))"
             );
         }
     }
@@ -732,38 +730,38 @@ mod tests {
 
         #[test]
         fn projection_list_trim_spec() {
-            parse!(r#"SELECT leading FROM t"#);
-            parse!(r#"SELECT leading, a FROM t"#);
-            parse!(r#"SELECT leading + trailing, b FROM t"#);
-            parse!(r#"SELECT both + leading + trailing, a, b, c FROM t"#);
+            parse!(r"SELECT leading FROM t");
+            parse!(r"SELECT leading, a FROM t");
+            parse!(r"SELECT leading + trailing, b FROM t");
+            parse!(r"SELECT both + leading + trailing, a, b, c FROM t");
         }
 
         #[test]
         fn from_source_trim_spec() {
-            parse!(r#"SELECT leading, trailing, both FROM leading, trailing, both"#);
+            parse!(r"SELECT leading, trailing, both FROM leading, trailing, both");
         }
 
         #[test]
         fn complex_trim() {
             parse!(
-                r#"SELECT leading + trim(leading leading FROM '  hello world'), both FROM leading, trailing, both"#
+                r"SELECT leading + trim(leading leading FROM '  hello world'), both FROM leading, trailing, both"
             );
         }
 
         #[test]
         fn graph_pattern_matching() {
-            parse!(r#"SELECT acyclic, trail, simple FROM t"#);
-            parse!(r#"AcYcLiC"#);
-            parse!(r#"TrAiL"#);
-            parse!(r#"SiMpLe"#);
+            parse!(r"SELECT acyclic, trail, simple FROM t");
+            parse!(r"AcYcLiC");
+            parse!(r"TrAiL");
+            parse!(r"SiMpLe");
         }
 
         #[test]
         fn user_public_domain() {
-            parse!(r#"SELECT user, puBlIC, DOMAIN FROM USER, pUbLIc, domain"#);
-            parse!(r#"USER"#);
-            parse!(r#"pUbLIC"#);
-            parse!(r#"domain"#);
+            parse!(r"SELECT user, puBlIC, DOMAIN FROM USER, pUbLIc, domain");
+            parse!(r"USER");
+            parse!(r"pUbLIC");
+            parse!(r"domain");
         }
     }
 
@@ -775,7 +773,7 @@ mod tests {
 
         #[test]
         fn eof() {
-            let res = parse_partiql(r#"SELECT"#);
+            let res = parse_partiql(r"SELECT");
             assert!(res.is_err());
             let err_data = res.unwrap_err();
             assert_eq!(1, err_data.errors.len());
@@ -784,7 +782,7 @@ mod tests {
 
         #[test]
         fn unterminated_ion_unicode() {
-            let q = r#"/`܋"#;
+            let q = r"/`܋";
             let res = parse_partiql(q);
             assert!(res.is_err());
             let err_data = res.unwrap_err();

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -8,7 +8,7 @@ bitflags! {
     /// Set of AST node attributes to use as synthesized attributes.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub(crate) struct Attrs: u8 {
-        const LIT = 0b00000001;
+        const LIT = 0b0000_0001;
 
         const INTERSECTABLE = Self::LIT.bits();
         const UNIONABLE = 0;

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -323,20 +323,18 @@ where
         (tok, _): BufferedToken<'input>,
         next_idx: usize,
     ) -> (SpannedToken<'input>, Option<SpannedTokenVec<'input>>) {
-        match tok {
-            (_, Token::UnquotedIdent(id) | Token::QuotedIdent(id), _) => {
-                if let Some(((_, Token::OpenParen, _), _)) = self.parser.peek_n(next_idx) {
-                    if let Some(fn_expr) = self.fn_exprs.find(id) {
-                        let replacement = match self.rewrite_fn_expr(fn_expr) {
-                            Ok(rewrites) => rewrites,
-                            Err(_err) => self.parser.flush().into_iter().map(|(t, _)| t).collect(),
-                        };
-                        return (tok, Some(replacement));
-                    }
+        if let (_, Token::UnquotedIdent(id) | Token::QuotedIdent(id), _) = tok {
+            if let Some(((_, Token::OpenParen, _), _)) = self.parser.peek_n(next_idx) {
+                if let Some(fn_expr) = self.fn_exprs.find(id) {
+                    let replacement = match self.rewrite_fn_expr(fn_expr) {
+                        Ok(rewrites) => rewrites,
+                        Err(_err) => self.parser.flush().into_iter().map(|(t, _)| t).collect(),
+                    };
+                    return (tok, Some(replacement));
                 }
             }
-            _ => (),
         }
+
         (tok, None)
     }
 

--- a/partiql-parser/src/preprocessor.rs
+++ b/partiql-parser/src/preprocessor.rs
@@ -59,7 +59,7 @@ pub(crate) struct FnExpr<'a> {
 }
 
 mod built_ins {
-    use super::*;
+    use super::{FnExpr, FnExprArgMatch, Token};
     use regex::Regex;
 
     use FnExprArgMatch::{
@@ -272,7 +272,7 @@ impl<'input, 'tracker> PreprocessingPartiqlLexer<'input, 'tracker>
 where
     'input: 'tracker,
 {
-    /// Creates a new PartiQL lexer over `input` text.
+    /// Creates a new `PartiQL` lexer over `input` text.
     #[inline]
     pub fn new(
         input: &'input str,
@@ -294,7 +294,7 @@ where
             self.buff.pop_front()
         } else {
             match self.parser.consume() {
-                Some(Ok(_)) => match self.parser.flush_1() {
+                Some(Ok(())) => match self.parser.flush_1() {
                     None => None,
                     Some(token) => {
                         let (tok, buffered) = self.parse_fn_expr(token, 0);
@@ -324,7 +324,7 @@ where
         next_idx: usize,
     ) -> (SpannedToken<'input>, Option<SpannedTokenVec<'input>>) {
         match tok {
-            (_, Token::UnquotedIdent(id), _) | (_, Token::QuotedIdent(id), _) => {
+            (_, Token::UnquotedIdent(id) | Token::QuotedIdent(id), _) => {
                 if let Some(((_, Token::OpenParen, _), _)) = self.parser.peek_n(next_idx) {
                     if let Some(fn_expr) = self.fn_exprs.find(id) {
                         let replacement = match self.rewrite_fn_expr(fn_expr) {
@@ -436,10 +436,10 @@ where
         }
 
         // Get the first successful matching pattern's substitutions
-        let pattern = patterns
-            .into_iter()
-            .filter_map(|(args, subs)| if args.len() == 1 { Some(subs) } else { None })
-            .next();
+        let pattern =
+            patterns
+                .into_iter()
+                .find_map(|(args, subs)| if args.len() == 1 { Some(subs) } else { None });
 
         // Rewrite the consumed tokens as per the substitution list
         match pattern {
@@ -503,7 +503,7 @@ where
         is_init_arg: bool,
         matchers: &[FnExprArgMatch<'input>],
     ) -> ArgMatch<'input> {
-        use FnExprArgMatch::*;
+        use FnExprArgMatch::{AnyOne, AnyZeroOrMore, Match, NamedArgId, NamedArgKw, Synthesize};
 
         match (&matchers[0], tok) {
             (AnyZeroOrMore(_), _) if is_nested => ArgMatch::Consume(0),
@@ -587,7 +587,7 @@ where
 
         // insert final ')'
         if let Some(t) = toks.pop().map(|(t, _)| t) {
-            rewrite.push(t)
+            rewrite.push(t);
         }
 
         rewrite
@@ -602,7 +602,7 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        self.next().map(|res| res.map_err(|e| e.into()))
+        self.next().map(|res| res.map_err(std::convert::Into::into))
     }
 }
 
@@ -722,30 +722,30 @@ mod tests {
             to_tokens(lexer)
         }
         assert_eq!(
-            preprocess(r#"trim(both from missing)"#)?,
+            preprocess(r"trim(both from missing)")?,
             lex(r#"trim(both: ' ', "from": missing)"#)?
         );
 
         // Valid, but missing final paren
         assert_eq!(
-            preprocess(r#"substring('FooBar' from 2 for 3"#)?,
+            preprocess(r"substring('FooBar' from 2 for 3")?,
             lex(r#"substring('FooBar', "from": 2, "for": 3"#)?
         );
 
         assert_eq!(
-            preprocess(r#"trim(LEADING 'Foo' from 'FooBar')"#)?,
+            preprocess(r"trim(LEADING 'Foo' from 'FooBar')")?,
             lex(r#"trim(LEADING : 'Foo', "from" : 'FooBar')"#)?
         );
 
         assert_eq!(
-            preprocess(r#"trim(LEADING /*blah*/ 'Foo' from 'FooBar')"#)?,
+            preprocess(r"trim(LEADING /*blah*/ 'Foo' from 'FooBar')")?,
             lex(r#"trim(LEADING : /*blah*/ 'Foo', "from" : 'FooBar')"#)?
         );
 
         assert_eq!(
             preprocess(
-                r#"trim(LEADING --blah
-                                             'Foo' from 'FooBar')"#
+                r"trim(LEADING --blah
+                                             'Foo' from 'FooBar')"
             )?,
             lex(r#"trim(LEADING : --blah
                                          'Foo', "from" : 'FooBar')"#)?
@@ -753,202 +753,200 @@ mod tests {
 
         // Trim Specification in all 3 spots
         assert_eq!(
-            preprocess(r#"trim(BOTH TrAiLiNg from TRAILING)"#)?,
+            preprocess(r"trim(BOTH TrAiLiNg from TRAILING)")?,
             lex(r#"trim(BOTH : TrAiLiNg, "from" : TRAILING)"#)?
         );
 
         // Trim specification in 1st and 2nd spot
         assert_eq!(
-            preprocess(r#"trim(LEADING LEADING from 'FooBar')"#)?,
+            preprocess(r"trim(LEADING LEADING from 'FooBar')")?,
             lex(r#"trim(LEADING : LEADING, "from" : 'FooBar')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(LEADING TrAiLiNg from 'FooBar')"#)?,
+            preprocess(r"trim(LEADING TrAiLiNg from 'FooBar')")?,
             lex(r#"trim(LEADING : TrAiLiNg, "from" : 'FooBar')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(tRaIlInG TrAiLiNg from 'FooBar')"#)?,
+            preprocess(r"trim(tRaIlInG TrAiLiNg from 'FooBar')")?,
             lex(r#"trim(tRaIlInG : TrAiLiNg, "from" : 'FooBar')"#)?
         );
 
         // Trim specification in 1st and 3rd spot
         assert_eq!(
-            preprocess(r#"trim(LEADING 'Foo' from leaDing)"#)?,
+            preprocess(r"trim(LEADING 'Foo' from leaDing)")?,
             lex(r#"trim(LEADING : 'Foo', "from" : leaDing)"#)?
         );
 
         // Trim Specification (quoted) in 2nd and 3rd spot
         assert_eq!(
-            preprocess(r#"trim('LEADING' from leaDing)"#)?,
+            preprocess(r"trim('LEADING' from leaDing)")?,
             lex(r#"trim('LEADING', "from" : leaDing)"#)?
         );
 
         // Trim Specification in 3rd spot only
         assert_eq!(
-            preprocess(r#"trim('a' from leaDing)"#)?,
+            preprocess(r"trim('a' from leaDing)")?,
             lex(r#"trim('a', "from" : leaDing)"#)?
         );
 
         assert_eq!(
-            preprocess(r#"trim(leading from '   Bar')"#)?,
+            preprocess(r"trim(leading from '   Bar')")?,
             lex(r#"trim(leading : ' ',  "from" : '   Bar')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(TrAiLiNg 'Bar' from 'FooBar')"#)?,
+            preprocess(r"trim(TrAiLiNg 'Bar' from 'FooBar')")?,
             lex(r#"trim(TrAiLiNg : 'Bar',  "from" : 'FooBar')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(TRAILING from 'Bar   ')"#)?,
+            preprocess(r"trim(TRAILING from 'Bar   ')")?,
             lex(r#"trim(TRAILING: ' ', "from": 'Bar   ')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(BOTH 'Foo' from 'FooBarBar')"#)?,
+            preprocess(r"trim(BOTH 'Foo' from 'FooBarBar')")?,
             lex(r#"trim(BOTH: 'Foo', "from": 'FooBarBar')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(botH from '   Bar   ')"#)?,
+            preprocess(r"trim(botH from '   Bar   ')")?,
             lex(r#"trim(botH: ' ', "from": '   Bar   ')"#)?
         );
         assert_eq!(
-            preprocess(r#"trim(from '   Bar   ')"#)?,
+            preprocess(r"trim(from '   Bar   ')")?,
             lex(r#"trim("from": '   Bar   ')"#)?
         );
 
         assert_eq!(
-            preprocess(r#"position('o' in 'foo')"#)?,
+            preprocess(r"position('o' in 'foo')")?,
             lex(r#"position('o', "in" : 'foo')"#)?
         );
 
         assert_eq!(
-            preprocess(r#"substring('FooBar' from 2 for 3)"#)?,
+            preprocess(r"substring('FooBar' from 2 for 3)")?,
             lex(r#"substring('FooBar', "from": 2, "for": 3)"#)?
         );
         assert_eq!(
-            preprocess(r#"substring('FooBar' from 2)"#)?,
+            preprocess(r"substring('FooBar' from 2)")?,
             lex(r#"substring('FooBar', "from": 2)"#)?
         );
         assert_eq!(
-            preprocess(r#"substring('FooBar' for 3)"#)?,
+            preprocess(r"substring('FooBar' for 3)")?,
             lex(r#"substring('FooBar', "for": 3)"#)?
         );
         assert_eq!(
-            preprocess(r#"substring('FooBar',1,3)"#)?,
-            lex(r#"substring('FooBar', 1,3)"#)?
+            preprocess(r"substring('FooBar',1,3)")?,
+            lex(r"substring('FooBar', 1,3)")?
         );
         assert_eq!(
-            preprocess(r#"substring('FooBar',3)"#)?,
-            lex(r#"substring('FooBar', 3)"#)?
+            preprocess(r"substring('FooBar',3)")?,
+            lex(r"substring('FooBar', 3)")?
         );
 
-        assert_eq!(preprocess(r#"CAST(9 AS b)"#)?, lex(r#"CAST(9, "AS": b)"#)?);
+        assert_eq!(preprocess(r"CAST(9 AS b)")?, lex(r#"CAST(9, "AS": b)"#)?);
         assert_eq!(
-            preprocess(r#"CAST(a AS VARCHAR)"#)?,
+            preprocess(r"CAST(a AS VARCHAR)")?,
             lex(r#"CAST(a, "AS": VARCHAR)"#)?
         );
         assert_eq!(
-            preprocess(r#"CAST(a AS VARCHAR(20))"#)?,
+            preprocess(r"CAST(a AS VARCHAR(20))")?,
             lex(r#"CAST(a, "AS": VARCHAR(20))"#)?
         );
         assert_eq!(
-            preprocess(r#"CAST(TRUE AS INTEGER)"#)?,
+            preprocess(r"CAST(TRUE AS INTEGER)")?,
             lex(r#"CAST(TRUE, "AS": INTEGER)"#)?
         );
         assert_eq!(
-            preprocess(r#"CAST( (4 in (1,2,3,4))  AS INTEGER)"#)?,
+            preprocess(r"CAST( (4 in (1,2,3,4))  AS INTEGER)")?,
             lex(r#"CAST( (4 in (1,2,3,4)) , "AS": INTEGER)"#)?
         );
         assert_eq!(
-            preprocess(r#"cast([1, 2] as INT)"#)?,
+            preprocess(r"cast([1, 2] as INT)")?,
             lex(r#"cast([1, 2] , "as": INT)"#)?
         );
         assert_eq!(
-            preprocess(r#"cast(<<1, 2>> as INT)"#)?,
+            preprocess(r"cast(<<1, 2>> as INT)")?,
             lex(r#"cast(<<1, 2>> , "as": INT)"#)?
         );
         assert_eq!(
-            preprocess(r#"cast({a:1} as INT)"#)?,
+            preprocess(r"cast({a:1} as INT)")?,
             lex(r#"cast({a:1} , "as": INT)"#)?
         );
 
         assert_eq!(
-            preprocess(r#"extract(timezone_minute from a)"#)?,
+            preprocess(r"extract(timezone_minute from a)")?,
             lex(r#"extract(timezone_minute:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(timezone_hour from a)"#)?,
+            preprocess(r"extract(timezone_hour from a)")?,
             lex(r#"extract(timezone_hour:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(year from a)"#)?,
+            preprocess(r"extract(year from a)")?,
             lex(r#"extract(year:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(month from a)"#)?,
+            preprocess(r"extract(month from a)")?,
             lex(r#"extract(month:True, "from" : a)"#)?
         );
 
         assert_eq!(
-            preprocess(r#"extract(day from a)"#)?,
+            preprocess(r"extract(day from a)")?,
             lex(r#"extract(day:True, "from" : a)"#)?
         );
 
         assert_eq!(
-            preprocess(r#"extract(day from day)"#)?,
+            preprocess(r"extract(day from day)")?,
             lex(r#"extract(day:True, "from" : day)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(hour from a)"#)?,
+            preprocess(r"extract(hour from a)")?,
             lex(r#"extract(hour:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(minute from a)"#)?,
+            preprocess(r"extract(minute from a)")?,
             lex(r#"extract(minute:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(second from a)"#)?,
+            preprocess(r"extract(second from a)")?,
             lex(r#"extract(second:True, "from" : a)"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(hour from TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(hour from TIME WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(hour:True, "from" : TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(minute from TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(minute from TIME WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(minute:True, "from" : TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(second from TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(second from TIME WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(second:True, "from" : TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(timezone_hour from TIME WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(timezone_hour from TIME WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(
                 r#"extract(timezone_hour:True, "from" : TIME WITH TIME ZONE '01:23:45.678-06:30')"#
             )?
         );
         assert_eq!(
-            preprocess(
-                r#"extract(timezone_minute from TIME WITH TIME ZONE '01:23:45.678-06:30')"#
-            )?,
+            preprocess(r"extract(timezone_minute from TIME WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(
                 r#"extract(timezone_minute:True, "from" : TIME WITH TIME ZONE '01:23:45.678-06:30')"#
             )?
         );
         assert_eq!(
-            preprocess(r#"extract(hour from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(hour from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(hour:True, "from" : TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(minute from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(minute from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(minute:True, "from" : TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
-            preprocess(r#"extract(second from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?,
+            preprocess(r"extract(second from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')")?,
             lex(r#"extract(second:True, "from" : TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#)?
         );
         assert_eq!(
             preprocess(
-                r#"extract(timezone_hour from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#
+                r"extract(timezone_hour from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"
             )?,
             lex(
                 r#"extract(timezone_hour:True, "from" : TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#
@@ -956,37 +954,37 @@ mod tests {
         );
         assert_eq!(
             preprocess(
-                r#"extract(timezone_minute from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#
+                r"extract(timezone_minute from TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"
             )?,
             lex(
                 r#"extract(timezone_minute:True, "from" : TIME (2) WITH TIME ZONE '01:23:45.678-06:30')"#
             )?
         );
 
-        assert_eq!(preprocess(r#"count(a)"#)?, lex(r#"count(a)"#)?);
+        assert_eq!(preprocess(r"count(a)")?, lex(r"count(a)")?);
         assert_eq!(
-            preprocess(r#"count(DISTINCT a)"#)?,
+            preprocess(r"count(DISTINCT a)")?,
             lex(r#"count("DISTINCT": a)"#)?
         );
-        assert_eq!(preprocess(r#"count(all a)"#)?, lex(r#"count("all": a)"#)?);
-        let q_count_1 = r#"count(1)"#;
+        assert_eq!(preprocess(r"count(all a)")?, lex(r#"count("all": a)"#)?);
+        let q_count_1 = r"count(1)";
         assert_eq!(preprocess(q_count_1)?, lex(q_count_1)?);
-        let q_count_star = r#"count(*)"#;
+        let q_count_star = r"count(*)";
         assert_eq!(preprocess(q_count_star)?, lex(q_count_star)?);
 
-        assert_eq!(preprocess(r#"sum(a)"#)?, lex(r#"sum(a)"#)?);
+        assert_eq!(preprocess(r"sum(a)")?, lex(r"sum(a)")?);
         assert_eq!(
-            preprocess(r#"sum(DISTINCT a)"#)?,
+            preprocess(r"sum(DISTINCT a)")?,
             lex(r#"sum("DISTINCT": a)"#)?
         );
-        assert_eq!(preprocess(r#"sum(all a)"#)?, lex(r#"sum("all": a)"#)?);
-        let q_sum_1 = r#"sum(1)"#;
+        assert_eq!(preprocess(r"sum(all a)")?, lex(r#"sum("all": a)"#)?);
+        let q_sum_1 = r"sum(1)";
         assert_eq!(preprocess(q_sum_1)?, lex(q_sum_1)?);
-        let q_sum_star = r#"sum(*)"#;
+        let q_sum_star = r"sum(*)";
         assert_eq!(preprocess(q_sum_star)?, lex(q_sum_star)?);
 
         assert_eq!(
-            preprocess(r#"COUNT(DISTINCT [1,1,1,1,2])"#)?,
+            preprocess(r"COUNT(DISTINCT [1,1,1,1,2])")?,
             lex(r#"COUNT("DISTINCT" : [1,1,1,1,2])"#)?
         );
 

--- a/partiql-parser/src/token_parser.rs
+++ b/partiql-parser/src/token_parser.rs
@@ -28,7 +28,7 @@ impl<'input, 'tracker> TokenParser<'input, 'tracker> {
     #[inline]
     pub fn consume(&mut self) -> Option<Result<(), Spanned<LexError<'input>, ByteOffset>>> {
         match self.buffer(1) {
-            Some(Ok(_)) => {
+            Some(Ok(())) => {
                 self.consumed_c += 1;
                 Some(Ok(()))
             }

--- a/partiql-rewriter/src/lib.rs
+++ b/partiql-rewriter/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 #[cfg(test)]
 mod tests {

--- a/partiql-source-map/src/lib.rs
+++ b/partiql-source-map/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 //! Source offset & position types and mapping-related helpers.
 

--- a/partiql-source-map/src/line_offset_tracker.rs
+++ b/partiql-source-map/src/line_offset_tracker.rs
@@ -72,6 +72,7 @@ impl LineOffsetTracker {
 
     /// Calculate the number of lines of source seen so far.
     #[inline(always)]
+    #[must_use]
     pub fn num_lines(&self) -> usize {
         self.line_starts.len()
     }
@@ -276,28 +277,28 @@ mod tests {
 
         //lines
         let idx = s.find('2').unwrap();
-        assert_eq!(&s[idx..idx + 1], "2");
+        assert_eq!(&s[idx..=idx], "2");
         assert_eq!(
             tracker.at(s, idx.into()).unwrap(),
             LineAndCharPosition::new(0, 2)
         );
 
         let idx = 1 + idx + s[idx + 1..].find('2').unwrap();
-        assert_eq!(&s[idx..idx + 1], "2");
+        assert_eq!(&s[idx..=idx], "2");
         assert_eq!(
             tracker.at(s, idx.into()).unwrap(),
             LineAndCharPosition::new(1, 2)
         );
 
         let idx = 1 + idx + s[idx + 1..].find('2').unwrap();
-        assert_eq!(&s[idx..idx + 1], "2");
+        assert_eq!(&s[idx..=idx], "2");
         assert_eq!(
             tracker.at(s, idx.into()).unwrap(),
             LineAndCharPosition::new(2, 2)
         );
 
         let idx = 1 + idx + s[idx + 1..].find('2').unwrap();
-        assert_eq!(&s[idx..idx + 1], "2");
+        assert_eq!(&s[idx..=idx], "2");
         assert_eq!(
             tracker.at(s, idx.into()).unwrap(),
             LineAndCharPosition::new(3, 2)

--- a/partiql-source-map/src/location.rs
+++ b/partiql-source-map/src/location.rs
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates.
 
-//! Types representing positions, spans, locations, etc of parsed PartiQL text.
+//! Types representing positions, spans, locations, etc of parsed `PartiQL` text.
 
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
@@ -43,12 +43,14 @@ macro_rules! impl_pos {
         impl $pos_type {
             /// Constructs from a `usize`
             #[inline(always)]
+            #[must_use]
             pub fn from_usize(n: usize) -> Self {
                 Self(n as $primitive)
             }
 
             /// Converts to a `usize`
             #[inline(always)]
+            #[must_use]
             pub fn to_usize(&self) -> usize {
                 self.0 as usize
             }
@@ -133,6 +135,7 @@ pub struct LineAndCharPosition {
 impl LineAndCharPosition {
     /// Constructs at [`LineAndCharPosition`]
     #[inline]
+    #[must_use]
     pub fn new(line: usize, char: usize) -> Self {
         Self {
             line: LineOffset::from_usize(line),
@@ -162,6 +165,7 @@ pub struct LineAndColumn {
 impl LineAndColumn {
     /// Constructs at [`LineAndColumn`] if non-zero-index invariants, else [`None`]
     #[inline]
+    #[must_use]
     pub fn new(line: usize, column: usize) -> Option<Self> {
         Some(Self {
             line: NonZeroUsize::new(line)?,
@@ -176,6 +180,7 @@ impl LineAndColumn {
     ///
     /// Both `line` and `column` values must not be zero.
     #[inline]
+    #[must_use]
     pub const unsafe fn new_unchecked(line: usize, column: usize) -> Self {
         Self {
             line: NonZeroUsize::new_unchecked(line),

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -188,7 +188,7 @@ impl Display for TypeKind {
             TypeKind::AnyOf(anyof) => {
                 format!(
                     "AnyOf({})",
-                    anyof.types.iter().map(|pt| pt.kind()).join(",")
+                    anyof.types.iter().map(PartiqlType::kind).join(",")
                 )
             }
             TypeKind::Null => "Null".to_string(),
@@ -218,7 +218,7 @@ impl Display for TypeKind {
             TypeKind::Array(_) => "Array".to_string(),
             TypeKind::Undefined => "Undefined".to_string(),
         };
-        write!(f, "{}", x)
+        write!(f, "{x}")
     }
 }
 
@@ -240,22 +240,27 @@ pub const TYPE_NUMERIC_TYPES: [PartiqlType; 4] = [TYPE_INT, TYPE_REAL, TYPE_DOUB
 
 #[allow(dead_code)]
 impl PartiqlType {
+    #[must_use]
     pub const fn new(kind: TypeKind) -> PartiqlType {
         PartiqlType(kind)
     }
 
+    #[must_use]
     pub fn new_any() -> PartiqlType {
         PartiqlType(TypeKind::Any)
     }
 
+    #[must_use]
     pub fn new_struct(s: StructType) -> PartiqlType {
         PartiqlType(TypeKind::Struct(s))
     }
 
+    #[must_use]
     pub fn new_bag(b: BagType) -> PartiqlType {
         PartiqlType(TypeKind::Bag(b))
     }
 
+    #[must_use]
     pub fn new_array(a: ArrayType) -> PartiqlType {
         PartiqlType(TypeKind::Array(a))
     }
@@ -275,6 +280,7 @@ impl PartiqlType {
         }
     }
 
+    #[must_use]
     pub fn union_with(self, other: PartiqlType) -> PartiqlType {
         match (self.0, other.0) {
             (TypeKind::Any, _) | (_, TypeKind::Any) => PartiqlType::new(TypeKind::Any),
@@ -293,44 +299,54 @@ impl PartiqlType {
         }
     }
 
+    #[must_use]
     pub fn is_string(&self) -> bool {
         matches!(&self, PartiqlType(TypeKind::String))
     }
 
+    #[must_use]
     pub fn kind(&self) -> &TypeKind {
         &self.0
     }
 
+    #[must_use]
     pub fn is_struct(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Struct(_)))
     }
 
+    #[must_use]
     pub fn is_collection(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Bag(_)))
             || matches!(*self, PartiqlType(TypeKind::Array(_)))
     }
 
+    #[must_use]
     pub fn is_unordered_collection(&self) -> bool {
         !self.is_ordered_collection()
     }
 
+    #[must_use]
     pub fn is_ordered_collection(&self) -> bool {
         // TODO Add Sexp when added
         matches!(*self, PartiqlType(TypeKind::Array(_)))
     }
 
+    #[must_use]
     pub fn is_bag(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Bag(_)))
     }
 
+    #[must_use]
     pub fn is_array(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Array(_)))
     }
 
+    #[must_use]
     pub fn is_any(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Any))
     }
 
+    #[must_use]
     pub fn is_undefined(&self) -> bool {
         matches!(*self, PartiqlType(TypeKind::Undefined))
     }
@@ -343,6 +359,7 @@ pub struct AnyOf {
 }
 
 impl AnyOf {
+    #[must_use]
     pub const fn new(types: BTreeSet<PartiqlType>) -> Self {
         AnyOf { types }
     }
@@ -367,16 +384,19 @@ pub struct StructType {
 }
 
 impl StructType {
+    #[must_use]
     pub fn new(constraints: BTreeSet<StructConstraint>) -> Self {
         StructType { constraints }
     }
 
+    #[must_use]
     pub fn new_any() -> Self {
         StructType {
             constraints: Default::default(),
         }
     }
 
+    #[must_use]
     pub fn fields(&self) -> Vec<StructField> {
         self.constraints
             .iter()
@@ -390,10 +410,12 @@ impl StructType {
             .collect()
     }
 
+    #[must_use]
     pub fn is_partial(&self) -> bool {
         !self.is_closed()
     }
 
+    #[must_use]
     pub fn is_closed(&self) -> bool {
         self.constraints.contains(&StructConstraint::Open(false))
     }
@@ -417,6 +439,7 @@ pub struct StructField {
 }
 
 impl StructField {
+    #[must_use]
     pub fn new(name: &str, ty: PartiqlType) -> Self {
         StructField {
             name: name.to_string(),
@@ -424,10 +447,12 @@ impl StructField {
         }
     }
 
+    #[must_use]
     pub fn name(&self) -> &str {
         self.name.as_str()
     }
 
+    #[must_use]
     pub fn ty(&self) -> &PartiqlType {
         &self.ty
     }
@@ -449,14 +474,17 @@ pub struct BagType {
 }
 
 impl BagType {
+    #[must_use]
     pub fn new_any() -> Self {
         BagType::new(Box::new(PartiqlType(TypeKind::Any)))
     }
 
+    #[must_use]
     pub fn new(typ: Box<PartiqlType>) -> Self {
         BagType { element_type: typ }
     }
 
+    #[must_use]
     pub fn element_type(&self) -> &PartiqlType {
         &self.element_type
     }
@@ -471,14 +499,17 @@ pub struct ArrayType {
 }
 
 impl ArrayType {
+    #[must_use]
     pub fn new_any() -> Self {
         ArrayType::new(Box::new(PartiqlType(TypeKind::Any)))
     }
 
+    #[must_use]
     pub fn new(typ: Box<PartiqlType>) -> Self {
         ArrayType { element_type: typ }
     }
 
+    #[must_use]
     pub fn element_type(&self) -> &PartiqlType {
         &self.element_type
     }

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use itertools::Itertools;
 use std::collections::BTreeSet;

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Default, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-/// Represents a PartiQL BAG value, e.g.: <<1, 'two', 4>>
+/// Represents a `PartiQL` BAG value, e.g.: <<1, 'two', 4>>
 pub struct Bag(Vec<Value>);
 
 impl Bag {
@@ -24,16 +24,19 @@ impl Bag {
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     #[inline]
+    #[must_use]
     pub fn iter(&self) -> BagIter<'_> {
         BagIter(self.0.iter())
     }
@@ -44,6 +47,7 @@ impl Bag {
     }
 
     #[inline]
+    #[must_use]
     pub fn to_vec(self) -> Vec<Value> {
         self.0
     }

--- a/partiql-value/src/datetime.rs
+++ b/partiql-value/src/datetime.rs
@@ -17,18 +17,22 @@ pub enum DateTime {
 }
 
 impl DateTime {
+    #[must_use]
     pub fn from_system_now_utc() -> Self {
         DateTime::TimestampWithTz(time::OffsetDateTime::now_utc())
     }
 
+    #[must_use]
     pub fn from_hms(hour: u8, minute: u8, second: u8) -> Self {
         DateTime::Time(time::Time::from_hms(hour, minute, second).expect("valid time value"))
     }
 
+    #[must_use]
     pub fn from_hms_nano(hour: u8, minute: u8, second: u8, nanosecond: u32) -> Self {
         Self::from_hms_nano_offset(hour, minute, second, nanosecond, None)
     }
 
+    #[must_use]
     pub fn from_hms_nano_tz(
         hour: u8,
         minute: u8,
@@ -47,6 +51,7 @@ impl DateTime {
         Self::from_hms_nano_offset(hour, minute, second, nanosecond, offset)
     }
 
+    #[must_use]
     pub fn from_ymd(year: i32, month: NonZeroU8, day: u8) -> Self {
         let month: time::Month = month.get().try_into().expect("valid month");
         let date = time::Date::from_calendar_date(year, month, day).expect("valid ymd");
@@ -54,6 +59,7 @@ impl DateTime {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[must_use]
     pub fn from_ymdhms_nano_offset_minutes(
         year: i32,
         month: NonZeroU8,
@@ -137,8 +143,8 @@ impl Ord for DateTime {
             (_, DateTime::Time(_)) => Ordering::Greater,
 
             (DateTime::TimeWithTz(l, lo), DateTime::TimeWithTz(r, ro)) => {
-                let lod = Duration::new(lo.whole_seconds() as i64, 0);
-                let rod = Duration::new(ro.whole_seconds() as i64, 0);
+                let lod = Duration::new(i64::from(lo.whole_seconds()), 0);
+                let rod = Duration::new(i64::from(ro.whole_seconds()), 0);
                 let l_adjusted = *l + lod;
                 let r_adjusted = *r + rod;
                 l_adjusted.cmp(&r_adjusted)

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -411,21 +411,15 @@ impl<'a, const GROUP_NULLS: bool> NullableEq for EqualityValue<'a, GROUP_NULLS, 
     type Output = Value;
 
     fn eq(&self, rhs: &Self) -> Self::Output {
-        match GROUP_NULLS {
-            true => match (self.0, rhs.0) {
-                (Value::Missing | Value::Null, Value::Missing | Value::Null) => {
-                    return Value::Boolean(true)
-                }
-                _ => {}
-            },
-            false => match (self.0, rhs.0) {
-                (Value::Missing, _) => return Value::Missing,
-                (_, Value::Missing) => return Value::Missing,
-                (Value::Null, _) => return Value::Null,
-                (_, Value::Null) => return Value::Null,
-                _ => {}
-            },
-        };
+        if GROUP_NULLS {
+            if let (Value::Missing | Value::Null, Value::Missing | Value::Null) = (self.0, rhs.0) {
+                return Value::Boolean(true);
+            }
+        } else if matches!(self.0, Value::Missing) || matches!(rhs.0, Value::Missing) {
+            return Value::Missing;
+        } else if matches!(self.0, Value::Null) || matches!(rhs.0, Value::Null) {
+            return Value::Null;
+        }
 
         match (self.0, rhs.0) {
             (Value::Integer(_), Value::Real(_)) => {

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Default, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-/// Represents a PartiQL List value, e.g. [1, 2, 'one']
+/// Represents a `PartiQL` List value, e.g. [1, 2, 'one']
 pub struct List(Vec<Value>);
 
 impl List {
@@ -21,16 +21,19 @@ impl List {
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     #[inline]
+    #[must_use]
     pub fn get(&self, idx: i64) -> Option<&Value> {
         self.0.get(idx as usize)
     }
@@ -41,11 +44,13 @@ impl List {
     }
 
     #[inline]
+    #[must_use]
     pub fn take_val(self, idx: i64) -> Option<Value> {
         self.0.into_iter().nth(idx as usize)
     }
 
     #[inline]
+    #[must_use]
     pub fn iter(&self) -> ListIter<'_> {
         ListIter(self.0.iter())
     }
@@ -56,6 +61,7 @@ impl List {
     }
 
     #[inline]
+    #[must_use]
     pub fn to_vec(self) -> Vec<Value> {
         self.0
     }
@@ -231,7 +237,7 @@ impl Ord for List {
 
 impl Hash for List {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for v in self.0.iter() {
+        for v in &self.0 {
             v.hash(state);
         }
     }

--- a/partiql-value/src/tuple.rs
+++ b/partiql-value/src/tuple.rs
@@ -21,6 +21,7 @@ pub struct Tuple {
 }
 
 impl Tuple {
+    #[must_use]
     pub fn new() -> Self {
         Tuple {
             attrs: vec![],
@@ -35,11 +36,13 @@ impl Tuple {
     }
 
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.attrs.len()
     }
 
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -50,6 +53,7 @@ impl Tuple {
     /// contains unique attributes. In the case of duplicate attributes between `self` and `other`,
     /// the result `Tuple` will contain the attribute provided by `other`. See section 3.4 of the
     /// spec for details: https://partiql.org/assets/PartiQL-Specification.pdf#subsection.3.4.
+    #[must_use]
     pub fn tuple_concat(&self, other: &Tuple) -> Self {
         other
             .pairs()
@@ -60,11 +64,13 @@ impl Tuple {
     }
 
     #[inline]
+    #[must_use]
     pub fn get(&self, attr: &BindingsName<'_>) -> Option<&Value> {
         self.find_value(attr).map(|i| &self.vals[i])
     }
 
     #[inline]
+    #[must_use]
     pub fn take_val(self, attr: &BindingsName<'_>) -> Option<Value> {
         self.find_value(attr)
             .and_then(|i| self.vals.into_iter().nth(i))
@@ -95,11 +101,13 @@ impl Tuple {
     }
 
     #[inline]
+    #[must_use]
     pub fn pairs(&self) -> PairsIter<'_> {
         PairsIter(zip(self.attrs.iter(), self.vals.iter()))
     }
 
     #[inline]
+    #[must_use]
     pub fn into_pairs(self) -> PairsIntoIter {
         PairsIntoIter(zip(self.attrs, self.vals))
     }

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(clippy::all)]
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Add `#![deny(clippy::all)]` to all `lib.rs`
- Apply automatic fixes from `cargo clippy --fix --all-features; cargo fmt`
- Manually clean-up the ~3 clippy recommendations that automatics fixes didn't fix.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
