### PR TITLE
Lowercase before snake-casing for conformance test string escaping.

### DIFF
--- a/partiql-conformance-test-generator/src/util.rs
+++ b/partiql-conformance-test-generator/src/util.rs
@@ -16,10 +16,11 @@ fn escape_str(s: &str) -> String {
     match s.chars().next() {
         None => "_".to_string(),
         Some(c) => {
+            let snake_case = s.to_lowercase().to_snake_case();
             if c.is_numeric() {
-                format!("_{}", s.to_snake_case())
+                format!("_{}", snake_case)
             } else {
-                s.to_snake_case()
+                snake_case
             }
         }
     }
@@ -84,6 +85,14 @@ mod test {
         assert_eq!(
             "a B c  1 2 3 e f G !?#$%*!(".escape_module_name(),
             "r#a_b_c_1_2_3_e_f_g"
+        );
+    }
+
+    #[test]
+    fn snake_case_uppercase_names() {
+        assert_eq!(
+            "Example 7 — NULL and MISSING Coercion - 1".escape_path(),
+            "example_7_null_and_missing_coercion_1"
         );
     }
 }


### PR DESCRIPTION
Replace names 
- like: `strict_example_7_nu_l_l_and_missin_g_coercion_1`
- with: `strict_example_7_null_and_missing_coercion_1`


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
