### PR TITLE
Use a BTreeSet for struct fields to assure stable hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- partiql-types: Fixed handling of struct fields to be resilient to field order w.r.t. equality and hashing 
 
 ## [0.7.1] - 2024-03-15
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,34 +2,33 @@
 authors = ["PartiQL Team <partiql-team@amazon.com>"]
 homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [workspace]
 resolver = "2"
 
 members = [
-  "partiql",
-  "partiql-ast",
-  "partiql-ast/partiql-ast-macros",
-  "partiql-ast-passes",
-  "partiql-catalog",
-  "partiql-conformance-tests",
-  "partiql-conformance-test-generator",
-  "partiql-source-map",
-  "partiql-logical-planner",
-  "partiql-logical",
-  "partiql-eval",
-  "partiql-ir",
-  "partiql-irgen",
-  "partiql-parser",
-  "partiql-rewriter",
-  "partiql-types",
-  "partiql-value",
-
-  "extension/partiql-extension-ion",
-  "extension/partiql-extension-ion-functions",
-  "extension/partiql-extension-visualize",
+    "partiql",
+    "partiql-ast",
+    "partiql-ast/partiql-ast-macros",
+    "partiql-ast-passes",
+    "partiql-catalog",
+    "partiql-conformance-tests",
+    "partiql-conformance-test-generator",
+    "partiql-source-map",
+    "partiql-logical-planner",
+    "partiql-logical",
+    "partiql-eval",
+    "partiql-ir",
+    "partiql-irgen",
+    "partiql-parser",
+    "partiql-rewriter",
+    "partiql-types",
+    "partiql-value",
+    "extension/partiql-extension-ion",
+    "extension/partiql-extension-ion-functions",
+    "extension/partiql-extension-visualize",
 ]
 
 [profile.dev.build-override]

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -109,7 +109,7 @@ macro_rules! r#struct {
 #[macro_export]
 macro_rules! struct_fields {
     ($(($x:expr, $y:expr)),+ $(,)?) => (
-        $crate::StructConstraint::Fields(vec![$(($x, $y).into()),+])
+        $crate::StructConstraint::Fields([$(($x, $y).into()),+].into())
     );
 }
 
@@ -397,14 +397,14 @@ impl StructType {
     }
 
     #[must_use]
-    pub fn fields(&self) -> Vec<StructField> {
+    pub fn fields(&self) -> BTreeSet<StructField> {
         self.constraints
             .iter()
             .flat_map(|c| {
                 if let StructConstraint::Fields(fields) = c.clone() {
                     fields
                 } else {
-                    vec![]
+                    Default::default()
                 }
             })
             .collect()
@@ -428,7 +428,7 @@ pub enum StructConstraint {
     Open(bool),
     Ordered(bool),
     DuplicateAttrs(bool),
-    Fields(Vec<StructField>),
+    Fields(BTreeSet<StructField>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]

--- a/partiql/src/subquery_tests.rs
+++ b/partiql/src/subquery_tests.rs
@@ -89,7 +89,7 @@ mod tests {
         let res = evaluate(&catalog, plan, bindings, &[]).expect("should eval correctly");
         dbg!(&res);
         assert!(res != Value::Missing);
-        assert_eq!(res, Value::from(bag![tuple![("a", "b")]]))
+        assert_eq!(res, Value::from(bag![tuple![("a", "b")]]));
     }
 
     #[test]
@@ -150,6 +150,6 @@ mod tests {
         let res = evaluate(&catalog, plan, bindings, &[]).expect("should eval correctly");
         dbg!(&res);
         assert!(res != Value::Missing);
-        assert_eq!(res, Value::from(bag![tuple![("a", "b")]]))
+        assert_eq!(res, Value::from(bag![tuple![("a", "b")]]));
     }
 }


### PR DESCRIPTION
partiql-types: Fixed handling of struct fields to be resilient to field order w.r.t. equality and hashing 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
