### PR TITLE
Add codecov token to CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 env:
   RUST_TEST_TIME_UNIT: 150,5000
   RUST_TEST_TIME_INTEGRATION: 150,5000
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
   build:


### PR DESCRIPTION
As per https://docs.codecov.com/docs/adding-the-codecov-token

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
