### PR TITLE
Replace usages of `derivative` with `educe`.

### DIFF
--- a/partiql-types/Cargo.toml
+++ b/partiql-types/Cargo.toml
@@ -29,6 +29,6 @@ thiserror = "1"
 
 indexmap = "2.5"
 
-derivative = "2.2"
+educe = "0.6"
 
 [dev-dependencies]

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-use derivative::Derivative;
+use educe::Educe;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use miette::Diagnostic;
@@ -584,11 +584,11 @@ impl PartiqlShapeBuilder {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct AnyOf {
-    #[derivative(Hash(hash_with = "indexset_hash"))]
+    #[educe(Hash(method(indexset_hash)))]
     types: IndexSet<PartiqlShape>,
 }
 
@@ -743,11 +743,11 @@ impl Display for Static {
 
 pub const TYPE_DYNAMIC: PartiqlShape = PartiqlShape::Dynamic;
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct StructType {
-    #[derivative(Hash(hash_with = "indexset_hash"))]
+    #[educe(Hash(method(indexset_hash)))]
     constraints: IndexSet<StructConstraint>,
 }
 
@@ -827,15 +827,15 @@ impl Display for StructType {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 #[non_exhaustive]
 pub enum StructConstraint {
     Open(bool),
     Ordered(bool),
     DuplicateAttrs(bool),
-    Fields(#[derivative(Hash(hash_with = "indexset_hash"))] IndexSet<StructField>),
+    Fields(#[educe(Hash(method(indexset_hash)))] IndexSet<StructField>),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -901,8 +901,8 @@ impl From<(&str, PartiqlShape, bool)> for StructField {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct BagType {
     element_type: Box<PartiqlShape>,
@@ -938,8 +938,8 @@ impl Display for BagType {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct ArrayType {
     element_type: Box<PartiqlShape>,


### PR DESCRIPTION
Fix the following as reported by `cargo deny check`

```
error[unmaintained]: `derivative` is unmaintained; consider using an alternative
   ┌─ /Users/joshps/work/partiql-lang-rust/Cargo.lock:55:1
   │
55 │ derivative 2.2.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0388
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0388
   ├ The [`derivative`](https://crates.io/crates/derivative) crate is no longer maintained.
     Consider using any alternative, for instance:
     - [derive_more](https://crates.io/crates/derive_more)
     - [derive-where](https://crates.io/crates/derive-where)
     - [educe](https://crates.io/crates/educe)
   ├ Announcement: https://github.com/mcarton/rust-derivative/issues/117
   ├ Solution: No safe upgrade is available!
   ├ derivative v2.2.0
     └── partiql-types v0.11.0
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
