### PR TITLE
Change modeling of boxed ion literals to be lazy until evaluator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - *BREAKING* partiql-parser: Added a source location to `ParseError::UnexpectedEndOfInput`
+- *BREAKING* partiql-ast: Changed the modelling of parsed literals.
+- *BREAKING* partiql-logical: Changed the modelling of logical plan literals.
 - partiql-eval: Fixed behavior of comparison and `BETWEEN` operations w.r.t. type mismatches
 
 ### Added

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -1,9 +1,8 @@
 use itertools::{Either, Itertools};
-use ordered_float::OrderedFloat;
 use partiql_logical as logical;
 use partiql_logical::{
     AggFunc, BagOperator, BinaryOp, BindingsOp, CallName, GroupingStrategy, IsTypeExpr, JoinKind,
-    Lit, LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier,
+    LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier,
     SortSpecNullOrder, SortSpecOrder, Type, UnaryOp, ValueExpr, VarRefType,
 };
 use petgraph::prelude::StableGraph;
@@ -25,8 +24,8 @@ use crate::eval::expr::{
 };
 use crate::eval::EvalPlan;
 use partiql_catalog::catalog::{Catalog, FunctionEntryFunction};
+use partiql_value::Value;
 use partiql_value::Value::Null;
-use partiql_value::{Bag, List, Tuple, Value};
 
 #[macro_export]
 macro_rules! correct_num_args_or_err {
@@ -787,7 +786,6 @@ mod tests {
     use partiql_catalog::catalog::PartiqlCatalog;
     use partiql_logical::CallExpr;
     use partiql_logical::ExprQuery;
-    use partiql_value::Value;
 
     #[test]
     fn test_logical_to_eval_plan_bad_num_arguments() {

--- a/partiql-logical-planner/Cargo.toml
+++ b/partiql-logical-planner/Cargo.toml
@@ -25,13 +25,11 @@ partiql-ast = { path = "../partiql-ast", version = "0.11.*" }
 partiql-ast-passes = { path = "../partiql-ast-passes", version = "0.11.*" }
 partiql-catalog = { path = "../partiql-catalog", version = "0.11.*" }
 partiql-common = { path = "../partiql-common", version = "0.11.*" }
-partiql-extension-ion = { path = "../extension/partiql-extension-ion", version = "0.11.*" }
 partiql-parser = { path = "../partiql-parser", version = "0.11.*" }
 partiql-logical = { path = "../partiql-logical", version = "0.11.*" }
 partiql-types = { path = "../partiql-types", version = "0.11.*" }
 partiql-value = { path = "../partiql-value", version = "0.11.*" }
 
-ion-rs_old = { version = "0.18", package = "ion-rs" }
 ordered-float = "4"
 itertools = "0.13"
 unicase = "2.7"

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -2,7 +2,6 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use partiql_logical as logical;
 use partiql_logical::{SetQuantifier, ValueExpr};
-use partiql_value::Value;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
@@ -241,7 +240,7 @@ fn function_call_def_trim() -> CallDef {
                 output: Box::new(|mut args| {
                     args.insert(
                         0,
-                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string().into()))),
+                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string()))),
                     );
 
                     logical::ValueExpr::Call(logical::CallExpr {
@@ -255,7 +254,7 @@ fn function_call_def_trim() -> CallDef {
                 output: Box::new(|mut args| {
                     args.insert(
                         0,
-                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string().into()))),
+                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string()))),
                     );
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::BTrim,

