### PR TITLE
Feat refactor shape builder

### DIFF
--- a/extension/partiql-extension-ddl/tests/ddl-tests.rs
+++ b/extension/partiql-extension-ddl/tests/ddl-tests.rs
@@ -4,26 +4,30 @@ use partiql_types::{
     struct_fields, type_bag, type_int, type_string, type_struct, PartiqlShapeBuilder,
     StructConstraint, StructField,
 };
-use partiql_types::{BagType, Static, StructType};
+use partiql_types::{Static, StructType};
 
 #[test]
 fn basic_ddl_test() {
-    let details_fields = struct_fields![("age", type_int!())];
-    let details = type_struct![IndexSet::from([details_fields])];
+    let mut bld = PartiqlShapeBuilder::default();
+    let details_fields = struct_fields![("age", type_int!(bld))];
+    let details = type_struct![bld, IndexSet::from([details_fields])];
     let fields = [
-        StructField::new("id", type_int!()),
-        StructField::new("name", type_string!()),
-        StructField::new(
-            "address",
-            PartiqlShapeBuilder::init_or_get().new_non_nullable_static(Static::String),
-        ),
+        StructField::new("id", type_int!(bld)),
+        StructField::new("name", type_string!(bld)),
+        StructField::new("address", bld.new_non_nullable_static(Static::String)),
         StructField::new_optional("details", details.clone()),
     ]
     .into();
-    let shape = type_bag![type_struct![IndexSet::from([
-        StructConstraint::Fields(fields),
-        StructConstraint::Open(false)
-    ])]];
+    let shape = type_bag![
+        bld,
+        type_struct![
+            bld,
+            IndexSet::from([
+                StructConstraint::Fields(fields),
+                StructConstraint::Open(false)
+            ])
+        ]
+    ];
 
     let ddl_compact = PartiqlBasicDdlEncoder::new(DdlFormat::Compact);
     let actual = ddl_compact.ddl(&shape).expect("ddl_output");

--- a/partiql-ast/src/builder.rs
+++ b/partiql-ast/src/builder.rs
@@ -43,6 +43,7 @@ mod tests {
     use crate::pretty::*;
     use crate::visit::{Traverse, Visit, Visitor};
     use partiql_common::node::NodeId;
+    use partiql_common::pretty::ToPretty;
 
     #[test]
     fn unique_ids() {

--- a/partiql-ast/src/builder.rs
+++ b/partiql-ast/src/builder.rs
@@ -16,9 +16,8 @@ where
     }
 
     pub fn node<T>(&mut self, node: T) -> AstNode<T> {
-        let id = self.id_gen.id();
-        let id = id.read().expect("NodId read lock");
-        AstNode { id: *id, node }
+        let id = self.id_gen.next_id();
+        AstNode { id, node }
     }
 }
 

--- a/partiql-ast/src/builder.rs
+++ b/partiql-ast/src/builder.rs
@@ -40,7 +40,7 @@ pub type AstNodeBuilderWithNullId = AstNodeBuilder<NullIdGenerator>;
 mod tests {
     use super::AstNodeBuilderWithAutoId;
     use crate::ast;
-    use crate::pretty::*;
+
     use crate::visit::{Traverse, Visit, Visitor};
     use partiql_common::node::NodeId;
     use partiql_common::pretty::ToPretty;

--- a/partiql-common/src/node.rs
+++ b/partiql-common/src/node.rs
@@ -59,3 +59,21 @@ impl NodeIdGenerator for NullIdGenerator {
         NodeId(0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::node::{AutoNodeIdGenerator, NodeIdGenerator};
+
+    #[test]
+    fn unique_ids() {
+        let gen = AutoNodeIdGenerator::default();
+
+        let ids: Vec<_> = std::iter::repeat_with(|| gen.next_id()).take(15).collect();
+        dbg!(&ids);
+        for i in 0..ids.len() {
+            for j in i + 1..ids.len() {
+                assert_ne!(ids[i], ids[j]);
+            }
+        }
+    }
+}

--- a/partiql-common/src/node.rs
+++ b/partiql-common/src/node.rs
@@ -1,11 +1,16 @@
 use indexmap::IndexMap;
 use std::hash::Hash;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub type NodeMap<T> = IndexMap<NodeId, T>;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeId(pub u32);
 
+#[derive(Debug)]
 /// Auto-incrementing [`NodeIdGenerator`]
 pub struct AutoNodeIdGenerator {
     next_id: NodeId,

--- a/partiql-common/src/node.rs
+++ b/partiql-common/src/node.rs
@@ -1,48 +1,34 @@
 use indexmap::IndexMap;
-use std::sync::{Arc, RwLock};
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use std::hash::Hash;
 
 pub type NodeMap<T> = IndexMap<NodeId, T>;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeId(pub u32);
 
 /// Auto-incrementing [`NodeIdGenerator`]
 pub struct AutoNodeIdGenerator {
-    next_id: Arc<RwLock<NodeId>>,
+    next_id: NodeId,
 }
 
 impl Default for AutoNodeIdGenerator {
     fn default() -> Self {
-        AutoNodeIdGenerator {
-            next_id: Arc::new(RwLock::from(NodeId(1))),
-        }
+        AutoNodeIdGenerator { next_id: NodeId(1) }
     }
 }
 
 /// A provider of 'fresh' [`NodeId`]s.
 pub trait NodeIdGenerator {
-    fn id(&self) -> Arc<RwLock<NodeId>>;
-
     /// Provides a 'fresh' [`NodeId`].
-    fn next_id(&self) -> NodeId;
+    fn next_id(&mut self) -> NodeId;
 }
 
 impl NodeIdGenerator for AutoNodeIdGenerator {
-    fn id(&self) -> Arc<RwLock<NodeId>> {
-        let id = self.next_id();
-        let mut w = self.next_id.write().expect("NodId write lock");
-        *w = id;
-        Arc::clone(&self.next_id)
-    }
-
     #[inline]
-    fn next_id(&self) -> NodeId {
-        let id = &self.next_id.read().expect("NodId read lock");
-        NodeId(id.0 + 1)
+    fn next_id(&mut self) -> NodeId {
+        let mut next = NodeId(&self.next_id.0 + 1);
+        std::mem::swap(&mut self.next_id, &mut next);
+        next
     }
 }
 
@@ -51,11 +37,7 @@ impl NodeIdGenerator for AutoNodeIdGenerator {
 pub struct NullIdGenerator {}
 
 impl NodeIdGenerator for NullIdGenerator {
-    fn id(&self) -> Arc<RwLock<NodeId>> {
-        Arc::new(RwLock::from(self.next_id()))
-    }
-
-    fn next_id(&self) -> NodeId {
+    fn next_id(&mut self) -> NodeId {
         NodeId(0)
     }
 }
@@ -66,7 +48,7 @@ mod tests {
 
     #[test]
     fn unique_ids() {
-        let gen = AutoNodeIdGenerator::default();
+        let mut gen = AutoNodeIdGenerator::default();
 
         let ids: Vec<_> = std::iter::repeat_with(|| gen.next_id()).take(15).collect();
         dbg!(&ids);

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -4,7 +4,7 @@ use crate::eval::expr::{BindError, EvalExpr};
 use crate::eval::EvalContext;
 use itertools::Itertools;
 
-use partiql_types::{type_dynamic, PartiqlShape, Static, TYPE_DYNAMIC};
+use partiql_types::{PartiqlShape, Static, TYPE_DYNAMIC};
 use partiql_value::Value::{Missing, Null};
 use partiql_value::{Tuple, Value};
 
@@ -469,7 +469,7 @@ impl UnaryValueExpr {
     where
         F: 'static + Fn(&Value) -> Value,
     {
-        Self::create_typed::<STRICT, F>([type_dynamic!(); 1], args, f)
+        Self::create_typed::<STRICT, F>([PartiqlShape::Dynamic; 1], args, f)
     }
 
     #[allow(dead_code)]

--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -5,7 +5,7 @@ use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use itertools::{Itertools, Unique};
 
 use partiql_types::{
-    type_numeric, DummyShapeBuilder, PartiqlShape, ShapeBuilderExtensions, Static,
+    type_numeric, PartiqlNoIdShapeBuilder, PartiqlShape, ShapeBuilderExtensions, Static,
 };
 use partiql_value::Value::{Missing, Null};
 use partiql_value::{BinaryAnd, BinaryOr, Value, ValueIter};
@@ -53,7 +53,7 @@ impl BindEvalExpr for EvalCollFn {
         }
 
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
 
         let boolean_elems = [
             bld.new_array_of_static(Static::Bool),

--- a/partiql-eval/src/eval/expr/datetime.rs
+++ b/partiql-eval/src/eval/expr/datetime.rs
@@ -1,6 +1,6 @@
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 
-use partiql_types::{type_datetime, DummyShapeBuilder};
+use partiql_types::{type_datetime, PartiqlNoIdShapeBuilder};
 use partiql_value::Value::Missing;
 use partiql_value::{DateTime, Value};
 
@@ -42,7 +42,7 @@ impl BindEvalExpr for EvalExtractFn {
             Decimal::from_i128_with_scale(total, NANOSECOND_SCALE).into()
         }
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
 
         let create = |f: fn(&DateTime) -> Value| {
             UnaryValueExpr::create_typed::<{ STRICT }, _>(

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -5,7 +5,7 @@ use crate::eval::eval_expr_wrapper::{
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;
 
-use partiql_types::{DummyShapeBuilder, PartiqlShapeBuilder, StructType};
+use partiql_types::PartiqlNoIdShapeBuilder;
 use partiql_value::{Tuple, Value};
 
 use std::borrow::Cow;
@@ -43,7 +43,7 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
     {
         type Check<const STRICT: bool> = DefaultArgChecker<STRICT, PropagateMissing<true>>;
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let typ = bld.new_struct_of_dyn();
         match evaluate_and_validate_args::<{ STRICT }, Check<STRICT>, _>(
             &self.args,

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -5,7 +5,7 @@ use crate::eval::eval_expr_wrapper::{
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;
 
-use partiql_types::{PartiqlShapeBuilder, StructType};
+use partiql_types::{DummyShapeBuilder, PartiqlShapeBuilder, StructType};
 use partiql_value::{Tuple, Value};
 
 use std::borrow::Cow;
@@ -42,7 +42,9 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
         'c: 'a,
     {
         type Check<const STRICT: bool> = DefaultArgChecker<STRICT, PropagateMissing<true>>;
-        let typ = PartiqlShapeBuilder::init_or_get().new_struct(StructType::new_any());
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
+        let typ = bld.new_struct_of_dyn();
         match evaluate_and_validate_args::<{ STRICT }, Check<STRICT>, _>(
             &self.args,
             |_| &typ,

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -8,7 +8,8 @@ use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;
 
 use partiql_types::{
-    type_bool, type_dynamic, type_numeric, DummyShapeBuilder, PartiqlShape, ShapeBuilderExtensions,
+    type_bool, type_dynamic, type_numeric, PartiqlNoIdShapeBuilder, PartiqlShape,
+    ShapeBuilderExtensions,
 };
 use partiql_value::Value::{Boolean, Missing, Null};
 use partiql_value::{BinaryAnd, Comparable, EqualityValue, NullableEq, NullableOrd, Tuple, Value};
@@ -80,7 +81,7 @@ impl BindEvalExpr for EvalOpUnary {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let any_num = type_numeric!(&mut bld);
 
         let unop = |types, f: fn(&Value) -> Value| {
@@ -190,7 +191,7 @@ impl BindEvalExpr for EvalOpBinary {
         type MathCheck<const STRICT: bool> = DefaultArgChecker<STRICT, PropagateMissing<true>>;
 
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
 
         macro_rules! create {
             ($check: ty, $types: expr, $f:expr) => {
@@ -398,7 +399,7 @@ impl BindEvalExpr for EvalFnAbs {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let nums = type_numeric!(&mut bld);
         UnaryValueExpr::create_typed::<{ STRICT }, _>([nums], args, |v| {
             match NullableOrd::lt(v, &Value::from(0)) {
@@ -421,7 +422,7 @@ impl BindEvalExpr for EvalFnCardinality {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let collections = [
             bld.new_array_of_dyn(),
             bld.new_bag_of_dyn(),

--- a/partiql-eval/src/eval/expr/pattern_match.rs
+++ b/partiql-eval/src/eval/expr/pattern_match.rs
@@ -2,7 +2,7 @@ use crate::error::PlanningError;
 
 use crate::eval::eval_expr_wrapper::{TernaryValueExpr, UnaryValueExpr};
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
-use partiql_types::{type_string, DummyShapeBuilder};
+use partiql_types::{type_string, PartiqlNoIdShapeBuilder};
 use partiql_value::Value;
 use partiql_value::Value::Missing;
 use regex::{Regex, RegexBuilder};
@@ -47,7 +47,7 @@ impl BindEvalExpr for EvalLikeMatch {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let pattern = self.pattern.clone();
         UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!(bld)], args, move |value| {
             match value {
@@ -69,7 +69,7 @@ impl BindEvalExpr for EvalLikeNonStringNonLiteralMatch {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let types = [type_string!(bld), type_string!(bld), type_string!(bld)];
         TernaryValueExpr::create_typed::<{ STRICT }, _>(
             types,

--- a/partiql-eval/src/eval/expr/pattern_match.rs
+++ b/partiql-eval/src/eval/expr/pattern_match.rs
@@ -2,7 +2,7 @@ use crate::error::PlanningError;
 
 use crate::eval::eval_expr_wrapper::{TernaryValueExpr, UnaryValueExpr};
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
-use partiql_types::type_string;
+use partiql_types::{type_string, DummyShapeBuilder};
 use partiql_value::Value;
 use partiql_value::Value::Missing;
 use regex::{Regex, RegexBuilder};
@@ -46,8 +46,10 @@ impl BindEvalExpr for EvalLikeMatch {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
         let pattern = self.pattern.clone();
-        UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!()], args, move |value| {
+        UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!(bld)], args, move |value| {
             match value {
                 Value::String(s) => Value::Boolean(pattern.is_match(s.as_ref())),
                 _ => Missing,
@@ -66,7 +68,9 @@ impl BindEvalExpr for EvalLikeNonStringNonLiteralMatch {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
-        let types = [type_string!(), type_string!(), type_string!()];
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
+        let types = [type_string!(bld), type_string!(bld), type_string!(bld)];
         TernaryValueExpr::create_typed::<{ STRICT }, _>(
             types,
             args,

--- a/partiql-eval/src/eval/expr/strings.rs
+++ b/partiql-eval/src/eval/expr/strings.rs
@@ -5,7 +5,7 @@ use crate::eval::eval_expr_wrapper::{
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use itertools::Itertools;
 
-use partiql_types::{type_int, type_string};
+use partiql_types::{type_int, type_string, DummyShapeBuilder};
 use partiql_value::Value;
 use partiql_value::Value::Missing;
 
@@ -40,7 +40,9 @@ impl BindEvalExpr for EvalStringFn {
             F: Fn(&Box<String>) -> R + 'static,
             R: Into<Value> + 'static,
         {
-            UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!()], args, move |value| {
+            // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+            let mut bld = DummyShapeBuilder::default();
+            UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!(bld)], args, move |value| {
                 match value {
                     Value::String(value) => (f(value)).into(),
                     _ => Missing,
@@ -72,9 +74,11 @@ impl BindEvalExpr for EvalTrimFn {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
         let create = |f: for<'a> fn(&'a str, &'a str) -> &'a str| {
             BinaryValueExpr::create_typed::<{ STRICT }, _>(
-                [type_string!(), type_string!()],
+                [type_string!(bld), type_string!(bld)],
                 args,
                 move |to_trim, value| match (to_trim, value) {
                     (Value::String(to_trim), Value::String(value)) => {
@@ -110,8 +114,10 @@ impl BindEvalExpr for EvalFnPosition {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
         BinaryValueExpr::create_typed::<STRICT, _>(
-            [type_string!(), type_string!()],
+            [type_string!(bld), type_string!(bld)],
             args,
             |needle, haystack| match (needle, haystack) {
                 (Value::String(needle), Value::String(haystack)) => {
@@ -132,9 +138,11 @@ impl BindEvalExpr for EvalFnSubstring {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
         match args.len() {
             2 => BinaryValueExpr::create_typed::<STRICT, _>(
-                [type_string!(), type_int!()],
+                [type_string!(bld), type_int!(bld)],
                 args,
                 |value, offset| match (value, offset) {
                     (Value::String(value), Value::Integer(offset)) => {
@@ -146,7 +154,7 @@ impl BindEvalExpr for EvalFnSubstring {
                 },
             ),
             3 => TernaryValueExpr::create_typed::<STRICT, _>(
-                [type_string!(), type_int!(), type_int!()],
+                [type_string!(bld), type_int!(bld), type_int!(bld)],
                 args,
                 |value, offset, length| match (value, offset, length) {
                     (Value::String(value), Value::Integer(offset), Value::Integer(length)) => {
@@ -182,6 +190,8 @@ impl BindEvalExpr for EvalFnOverlay {
         self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
+        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
+        let mut bld = DummyShapeBuilder::default();
         fn overlay(value: &str, replacement: &str, offset: i64, length: usize) -> Value {
             let mut value = value.to_string();
             let start = std::cmp::max(offset - 1, 0) as usize;
@@ -197,7 +207,7 @@ impl BindEvalExpr for EvalFnOverlay {
 
         match args.len() {
             3 => TernaryValueExpr::create_typed::<STRICT, _>(
-                [type_string!(), type_string!(), type_int!()],
+                [type_string!(bld), type_string!(bld), type_int!(bld)],
                 args,
                 |value, replacement, offset| match (value, replacement, offset) {
                     (Value::String(value), Value::String(replacement), Value::Integer(offset)) => {
@@ -208,7 +218,12 @@ impl BindEvalExpr for EvalFnOverlay {
                 },
             ),
             4 => QuaternaryValueExpr::create_typed::<STRICT, _>(
-                [type_string!(), type_string!(), type_int!(), type_int!()],
+                [
+                    type_string!(bld),
+                    type_string!(bld),
+                    type_int!(bld),
+                    type_int!(bld),
+                ],
                 args,
                 |value, replacement, offset, length| match (value, replacement, offset, length) {
                     (

--- a/partiql-eval/src/eval/expr/strings.rs
+++ b/partiql-eval/src/eval/expr/strings.rs
@@ -5,7 +5,7 @@ use crate::eval::eval_expr_wrapper::{
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use itertools::Itertools;
 
-use partiql_types::{type_int, type_string, DummyShapeBuilder};
+use partiql_types::{type_int, type_string, PartiqlNoIdShapeBuilder};
 use partiql_value::Value;
 use partiql_value::Value::Missing;
 
@@ -41,7 +41,7 @@ impl BindEvalExpr for EvalStringFn {
             R: Into<Value> + 'static,
         {
             // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-            let mut bld = DummyShapeBuilder::default();
+            let mut bld = PartiqlNoIdShapeBuilder::default();
             UnaryValueExpr::create_typed::<{ STRICT }, _>([type_string!(bld)], args, move |value| {
                 match value {
                     Value::String(value) => (f(value)).into(),
@@ -75,7 +75,7 @@ impl BindEvalExpr for EvalTrimFn {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         let create = |f: for<'a> fn(&'a str, &'a str) -> &'a str| {
             BinaryValueExpr::create_typed::<{ STRICT }, _>(
                 [type_string!(bld), type_string!(bld)],
@@ -115,7 +115,7 @@ impl BindEvalExpr for EvalFnPosition {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         BinaryValueExpr::create_typed::<STRICT, _>(
             [type_string!(bld), type_string!(bld)],
             args,
@@ -139,7 +139,7 @@ impl BindEvalExpr for EvalFnSubstring {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         match args.len() {
             2 => BinaryValueExpr::create_typed::<STRICT, _>(
                 [type_string!(bld), type_int!(bld)],
@@ -191,7 +191,7 @@ impl BindEvalExpr for EvalFnOverlay {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         fn overlay(value: &str, replacement: &str, offset: i64, length: usize) -> Value {
             let mut value = value.to_string();
             let start = std::cmp::max(offset - 1, 0) as usize;

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1966,7 +1966,7 @@ mod tests {
     use partiql_catalog::catalog::{PartiqlCatalog, TypeEnvEntry};
     use partiql_logical::BindingsOp::Project;
     use partiql_logical::ValueExpr;
-    use partiql_types::type_dynamic;
+    use partiql_types::PartiqlShape;
 
     #[test]
     fn test_plan_non_existent_fns() {
@@ -2062,7 +2062,8 @@ mod tests {
         expected_logical.add_flow_with_branch_num(project, sink, 0);
 
         let mut catalog = PartiqlCatalog::default();
-        let _oid = catalog.add_type_entry(TypeEnvEntry::new("customers", &[], type_dynamic!()));
+        let _oid =
+            catalog.add_type_entry(TypeEnvEntry::new("customers", &[], PartiqlShape::Dynamic));
         let statement = "SELECT c.id AS my_id, customers.name AS my_name FROM customers AS c";
         let parsed = partiql_parser::Parser::default()
             .parse(statement)

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -612,11 +612,13 @@ mod tests {
     use partiql_ast_passes::error::AstTransformationError;
     use partiql_catalog::catalog::{PartiqlCatalog, TypeEnvEntry};
     use partiql_parser::{Parsed, Parser};
-    use partiql_types::{struct_fields, DummyShapeBuilder, ShapeBuilderExtensions, StructType};
+    use partiql_types::{
+        struct_fields, PartiqlNoIdShapeBuilder, ShapeBuilderExtensions, StructType,
+    };
 
     #[test]
     fn simple_sfw() {
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         // Closed schema with `Strict` typing mode.
         assert_query_typing(
             TypingMode::Strict,
@@ -749,7 +751,7 @@ mod tests {
 
     #[test]
     fn simple_sfw_with_alias() {
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         // Open Schema with `Strict` typing mode and `age` in nested attribute.
         let details_fields = struct_fields![("age", type_int!(bld))];
         let details = type_struct![bld, IndexSet::from([details_fields])];
@@ -797,7 +799,7 @@ mod tests {
 
     #[test]
     fn simple_sfw_err() {
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
         // Closed Schema with `Strict` typing mode and `age` non-existent projection.
         let err1 = r#"No Typing Information for SymbolPrimitive { value: "age", case: CaseInsensitive } in closed Schema Static(StaticType { id: NodeId(0), ty: Struct(StructType { constraints: {Fields({StructField { optional: false, name: "id", ty: Static(StaticType { id: NodeId(0), ty: Int, nullable: true }) }, StructField { optional: false, name: "name", ty: Static(StaticType { id: NodeId(0), ty: String, nullable: true }) }}), Open(false)} }), nullable: true })"#;
 
@@ -866,7 +868,7 @@ mod tests {
     fn create_customer_schema(
         is_open: bool,
         fields: IndexSet<StructField>,
-        bld: &mut DummyShapeBuilder,
+        bld: &mut PartiqlNoIdShapeBuilder,
     ) -> PartiqlShape {
         let constraints = StructType::new(IndexSet::from([
             StructConstraint::Fields(fields),

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -386,10 +386,10 @@ impl PartiqlShape {
 
     pub fn expect_bool(&self) -> ShapeResult<StaticType> {
         if let PartiqlShape::Static(StaticType {
-            id,
-            ty: Static::Bool,
-            nullable: n,
-        }) = self
+                                        id,
+                                        ty: Static::Bool,
+                                        nullable: n,
+                                    }) = self
         {
             Ok(StaticType {
                 id: *id,
@@ -403,9 +403,9 @@ impl PartiqlShape {
 
     pub fn expect_bag(&self) -> ShapeResult<BagType> {
         if let PartiqlShape::Static(StaticType {
-            ty: Static::Bag(bag),
-            ..
-        }) = self
+                                        ty: Static::Bag(bag),
+                                        ..
+                                    }) = self
         {
             Ok(bag.clone())
         } else {
@@ -415,9 +415,9 @@ impl PartiqlShape {
 
     pub fn expect_struct(&self) -> ShapeResult<StructType> {
         if let PartiqlShape::Static(StaticType {
-            ty: Static::Struct(stct),
-            ..
-        }) = self
+                                        ty: Static::Struct(stct),
+                                        ..
+                                    }) = self
         {
             Ok(stct.clone())
         } else {
@@ -480,7 +480,7 @@ impl PartiqlShapeBuilder {
 
     #[must_use]
     pub fn new_static(&self, ty: Static) -> PartiqlShape {
-        let id = self.id_gen.id();
+        let id = self.id_gen.next_id();
         let id = id.read().expect("NodeId read lock");
         PartiqlShape::Static(StaticType {
             id: *id,
@@ -500,7 +500,7 @@ impl PartiqlShapeBuilder {
 
     #[must_use]
     pub fn new_non_nullable_static(&self, ty: Static) -> PartiqlShape {
-        let id = self.id_gen.id();
+        let id = self.id_gen.next_id();
         let id = id.read().expect("NodeId read lock");
         PartiqlShape::Static(StaticType {
             id: *id,
@@ -560,7 +560,7 @@ impl PartiqlShapeBuilder {
     // user-defined control.
     pub fn any_of<I>(&self, types: I) -> PartiqlShape
     where
-        I: IntoIterator<Item = PartiqlShape>,
+        I: IntoIterator<Item=PartiqlShape>,
     {
         let any_of = AnyOf::from_iter(types);
         match any_of.types.len() {
@@ -598,13 +598,13 @@ impl AnyOf {
         AnyOf { types }
     }
 
-    pub fn types(&self) -> impl Iterator<Item = &PartiqlShape> {
+    pub fn types(&self) -> impl Iterator<Item=&PartiqlShape> {
         self.types.iter()
     }
 }
 
 impl FromIterator<PartiqlShape> for AnyOf {
-    fn from_iter<T: IntoIterator<Item = PartiqlShape>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item=PartiqlShape>>(iter: T) -> Self {
         AnyOf {
             types: iter.into_iter().collect(),
         }
@@ -777,7 +777,7 @@ impl StructType {
             .collect()
     }
 
-    pub fn fields(&self) -> impl Iterator<Item = &StructField> {
+    pub fn fields(&self) -> impl Iterator<Item=&StructField> {
         self.constraints
             .iter()
             .filter_map(|c| {

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -379,7 +379,7 @@ pub struct ShapeBuilder<Id: NodeIdGenerator> {
 }
 
 pub type PartiqlShapeBuilder = ShapeBuilder<AutoNodeIdGenerator>;
-pub type DummyShapeBuilder = ShapeBuilder<NullIdGenerator>;
+pub type PartiqlNoIdShapeBuilder = ShapeBuilder<NullIdGenerator>;
 
 impl<Id: NodeIdGenerator + Default> ShapeBuilder<Id> {
     /// A thread-safe method for creating PartiQL shapes with guaranteed uniqueness over
@@ -391,9 +391,9 @@ impl<Id: NodeIdGenerator + Default> ShapeBuilder<Id> {
     }
 
     #[track_caller]
-    pub fn dummy_singleton() -> &'static DummyShapeBuilder {
-        static SHAPE_BUILDER: OnceLock<DummyShapeBuilder> = OnceLock::new();
-        SHAPE_BUILDER.get_or_init(DummyShapeBuilder::default)
+    pub fn dummy_singleton() -> &'static PartiqlNoIdShapeBuilder {
+        static SHAPE_BUILDER: OnceLock<PartiqlNoIdShapeBuilder> = OnceLock::new();
+        SHAPE_BUILDER.get_or_init(PartiqlNoIdShapeBuilder::default)
     }
 }
 
@@ -1029,14 +1029,14 @@ impl Display for ArrayType {
 #[cfg(test)]
 mod tests {
     use crate::{
-        DummyShapeBuilder, PartiqlShape, PartiqlShapeBuilder, ShapeBuilderExtensions, Static,
+        PartiqlNoIdShapeBuilder, PartiqlShape, PartiqlShapeBuilder, ShapeBuilderExtensions, Static,
         StructConstraint, StructField, StructType,
     };
     use indexmap::IndexSet;
 
     #[test]
     fn union() {
-        let mut bld = DummyShapeBuilder::default();
+        let mut bld = PartiqlNoIdShapeBuilder::default();
 
         let expect_int = bld.new_static(Static::Int);
         assert_eq!(


### PR DESCRIPTION
I had issues practically using Shapes with Ids in an external project. I began fixing one thing, and ended up with this refactor.

Esentially, this removes usages of `Arc`s and allows control of the `ID` generation by using a builder that is threaded through type creation. While this is slightly less ergonomic, it allows serialization/deserialization, test cases, etc.

In addition to these changes, I also think that we will need to add `ID`s to, for example, undefined and dynamic types, not just static in the future.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
