### PR TITLE
Change modeling of Literals in the AST remove ambiguity

### DIFF
--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -454,14 +454,39 @@ pub enum Lit {
     #[visit(skip)]
     HexStringLit(String),
     #[visit(skip)]
-    StructLit(AstNode<Struct>),
+    StructLit(AstNode<StructLit>),
     #[visit(skip)]
-    BagLit(AstNode<Bag>),
+    BagLit(AstNode<BagLit>),
     #[visit(skip)]
-    ListLit(AstNode<List>),
+    ListLit(AstNode<ListLit>),
     /// E.g. `TIME WITH TIME ZONE` in `SELECT TIME WITH TIME ZONE '12:00' FROM ...`
     #[visit(skip)]
     TypedLit(String, Type),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct LitField {
+    pub first: String,
+    pub second: AstNode<Lit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct StructLit {
+    pub fields: Vec<LitField>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct BagLit {
+    pub values: Vec<Lit>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ListLit {
+    pub values: Vec<Lit>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq, Eq)]

--- a/partiql-ast/src/pretty.rs
+++ b/partiql-ast/src/pretty.rs
@@ -699,6 +699,38 @@ impl PrettyDoc for StructExprPair {
     }
 }
 
+impl PrettyDoc for StructLit {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        let wrapped = self.fields.iter().map(|p| unsafe {
+            let x: &'b StructLitField = std::mem::transmute(p);
+            x
+        });
+        pretty_seq(wrapped, "{", "}", ",", PRETTY_INDENT_MINOR_NEST, arena)
+    }
+}
+
+pub struct StructLitField(pub LitField);
+
+impl PrettyDoc for StructLitField {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        let k = self.0.first.pretty_doc(arena);
+        let v = self.0.second.pretty_doc(arena);
+        let sep = arena.text(": ");
+
+        k.append(sep).group().append(v).group()
+    }
+}
+
 impl PrettyDoc for Bag {
     fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
     where
@@ -718,6 +750,35 @@ impl PrettyDoc for Bag {
 }
 
 impl PrettyDoc for List {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        pretty_seq(&self.values, "[", "]", ",", PRETTY_INDENT_MINOR_NEST, arena)
+    }
+}
+
+impl PrettyDoc for BagLit {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        pretty_seq(
+            &self.values,
+            "<<",
+            ">>",
+            ",",
+            PRETTY_INDENT_MINOR_NEST,
+            arena,
+        )
+    }
+}
+
+impl PrettyDoc for ListLit {
     fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
     where
         D: DocAllocator<'b, A>,

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -1,9 +1,11 @@
 use partiql_ast::ast;
 
 use crate::parse::parser_state::ParserState;
+use crate::ParseError;
 use bitflags::bitflags;
+use partiql_ast::ast::{AstNode, Expr, Lit, LitField};
 use partiql_common::node::NodeIdGenerator;
-use partiql_common::syntax::location::ByteOffset;
+use partiql_common::syntax::location::{ByteOffset, BytePosition};
 
 bitflags! {
     /// Set of AST node attributes to use as synthesized attributes.
@@ -33,13 +35,24 @@ pub(crate) struct Synth<T> {
 
 impl<T> Synth<T> {
     #[inline]
-    pub fn new(data: T, attrs: Attrs) -> Self {
+    fn new(data: T, attrs: Attrs) -> Self {
         Synth { data, attrs }
     }
 
     #[inline]
     pub fn empty(data: T) -> Self {
         Self::new(data, Attrs::empty())
+    }
+
+    #[inline]
+    pub fn lit(data: T) -> Self {
+        Self::new(data, Attrs::LIT)
+    }
+
+    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> Synth<U> {
+        let Self { data, attrs } = self;
+        let data = f(data);
+        Synth::new(data, attrs)
     }
 }
 
@@ -168,5 +181,63 @@ pub(crate) fn strip_expr(q: ast::AstNode<ast::Query>) -> Box<ast::Expr> {
         e
     } else {
         Box::new(ast::Expr::Query(q))
+    }
+}
+
+#[inline]
+#[track_caller]
+fn illegal_literal<'a, T>() -> Result<T, crate::error::ParseError<'a, BytePosition>> {
+    Err(ParseError::IllegalState("Expected literal".to_string()))
+}
+
+pub(crate) type LitFlattenResult<'a, T> = Result<T, ParseError<'a>>;
+#[inline]
+pub(crate) fn struct_to_lit<'a>(strct: ast::Struct) -> LitFlattenResult<'a, ast::StructLit> {
+    strct
+        .fields
+        .into_iter()
+        .map(exprpair_to_lit)
+        .collect::<LitFlattenResult<'_, Vec<_>>>()
+        .map(|fields| ast::StructLit { fields })
+}
+
+#[inline]
+pub(crate) fn bag_to_lit<'a>(bag: ast::Bag) -> LitFlattenResult<'a, ast::BagLit> {
+    bag.values
+        .into_iter()
+        .map(|v| expr_to_lit(*v).map(|n| n.node))
+        .collect::<LitFlattenResult<'_, Vec<_>>>()
+        .map(|values| ast::BagLit { values })
+}
+
+#[inline]
+pub(crate) fn list_to_lit<'a>(list: ast::List) -> LitFlattenResult<'a, ast::ListLit> {
+    list.values
+        .into_iter()
+        .map(|v| expr_to_lit(*v).map(|n| n.node))
+        .collect::<LitFlattenResult<'_, Vec<_>>>()
+        .map(|values| ast::ListLit { values })
+}
+
+#[inline]
+pub(crate) fn exprpair_to_lit<'a>(pair: ast::ExprPair) -> LitFlattenResult<'a, ast::LitField> {
+    let ast::ExprPair { first, second } = pair;
+    let (first, second) = (expr_to_litstr(*first)?, expr_to_lit(*second)?);
+    Ok(ast::LitField { first, second })
+}
+
+#[inline]
+pub(crate) fn expr_to_litstr<'a>(expr: ast::Expr) -> LitFlattenResult<'a, String> {
+    match expr_to_lit(expr)?.node {
+        Lit::CharStringLit(s) | Lit::NationalCharStringLit(s) => Ok(s),
+        _ => illegal_literal(),
+    }
+}
+
+#[inline]
+pub(crate) fn expr_to_lit<'a>(expr: ast::Expr) -> LitFlattenResult<'a, ast::AstNode<ast::Lit>> {
+    match expr {
+        Expr::Lit(lit) => Ok(lit),
+        _ => illegal_literal(),
     }
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -9,7 +9,17 @@ use partiql_ast::ast;
 
 use partiql_common::syntax::location::{ByteOffset, BytePosition, Location, ToLocated};
 
-use crate::parse::parse_util::{strip_expr, strip_query, strip_query_set, CallSite, Attrs, Synth};
+use crate::parse::parse_util::{
+    strip_expr,
+    strip_query,
+    strip_query_set,
+    struct_to_lit,
+    bag_to_lit,
+    list_to_lit,
+    CallSite,
+    Attrs,
+    Synth
+};
 use crate::parse::parser_state::ParserState;
 use partiql_common::node::NodeIdGenerator;
 
@@ -568,8 +578,7 @@ ExprQuery: Box<ast::Expr> = {
 
 ExprQuerySynth: Synth<Box<ast::Expr>> = {
     <e:ExprPrecedence15> => {
-        let Synth{data, attrs} = e;
-        Synth::new(Box::new(data), attrs)
+        e.map_data(|e| Box::new(e))
     }
 }
 
@@ -865,13 +874,39 @@ ExprPrecedence01: Synth<ast::Expr> = {
 
 ExprTerm: Synth<ast::Expr> = {
     <s:SubQuery> => Synth::empty(s),
-    <lo:@L> <lit:Literal> <hi:@R> => Synth::new(ast::Expr::Lit( state.node(lit, lo..hi) ), Attrs::LIT),
+    <lo:@L> <lit:Literal> <hi:@R> => Synth::lit(ast::Expr::Lit( state.node(lit, lo..hi) )),
     <v:VarRefExpr> => Synth::empty(v),
     <lo:@L> <c:ExprTermCollection> <hi:@R> => {
         if c.attrs.contains(Attrs::LIT) {
             match c.data {
-                ast::Expr::List(l) => Synth::new(ast::Expr::Lit( state.node(ast::Lit::ListLit(l), lo..hi) ), Attrs::LIT),
-                ast::Expr::Bag(b) => Synth::new(ast::Expr::Lit( state.node(ast::Lit::BagLit(b), lo..hi) ), Attrs::LIT),
+                ast::Expr::List(l) => {
+                    match list_to_lit(l.node) {
+                        Ok(list_lit) => {
+                            let list_lit = state.node(list_lit, lo..hi);
+                            let lit = state.node(ast::Lit::ListLit(list_lit), lo..hi);
+                            Synth::lit(ast::Expr::Lit( lit ))
+                        },
+                        Err(e) => {
+                            let err = lpop::ErrorRecovery{error: e.into(), dropped_tokens: Default::default()};
+                            state.errors.push(err);
+                            Synth::empty(ast::Expr::Error)
+                        }
+                    }
+                },
+                ast::Expr::Bag(b) => {
+                    match bag_to_lit(b.node) {
+                        Ok(bag_lit) => {
+                            let bag_lit = state.node(bag_lit, lo..hi);
+                            let lit = state.node(ast::Lit::BagLit(bag_lit), lo..hi);
+                            Synth::lit(ast::Expr::Lit( lit ))
+                        },
+                        Err(e) => {
+                            let err = lpop::ErrorRecovery{error: e.into(), dropped_tokens: Default::default()};
+                            state.errors.push(err);
+                            Synth::empty(ast::Expr::Error)
+                        }
+                    }
+                },
                 _ => unreachable!(),
             }
         } else {
@@ -881,7 +916,20 @@ ExprTerm: Synth<ast::Expr> = {
     <lo:@L> <t:ExprTermTuple> <hi:@R> => {
         if t.attrs.contains(Attrs::LIT) {
             match t.data {
-                ast::Expr::Struct(s) => Synth::new(ast::Expr::Lit( state.node(ast::Lit::StructLit(s), lo..hi) ), Attrs::LIT),
+                ast::Expr::Struct(s) => {
+                    match struct_to_lit(s.node) {
+                        Ok(struct_lit) => {
+                            let struct_lit = state.node(struct_lit, lo..hi);
+                            let lit = state.node(ast::Lit::StructLit(struct_lit), lo..hi);
+                            Synth::lit(ast::Expr::Lit( lit ))
+                        },
+                        Err(e) => {
+                            let err = lpop::ErrorRecovery{error: e.into(), dropped_tokens: Default::default()};
+                            state.errors.push(err);
+                            Synth::empty(ast::Expr::Error)
+                        }
+                    }
+                },
                 _ => unreachable!(),
             }
         } else {


### PR DESCRIPTION
Change parsing and AST-modeling of literals to not share AST structures with non-scalar expressions.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