--- a/partiql-logical-planner/src/builtins.rs
+++ b/partiql-logical-planner/src/builtins.rs
@@ -135,7 +135,7 @@ fn function_call_def_substring() -> CallDef {
             CallSpec {
                 input: vec![CallSpecArg::Positional, CallSpecArg::Named("for".into())],
                 output: Box::new(|mut args| {
-                    args.insert(1, ValueExpr::Lit(Box::new(Value::Integer(0))));
+                    args.insert(1, ValueExpr::Lit(Box::new(logical::Lit::Int8(0))));
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::Substring,
                         arguments: args,
@@ -241,7 +241,7 @@ fn function_call_def_trim() -> CallDef {
                 output: Box::new(|mut args| {
                     args.insert(
                         0,
-                        ValueExpr::Lit(Box::new(Value::String(" ".to_string().into()))),
+                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string().into()))),
                     );
 
                     logical::ValueExpr::Call(logical::CallExpr {
@@ -255,7 +255,7 @@ fn function_call_def_trim() -> CallDef {
                 output: Box::new(|mut args| {
                     args.insert(
                         0,
-                        ValueExpr::Lit(Box::new(Value::String(" ".to_string().into()))),
+                        ValueExpr::Lit(Box::new(logical::Lit::String(" ".to_string().into()))),
                     );
                     logical::ValueExpr::Call(logical::CallExpr {
                         name: logical::CallName::BTrim,

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -36,8 +36,6 @@ use crate::functions::Function;
 use partiql_ast_passes::name_resolver::NameRef;
 use partiql_catalog::catalog::Catalog;
 use partiql_common::node::NodeId;
-use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
-use partiql_extension_ion::Encoding;
 use partiql_logical::AggFunc::{AggAny, AggAvg, AggCount, AggEvery, AggMax, AggMin, AggSum};
 use partiql_logical::ValueExpr::DynamicLookup;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -541,8 +539,8 @@ impl<'a> AstToLogical<'a> {
     }
 
     #[inline]
-    fn push_value(&mut self, val: Value) {
-        self.push_vexpr(ValueExpr::Lit(Box::new(val)));
+    fn push_lit(&mut self, lit: logical::Lit) {
+        self.push_vexpr(ValueExpr::Lit(Box::new(lit)));
     }
 
     #[inline]
@@ -832,7 +830,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         {
             let exprs = HashMap::from([(
                 "$__gk".to_string(),
-                ValueExpr::Lit(Box::new(Value::from(true))),
+                ValueExpr::Lit(Box::new(logical::Lit::Bool(true))),
             )]);
             let group_by: BindingsOp = BindingsOp::GroupBy(logical::GroupBy {
                 strategy: logical::GroupingStrategy::GroupFull,
@@ -889,7 +887,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                     let alias = iter.next().unwrap();
                     let alias = match alias {
                         ValueExpr::Lit(lit) => match *lit {
-                            Value::String(s) => (*s).clone(),
+                            logical::Lit::String(s) => s.clone(),
                             _ => {
                                 // Report error but allow visitor to continue
                                 self.errors.push(AstTransformError::IllegalState(
@@ -951,7 +949,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             name_resolver::Symbol::Known(sym) => sym.value.clone(),
             name_resolver::Symbol::Unknown(id) => format!("_{id}"),
         };
-        self.push_value(as_key.into());
+        self.push_lit(logical::Lit::String(as_key));
         Traverse::Continue
     }
 
@@ -969,8 +967,8 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         if _bin_op.kind == BinOpKind::Is {
             let is_type = match rhs {
                 ValueExpr::Lit(lit) => match lit.as_ref() {
-                    Value::Null => logical::Type::NullType,
-                    Value::Missing => logical::Type::MissingType,
+                    logical::Lit::Null => logical::Type::NullType,
+                    logical::Lit::Missing => logical::Type::MissingType,
                     _ => {
                         not_yet_implemented_fault!(
                             self,
@@ -1079,7 +1077,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         let escape_ve = if env.len() == 3 {
             env.pop().unwrap()
         } else {
-            ValueExpr::Lit(Box::new(Value::String(Box::default())))
+            ValueExpr::Lit(Box::new(logical::Lit::String(String::default())))
         };
         let pattern_ve = env.pop().unwrap();
         let value = Box::new(env.pop().unwrap());
@@ -1087,10 +1085,12 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
         let pattern = match (&pattern_ve, &escape_ve) {
             (ValueExpr::Lit(pattern_lit), ValueExpr::Lit(escape_lit)) => {
                 match (pattern_lit.as_ref(), escape_lit.as_ref()) {
-                    (Value::String(pattern), Value::String(escape)) => Pattern::Like(LikeMatch {
-                        pattern: pattern.to_string(),
-                        escape: escape.to_string(),
-                    }),
+                    (logical::Lit::String(pattern), logical::Lit::String(escape)) => {
+                        Pattern::Like(LikeMatch {
+                            pattern: pattern.to_string(),
+                            escape: escape.to_string(),
+                        })
+                    }
                     _ => Pattern::LikeNonStringNonLiteral(LikeNonStringNonLiteralMatch {
                         pattern: Box::new(pattern_ve),
                         escape: Box::new(escape_ve),
@@ -1136,7 +1136,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             Ok(expr) => expr,
             Err(err) => {
                 self.errors.push(err);
-                ValueExpr::Lit(Box::new(Value::Missing)) // dummy expression to allow lowering to continue
+                ValueExpr::Lit(Box::new(logical::Lit::Missing)) // dummy expression to allow lowering to continue
             }
         };
         self.push_vexpr(expr);
@@ -1178,15 +1178,15 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
     // Values & Value Constructors
 
     fn enter_lit(&mut self, lit: &'ast Lit) -> Traverse {
-        let val = match lit_to_value(lit) {
+        let val = match lit_to_lit(lit) {
             Ok(v) => v,
             Err(e) => {
                 // Report error but allow visitor to continue
                 self.errors.push(e);
-                Value::Missing
+                logical::Lit::Missing
             }
         };
-        self.push_value(val);
+        self.push_lit(val);
         Traverse::Continue
     }
 
@@ -1281,7 +1281,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             },
             CallArgument::Star => (
                 logical::SetQuantifier::All,
-                ValueExpr::Lit(Box::new(Value::Integer(1))),
+                ValueExpr::Lit(Box::new(logical::Lit::Int8(1))),
             ),
         };
 
@@ -1417,9 +1417,12 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
                 let path = env.pop().unwrap();
                 match path {
                     ValueExpr::Lit(val) => match *val {
-                        Value::Integer(idx) => logical::PathComponent::Index(idx),
-                        Value::String(k) => logical::PathComponent::Key(
-                            BindingsName::CaseInsensitive(Cow::Owned(*k)),
+                        logical::Lit::Int8(idx) => logical::PathComponent::Index(idx.into()),
+                        logical::Lit::Int16(idx) => logical::PathComponent::Index(idx.into()),
+                        logical::Lit::Int32(idx) => logical::PathComponent::Index(idx.into()),
+                        logical::Lit::Int64(idx) => logical::PathComponent::Index(idx),
+                        logical::Lit::String(k) => logical::PathComponent::Key(
+                            BindingsName::CaseInsensitive(Cow::Owned(k)),
                         ),
                         expr => logical::PathComponent::IndexExpr(Box::new(ValueExpr::Lit(
                             Box::new(expr),
@@ -1678,7 +1681,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             let alias = iter.next().unwrap();
             let alias = match alias {
                 ValueExpr::Lit(lit) => match *lit {
-                    Value::String(s) => (*s).clone(),
+                    logical::Lit::String(s) => s.clone(),
                     _ => {
                         // Report error but allow visitor to continue
                         self.errors.push(AstTransformError::IllegalState(
@@ -1727,7 +1730,7 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
             name_resolver::Symbol::Known(sym) => sym.value.clone(),
             name_resolver::Symbol::Unknown(id) => format!("_{id}"),
         };
-        self.push_value(as_key.into());
+        self.push_lit(logical::Lit::String(as_key));
         Traverse::Continue
     }
 
@@ -1892,12 +1895,14 @@ impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
     }
 }
 
-fn lit_to_value(lit: &Lit) -> Result<Value, AstTransformError> {
-    fn tuple_pair(field: &ast::LitField) -> Option<Result<(String, Value), AstTransformError>> {
+fn lit_to_lit(lit: &Lit) -> Result<logical::Lit, AstTransformError> {
+    fn tuple_pair(
+        field: &ast::LitField,
+    ) -> Option<Result<(String, logical::Lit), AstTransformError>> {
         let key = field.first.clone();
         match &field.second.node {
             Lit::Missing => None,
-            value => match lit_to_value(value) {
+            value => match lit_to_lit(value) {
                 Ok(value) => Some(Ok((key, value))),
                 Err(e) => Some(Err(e)),
             },
@@ -1905,21 +1910,23 @@ fn lit_to_value(lit: &Lit) -> Result<Value, AstTransformError> {
     }
 
     let val = match lit {
-        Lit::Null => Value::Null,
-        Lit::Missing => Value::Missing,
-        Lit::Int8Lit(n) => Value::Integer(i64::from(*n)),
-        Lit::Int16Lit(n) => Value::Integer(i64::from(*n)),
-        Lit::Int32Lit(n) => Value::Integer(i64::from(*n)),
-        Lit::Int64Lit(n) => Value::Integer(*n),
-        Lit::DecimalLit(d) => Value::Decimal(Box::new(*d)),
-        Lit::NumericLit(n) => Value::Decimal(Box::new(*n)),
-        Lit::RealLit(f) => Value::Real(OrderedFloat::from(f64::from(*f))),
-        Lit::FloatLit(f) => Value::Real(OrderedFloat::from(f64::from(*f))),
-        Lit::DoubleLit(f) => Value::Real(OrderedFloat::from(*f)),
-        Lit::BoolLit(b) => Value::Boolean(*b),
-        Lit::EmbeddedDocLit(s) => parse_embedded_ion_str(s)?,
-        Lit::CharStringLit(s) => Value::String(Box::new(s.clone())),
-        Lit::NationalCharStringLit(s) => Value::String(Box::new(s.clone())),
+        Lit::Null => logical::Lit::Null,
+        Lit::Missing => logical::Lit::Missing,
+        Lit::Int8Lit(n) => logical::Lit::Int8(*n),
+        Lit::Int16Lit(n) => logical::Lit::Int16(*n),
+        Lit::Int32Lit(n) => logical::Lit::Int32(*n),
+        Lit::Int64Lit(n) => logical::Lit::Int64(*n),
+        Lit::DecimalLit(d) => logical::Lit::Decimal(*d),
+        Lit::NumericLit(n) => logical::Lit::Decimal(*n),
+        Lit::RealLit(f) => logical::Lit::Double(OrderedFloat::from(*f as f64)),
+        Lit::FloatLit(f) => logical::Lit::Double(OrderedFloat::from(*f as f64)),
+        Lit::DoubleLit(f) => logical::Lit::Double(OrderedFloat::from(*f)),
+        Lit::BoolLit(b) => logical::Lit::Bool(*b),
+        Lit::EmbeddedDocLit(s) => {
+            logical::Lit::BoxDocument(s.clone().into_bytes(), "Ion".to_string())
+        }
+        Lit::CharStringLit(s) => logical::Lit::String(s.clone()),
+        Lit::NationalCharStringLit(s) => logical::Lit::String(s.clone()),
         Lit::BitStringLit(_) => {
             return Err(AstTransformError::NotYetImplemented(
                 "Lit::BitStringLit".to_string(),
@@ -1931,19 +1938,16 @@ fn lit_to_value(lit: &Lit) -> Result<Value, AstTransformError> {
             ))
         }
         Lit::BagLit(b) => {
-            let bag: Result<partiql_value::Bag, _> =
-                b.node.values.iter().map(lit_to_value).collect();
-            Value::from(bag?)
+            let bag: Result<_, _> = b.node.values.iter().map(lit_to_lit).collect();
+            logical::Lit::Bag(bag?)
         }
         Lit::ListLit(l) => {
-            let l: Result<partiql_value::List, _> =
-                l.node.values.iter().map(lit_to_value).collect();
-            Value::from(l?)
+            let l: Result<_, _> = l.node.values.iter().map(lit_to_lit).collect();
+            logical::Lit::List(l?)
         }
         Lit::StructLit(s) => {
-            let tuple: Result<partiql_value::Tuple, _> =
-                s.node.fields.iter().filter_map(tuple_pair).collect();
-            Value::from(tuple?)
+            let tuple: Result<_, _> = s.node.fields.iter().filter_map(tuple_pair).collect();
+            logical::Lit::Struct(tuple?)
         }
         Lit::TypedLit(_, _) => {
             return Err(AstTransformError::NotYetImplemented(
@@ -1952,30 +1956,6 @@ fn lit_to_value(lit: &Lit) -> Result<Value, AstTransformError> {
         }
     };
     Ok(val)
-}
-
-// TODO
-fn parse_embedded_ion_str(contents: &str) -> Result<Value, AstTransformError> {
-    fn lit_err(literal: &str, err: impl std::error::Error) -> AstTransformError {
-        AstTransformError::Literal {
-            literal: literal.into(),
-            error: err.to_string(),
-        }
-    }
-
-    let reader = ion_rs_old::ReaderBuilder::new()
-        .build(contents)
-        .map_err(|e| lit_err(contents, e))?;
-    let mut iter = IonDecoderBuilder::new(IonDecoderConfig::default().with_mode(Encoding::Ion))
-        .build(reader)
-        .map_err(|e| lit_err(contents, e))?;
-
-    iter.next()
-        .ok_or_else(|| AstTransformError::Literal {
-            literal: contents.into(),
-            error: "Contains no value".into(),
-        })?
-        .map_err(|e| lit_err(contents, e))
 }
 
 #[cfg(test)]

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -21,7 +21,7 @@ use partiql_logical::{
 };
 use std::borrow::Cow;
 
-use partiql_value::{BindingsName, Value};
+use partiql_value::BindingsName;
 
 use std::collections::{HashMap, HashSet};
 

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -2,11 +2,11 @@ use crate::typer::LookupOrder::{GlobalLocal, LocalGlobal};
 use indexmap::{IndexMap, IndexSet};
 use partiql_ast::ast::{CaseSensitivity, SymbolPrimitive};
 use partiql_catalog::catalog::Catalog;
-use partiql_logical::{BindingsOp, LogicalPlan, OpId, PathComponent, ValueExpr, VarRefType};
+use partiql_logical::{BindingsOp, Lit, LogicalPlan, OpId, PathComponent, ValueExpr, VarRefType};
 use partiql_types::{
-    type_array, type_bag, type_bool, type_decimal, type_dynamic, type_int, type_string,
-    type_struct, type_undefined, ArrayType, BagType, PartiqlShape, PartiqlShapeBuilder,
-    ShapeResultError, Static, StructConstraint, StructField, StructType,
+    type_array, type_bag, type_bool, type_decimal, type_dynamic, type_float64, type_int,
+    type_string, type_struct, type_undefined, ArrayType, BagType, PartiqlShape,
+    PartiqlShapeBuilder, ShapeResultError, Static, StructConstraint, StructField, StructType,
 };
 use partiql_value::{BindingsName, Value};
 use petgraph::algo::toposort;
@@ -333,15 +333,17 @@ impl<'c> PlanTyper<'c> {
             }
             ValueExpr::Lit(v) => {
                 let ty = match **v {
-                    Value::Null => type_undefined!(),
-                    Value::Missing => type_undefined!(),
-                    Value::Integer(_) => type_int!(),
-                    Value::Decimal(_) => type_decimal!(),
-                    Value::Boolean(_) => type_bool!(),
-                    Value::String(_) => type_string!(),
-                    Value::Tuple(_) => type_struct!(),
-                    Value::List(_) => type_array!(),
-                    Value::Bag(_) => type_bag!(),
+                    Lit::Null | Lit::Missing => type_undefined!(),
+                    Lit::Int8(_) | Lit::Int16(_) | Lit::Int32(_) | Lit::Int64(_) => {
+                        type_int!()
+                    }
+                    Lit::Decimal(_) => type_decimal!(),
+                    Lit::Double(_) => type_float64!(),
+                    Lit::Bool(_) => type_bool!(),
+                    Lit::String(_) => type_string!(),
+                    Lit::Struct(_) => type_struct!(),
+                    Lit::Bag(_) => type_bag!(),
+                    Lit::List(_) => type_array!(),
                     _ => {
                         self.errors.push(TypingError::NotYetImplemented(
                             "Unsupported Literal".to_string(),

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -8,7 +8,7 @@ use partiql_types::{
     type_string, type_struct, type_undefined, ArrayType, BagType, PartiqlShape,
     PartiqlShapeBuilder, ShapeResultError, Static, StructConstraint, StructField, StructType,
 };
-use partiql_value::{BindingsName, Value};
+use partiql_value::BindingsName;
 use petgraph::algo::toposort;
 use petgraph::graph::NodeIndex;
 use petgraph::prelude::StableGraph;

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -23,9 +23,15 @@ bench = false
 [dependencies]
 partiql-value = { path = "../partiql-value", version = "0.11.*" }
 partiql-common = { path = "../partiql-common", version = "0.11.*" }
+partiql-extension-ion = { path = "../extension/partiql-extension-ion", version = "0.11.*" }
+
+ion-rs_old = { version = "0.18", package = "ion-rs" }
 ordered-float = "4"
 itertools = "0.13"
+rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
+rust_decimal_macros = "1.36"
 unicase = "2.7"
+thiserror = "1"
 
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -459,7 +459,7 @@ pub enum Lit {
     Double(OrderedFloat<f64>),
     Bool(bool),
     String(String),
-    BoxDocument(Vec<u8>, String),
+    BoxDocument(Vec<u8>, String), // (bytes, type-name as string) TODO replace with strongly typed box name.
     Struct(Vec<(String, Lit)>),
     Bag(Vec<Lit>),
     List(Vec<Lit>),

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -56,7 +56,7 @@ use partiql_common::catalog::ObjectId;
 /// assert_eq!(3, p.operators().len());
 /// assert_eq!(2, p.flows().len());
 /// ```
-use partiql_value::{BindingsName, Value};
+use partiql_value::BindingsName;
 use rust_decimal::Decimal as RustDecimal;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Formatter};

--- a/partiql-logical/src/util.rs
+++ b/partiql-logical/src/util.rs
@@ -14,10 +14,10 @@ impl From<Value> for Lit {
             Value::Real(f) => Lit::Double(f),
             Value::Decimal(d) => Lit::Decimal(*d),
             Value::String(s) => Lit::String(*s),
-            Value::Blob(bytes) => {
+            Value::Blob(_bytes) => {
                 todo!("Value to Lit: Blob")
             }
-            Value::DateTime(dt) => {
+            Value::DateTime(_dt) => {
                 todo!("Value to Lit: DateTime")
             }
             Value::List(list) => (*list).into(),
@@ -58,7 +58,7 @@ impl From<Lit> for Value {
             Lit::Double(f) => Value::Real(f),
             Lit::Bool(b) => Value::Boolean(b),
             Lit::String(s) => Value::String(s.into()),
-            Lit::BoxDocument(contents, typ) => {
+            Lit::BoxDocument(contents, _typ) => {
                 parse_embedded_ion_str(&String::from_utf8_lossy(contents.as_slice()))
                     .expect("TODO ion parsing error")
             }
@@ -71,14 +71,10 @@ impl From<Lit> for Value {
     }
 }
 
-/// Represents an AST transform Error
+/// Represents a Literal Value Error
 #[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum LiteralError {
-    /// Indicates that there is an internal error that was not due to user input or API violation.
-    #[error("Illegal State: {0}")]
-    IllegalState(String),
-
     /// Indicates that there was an error interpreting a literal value.
     #[error("Error with literal: {literal}: {error}")]
     Literal { literal: String, error: String },

--- a/partiql-logical/src/util.rs
+++ b/partiql-logical/src/util.rs
@@ -11,7 +11,7 @@ impl From<Value> for Lit {
             Value::Missing => Lit::Missing,
             Value::Boolean(b) => Lit::Bool(b),
             Value::Integer(n) => Lit::Int64(n),
-            Value::Real(f) => Lit::Double(f.into()),
+            Value::Real(f) => Lit::Double(f),
             Value::Decimal(d) => Lit::Decimal(*d),
             Value::String(s) => Lit::String(*s),
             Value::Blob(bytes) => {
@@ -53,18 +53,18 @@ impl From<Lit> for Value {
             Lit::Int8(n) => Value::Integer(n.into()),
             Lit::Int16(n) => Value::Integer(n.into()),
             Lit::Int32(n) => Value::Integer(n.into()),
-            Lit::Int64(n) => Value::Integer(n.into()),
+            Lit::Int64(n) => Value::Integer(n),
             Lit::Decimal(d) => Value::Decimal(d.into()),
-            Lit::Double(f) => Value::Real(f.into()),
+            Lit::Double(f) => Value::Real(f),
             Lit::Bool(b) => Value::Boolean(b),
             Lit::String(s) => Value::String(s.into()),
             Lit::BoxDocument(contents, typ) => {
                 parse_embedded_ion_str(&String::from_utf8_lossy(contents.as_slice()))
                     .expect("TODO ion parsing error")
             }
-            Lit::Struct(strct) => Value::from(Tuple::from(Tuple::from_iter(
+            Lit::Struct(strct) => Value::from(Tuple::from_iter(
                 strct.into_iter().map(|(k, v)| (k, Value::from(v))),
-            ))),
+            )),
             Lit::Bag(bag) => Value::from(Bag::from_iter(bag.into_iter().map(Value::from))),
             Lit::List(list) => Value::from(List::from_iter(list.into_iter().map(Value::from))),
         }

--- a/partiql-logical/src/util.rs
+++ b/partiql-logical/src/util.rs
@@ -1,0 +1,194 @@
+use crate::Lit;
+use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
+use partiql_extension_ion::Encoding;
+use partiql_value::{Bag, List, Tuple, Value};
+use thiserror::Error;
+
+impl From<Value> for Lit {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Null => Lit::Null,
+            Value::Missing => Lit::Missing,
+            Value::Boolean(b) => Lit::Bool(b),
+            Value::Integer(n) => Lit::Int64(n),
+            Value::Real(f) => Lit::Double(f.into()),
+            Value::Decimal(d) => Lit::Decimal(*d),
+            Value::String(s) => Lit::String(*s),
+            Value::Blob(bytes) => {
+                todo!("Value to Lit: Blob")
+            }
+            Value::DateTime(dt) => {
+                todo!("Value to Lit: DateTime")
+            }
+            Value::List(list) => (*list).into(),
+            Value::Bag(bag) => (*bag).into(),
+            Value::Tuple(tuple) => (*tuple).into(),
+        }
+    }
+}
+
+impl From<List> for Lit {
+    fn from(list: List) -> Self {
+        Lit::List(list.into_iter().map(Lit::from).collect())
+    }
+}
+
+impl From<Bag> for Lit {
+    fn from(bag: Bag) -> Self {
+        Lit::Bag(bag.into_iter().map(Lit::from).collect())
+    }
+}
+
+impl From<Tuple> for Lit {
+    fn from(tuple: Tuple) -> Self {
+        Lit::Struct(tuple.into_iter().map(|(k, v)| (k, Lit::from(v))).collect())
+    }
+}
+
+impl From<Lit> for Value {
+    fn from(lit: Lit) -> Self {
+        match lit {
+            Lit::Null => Value::Null,
+            Lit::Missing => Value::Missing,
+            Lit::Int8(n) => Value::Integer(n.into()),
+            Lit::Int16(n) => Value::Integer(n.into()),
+            Lit::Int32(n) => Value::Integer(n.into()),
+            Lit::Int64(n) => Value::Integer(n.into()),
+            Lit::Decimal(d) => Value::Decimal(d.into()),
+            Lit::Double(f) => Value::Real(f.into()),
+            Lit::Bool(b) => Value::Boolean(b),
+            Lit::String(s) => Value::String(s.into()),
+            Lit::BoxDocument(contents, typ) => {
+                parse_embedded_ion_str(&String::from_utf8_lossy(contents.as_slice()))
+                    .expect("TODO ion parsing error")
+            }
+            Lit::Struct(strct) => Value::from(Tuple::from(Tuple::from_iter(
+                strct.into_iter().map(|(k, v)| (k, Value::from(v))),
+            ))),
+            Lit::Bag(bag) => Value::from(Bag::from_iter(bag.into_iter().map(Value::from))),
+            Lit::List(list) => Value::from(List::from_iter(list.into_iter().map(Value::from))),
+        }
+    }
+}
+
+/// Represents an AST transform Error
+#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LiteralError {
+    /// Indicates that there is an internal error that was not due to user input or API violation.
+    #[error("Illegal State: {0}")]
+    IllegalState(String),
+
+    /// Indicates that there was an error interpreting a literal value.
+    #[error("Error with literal: {literal}: {error}")]
+    Literal { literal: String, error: String },
+}
+
+// TODO remove parsing in favor of embedding
+fn parse_embedded_ion_str(contents: &str) -> Result<Value, LiteralError> {
+    fn lit_err(literal: &str, err: impl std::error::Error) -> LiteralError {
+        LiteralError::Literal {
+            literal: literal.into(),
+            error: err.to_string(),
+        }
+    }
+
+    let reader = ion_rs_old::ReaderBuilder::new()
+        .build(contents)
+        .map_err(|e| lit_err(contents, e))?;
+    let mut iter = IonDecoderBuilder::new(IonDecoderConfig::default().with_mode(Encoding::Ion))
+        .build(reader)
+        .map_err(|e| lit_err(contents, e))?;
+
+    iter.next()
+        .ok_or_else(|| LiteralError::Literal {
+            literal: contents.into(),
+            error: "Contains no value".into(),
+        })?
+        .map_err(|e| lit_err(contents, e))
+}
+
+impl From<bool> for Lit {
+    #[inline]
+    fn from(b: bool) -> Self {
+        Lit::Bool(b)
+    }
+}
+
+impl From<String> for Lit {
+    #[inline]
+    fn from(s: String) -> Self {
+        Lit::String(s)
+    }
+}
+
+impl From<&str> for Lit {
+    #[inline]
+    fn from(s: &str) -> Self {
+        Lit::String(s.to_string())
+    }
+}
+
+impl From<i64> for Lit {
+    #[inline]
+    fn from(n: i64) -> Self {
+        Lit::Int64(n)
+    }
+}
+
+impl From<i32> for Lit {
+    #[inline]
+    fn from(n: i32) -> Self {
+        i64::from(n).into()
+    }
+}
+
+impl From<i16> for Lit {
+    #[inline]
+    fn from(n: i16) -> Self {
+        i64::from(n).into()
+    }
+}
+
+impl From<i8> for Lit {
+    #[inline]
+    fn from(n: i8) -> Self {
+        i64::from(n).into()
+    }
+}
+
+impl From<usize> for Lit {
+    #[inline]
+    fn from(n: usize) -> Self {
+        // TODO overflow to bigint/decimal
+        Lit::Int64(n as i64)
+    }
+}
+
+impl From<u8> for Lit {
+    #[inline]
+    fn from(n: u8) -> Self {
+        (n as usize).into()
+    }
+}
+
+impl From<u16> for Lit {
+    #[inline]
+    fn from(n: u16) -> Self {
+        (n as usize).into()
+    }
+}
+
+impl From<u32> for Lit {
+    #[inline]
+    fn from(n: u32) -> Self {
+        (n as usize).into()
+    }
+}
+
+impl From<u64> for Lit {
+    #[inline]
+    fn from(n: u64) -> Self {
+        (n as usize).into()
+    }
+}

--- a/partiql-parser/src/parse/parse_util.rs
+++ b/partiql-parser/src/parse/parse_util.rs
@@ -3,7 +3,7 @@ use partiql_ast::ast;
 use crate::parse::parser_state::ParserState;
 use crate::ParseError;
 use bitflags::bitflags;
-use partiql_ast::ast::{AstNode, Expr, Lit, LitField};
+use partiql_ast::ast::{Expr, Lit};
 use partiql_common::node::NodeIdGenerator;
 use partiql_common::syntax::location::{ByteOffset, BytePosition};
 

--- a/partiql/src/subquery_tests.rs
+++ b/partiql/src/subquery_tests.rs
@@ -40,11 +40,16 @@ mod tests {
     fn locals_in_subqueries() {
         //  `SELECT VALUE _1 from (SELECT VALUE foo from <<{'a': 'b'}>> AS foo) AS _1;`
         let mut sub_query = LogicalPlan::new();
+
+        let data = Box::new(partiql_logical::Lit::Bag(vec![
+            partiql_logical::Lit::Struct(vec![(
+                "a".to_string(),
+                partiql_logical::Lit::String("b".to_string()),
+            )]),
+        ]));
         let scan_op_id =
             sub_query.add_operator(partiql_logical::BindingsOp::Scan(partiql_logical::Scan {
-                expr: partiql_logical::ValueExpr::Lit(Box::new(Value::Bag(Box::new(Bag::from(
-                    vec![tuple![("a", "b")].into()],
-                ))))),
+                expr: partiql_logical::ValueExpr::Lit(data),
                 as_key: "foo".into(),
                 at_key: None,
             }));


### PR DESCRIPTION
Changes the logical plan to have a distinct `Lit` type to hold literals instead of embedded `Value`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
