### PR TITLE
Fix build & advisory issues.

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-08-06
+          toolchain: nightly-2024-10-17
       - uses: actions/cache@v3
         id: restore-build
         with:
@@ -132,7 +132,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-08-06
+          toolchain: nightly-2024-10-17
       - uses: actions/cache@v3
         id: restore-build-and-conformance
         with:

--- a/about.toml
+++ b/about.toml
@@ -21,5 +21,6 @@ accepted = [
     "ISC",
     "Zlib",
     "ICU",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
+    "Unicode-3.0"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,7 @@ allow = [
 # If you change this list, please also change `about.toml`
 #    see https://github.com/EmbarkStudios/cargo-about/issues/201
 exceptions = [
-    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+    { allow = ["Unicode-DFS-2016", "Unicode-3.0"], name = "unicode-ident" },
 ]
 
 # The confidence threshold for detecting a license from license text.

--- a/extension/partiql-extension-ion/src/decode.rs
+++ b/extension/partiql-extension-ion/src/decode.rs
@@ -122,7 +122,7 @@ pub struct IonValueIter<'a> {
     inner: Box<dyn Iterator<Item = IonDecodeResult> + 'a>,
 }
 
-impl<'a> Iterator for IonValueIter<'a> {
+impl Iterator for IonValueIter<'_> {
     type Item = IonDecodeResult;
 
     #[inline]

--- a/partiql-ast-passes/src/name_resolver.rs
+++ b/partiql-ast-passes/src/name_resolver.rs
@@ -212,7 +212,7 @@ impl<'c> NameResolver<'c> {
     }
 }
 
-impl<'ast, 'c> Visitor<'ast> for NameResolver<'c> {
+impl<'ast> Visitor<'ast> for NameResolver<'_> {
     fn enter_ast_node(&mut self, id: NodeId) -> Traverse {
         self.id_path_to_root.push(id);
         if let Some(children) = self.id_child_stack.last_mut() {

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -115,7 +115,7 @@ pub mod basic {
         }
     }
 
-    impl<'a, T> Bindings<T> for NestedBindings<'a, T>
+    impl<T> Bindings<T> for NestedBindings<'_, T>
     where
         T: Debug,
     {

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -494,7 +494,7 @@ impl AggregateFunction for Max {
     }
 
     fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
-        Ok(state.unwrap_or_else(|| Null))
+        Ok(state.unwrap_or(Null))
     }
 }
 
@@ -515,7 +515,7 @@ impl AggregateFunction for Min {
     }
 
     fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
-        Ok(state.unwrap_or_else(|| Null))
+        Ok(state.unwrap_or(Null))
     }
 }
 
@@ -532,7 +532,7 @@ impl AggregateFunction for Sum {
     }
 
     fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
-        Ok(state.unwrap_or_else(|| Null))
+        Ok(state.unwrap_or(Null))
     }
 }
 
@@ -559,7 +559,7 @@ impl AggregateFunction for Any {
     }
 
     fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
-        Ok(state.unwrap_or_else(|| Null))
+        Ok(state.unwrap_or(Null))
     }
 }
 
@@ -586,7 +586,7 @@ impl AggregateFunction for Every {
     }
 
     fn finalize(&self, state: Option<Value>) -> Result<Value, EvaluationError> {
-        Ok(state.unwrap_or_else(|| Null))
+        Ok(state.unwrap_or(Null))
     }
 }
 
@@ -1278,7 +1278,7 @@ pub(crate) struct EvalSink {
 
 impl Evaluable for EvalSink {
     fn evaluate<'a, 'c>(&mut self, _ctx: &'c dyn EvalContext<'c>) -> Value {
-        self.input.take().unwrap_or_else(|| Missing)
+        self.input.take().unwrap_or(Missing)
     }
 
     fn update_input(&mut self, input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -138,7 +138,7 @@ impl EvalExpr for EvalPath {
                 .try_fold(owned, |v, path| path.take_val(v, bindings, ctx))
                 .map(Cow::Owned),
         }
-        .unwrap_or_else(|| Cow::Owned(Value::Missing))
+        .unwrap_or(Cow::Owned(Value::Missing))
     }
 }
 
@@ -165,7 +165,7 @@ impl EvalExpr for EvalDynamicLookup {
             }
         });
 
-        lookups.next().unwrap_or_else(|| Cow::Owned(Value::Missing))
+        lookups.next().unwrap_or(Cow::Owned(Value::Missing))
     }
 }
 

--- a/partiql-eval/src/eval/mod.rs
+++ b/partiql-eval/src/eval/mod.rs
@@ -170,7 +170,7 @@ pub struct BasicContext<'a> {
     pub errors: RefCell<Vec<EvaluationError>>,
 }
 
-impl<'a> BasicContext<'a> {
+impl BasicContext<'_> {
     #[must_use]
     pub fn new(bindings: MapBindings<Value>, sys: SystemContext) -> Self {
         BasicContext {
@@ -228,7 +228,7 @@ impl<'a, 'c> NestedContext<'a, 'c> {
     }
 }
 
-impl<'a, 'c> SessionContext<'a> for NestedContext<'a, 'c> {
+impl<'a> SessionContext<'a> for NestedContext<'a, '_> {
     fn bindings(&self) -> &dyn Bindings<Value> {
         &self.bindings
     }
@@ -241,7 +241,7 @@ impl<'a, 'c> SessionContext<'a> for NestedContext<'a, 'c> {
     }
 }
 
-impl<'a, 'c> EvalContext<'a> for NestedContext<'a, 'c> {
+impl<'a> EvalContext<'a> for NestedContext<'a, '_> {
     fn as_session(&'a self) -> &'a dyn SessionContext<'a> {
         self
     }

--- a/partiql-logical-planner/src/functions.rs
+++ b/partiql-logical-planner/src/functions.rs
@@ -8,7 +8,7 @@ pub(crate) trait Function {
     fn resolve(&self, name: &str, args: &[CallArgument]) -> Result<ValueExpr, CallLookupError>;
 }
 
-impl<'a> Function for FunctionEntry<'a> {
+impl Function for FunctionEntry<'_> {
     fn resolve(&self, name: &str, args: &[CallArgument]) -> Result<ValueExpr, CallLookupError> {
         let oid = self.id();
         match self.entry() {
@@ -30,7 +30,7 @@ struct ScalarFnResolver<'a> {
     pub scfn: &'a ScalarFnCallSpecs,
 }
 
-impl<'a> Function for ScalarFnResolver<'a> {
+impl Function for ScalarFnResolver<'_> {
     fn resolve(&self, name: &str, args: &[CallArgument]) -> Result<ValueExpr, CallLookupError> {
         let oid = self.oid;
         let overloads = self.scfn;

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -609,7 +609,7 @@ impl<'a> AstToLogical<'a> {
 // so there is nothing done between the `enter_<x>` and `exit_<x>` calls.
 // By convention, processing for them is done in the `enter_<x>` calls here.
 //
-impl<'a, 'ast> Visitor<'ast> for AstToLogical<'a> {
+impl<'ast> Visitor<'ast> for AstToLogical<'_> {
     fn enter_ast_node(&mut self, id: NodeId) -> Traverse {
         self.id_stack.push(id);
         Traverse::Continue

--- a/partiql-parser/src/lexer/comment.rs
+++ b/partiql-parser/src/lexer/comment.rs
@@ -122,7 +122,7 @@ impl<'input, 'tracker> CommentLexer<'input, 'tracker> {
     }
 }
 
-impl<'input, 'tracker> Iterator for CommentLexer<'input, 'tracker> {
+impl<'input> Iterator for CommentLexer<'input, '_> {
     type Item = CommentStringResult<'input>;
 
     #[inline(always)]

--- a/partiql-parser/src/lexer/embedded_ion.rs
+++ b/partiql-parser/src/lexer/embedded_ion.rs
@@ -125,7 +125,7 @@ impl<'input, 'tracker> EmbeddedIonLexer<'input, 'tracker> {
     }
 }
 
-impl<'input, 'tracker> Iterator for EmbeddedIonLexer<'input, 'tracker> {
+impl<'input> Iterator for EmbeddedIonLexer<'input, '_> {
     type Item = EmbeddedIonStringResult<'input>;
 
     #[inline(always)]

--- a/partiql-parser/src/lexer/partiql.rs
+++ b/partiql-parser/src/lexer/partiql.rs
@@ -115,7 +115,7 @@ impl<'input, 'tracker> PartiqlLexer<'input, 'tracker> {
     }
 }
 
-impl<'input, 'tracker> Iterator for PartiqlLexer<'input, 'tracker> {
+impl<'input> Iterator for PartiqlLexer<'input, '_> {
     type Item = LexResult<'input>;
 
     #[inline(always)]
@@ -382,7 +382,7 @@ pub enum Token<'input> {
     Zone,
 }
 
-impl<'input> Token<'input> {
+impl Token<'_> {
     pub fn is_keyword(&self) -> bool {
         matches!(
             self,
@@ -449,7 +449,7 @@ impl<'input> Token<'input> {
     }
 }
 
-impl<'input> fmt::Display for Token<'input> {
+impl fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Token::Newline => write!(f, "\\n"),

--- a/partiql-parser/src/parse/parser_state.rs
+++ b/partiql-parser/src/parse/parser_state.rs
@@ -32,7 +32,7 @@ pub(crate) struct ParserState<'input, Id: NodeIdGenerator> {
     aggregates_pat: &'static Regex,
 }
 
-impl<'input> Default for ParserState<'input, AutoNodeIdGenerator> {
+impl Default for ParserState<'_, AutoNodeIdGenerator> {
     fn default() -> Self {
         ParserState::with_id_gen(AutoNodeIdGenerator::default())
     }
@@ -44,7 +44,7 @@ const KNOWN_AGGREGATES: &str =
     "(?i:^count$)|(?i:^avg$)|(?i:^min$)|(?i:^max$)|(?i:^sum$)|(?i:^any$)|(?i:^some$)|(?i:^every$)";
 static KNOWN_AGGREGATE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(KNOWN_AGGREGATES).unwrap());
 
-impl<'input, I> ParserState<'input, I>
+impl<I> ParserState<'_, I>
 where
     I: NodeIdGenerator,
 {
@@ -58,7 +58,7 @@ where
     }
 }
 
-impl<'input, IdGen: NodeIdGenerator> ParserState<'input, IdGen> {
+impl<IdGen: NodeIdGenerator> ParserState<'_, IdGen> {
     /// Create a new [`AstNode`] from the inner data which it is to hold and a source location.
     pub fn create_node<T, IntoLoc>(&mut self, node: T, location: IntoLoc) -> AstNode<T>
     where

--- a/partiql-types/Cargo.toml
+++ b/partiql-types/Cargo.toml
@@ -29,6 +29,6 @@ thiserror = "1"
 
 indexmap = "2.5"
 
-derivative = "2.2"
+educe = "0.6"
 
 [dev-dependencies]

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-use derivative::Derivative;
+use educe::Educe;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use miette::Diagnostic;
@@ -584,11 +584,11 @@ impl PartiqlShapeBuilder {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct AnyOf {
-    #[derivative(Hash(hash_with = "indexset_hash"))]
+    #[educe(Hash(method(indexset_hash)))]
     types: IndexSet<PartiqlShape>,
 }
 
@@ -743,11 +743,11 @@ impl Display for Static {
 
 pub const TYPE_DYNAMIC: PartiqlShape = PartiqlShape::Dynamic;
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct StructType {
-    #[derivative(Hash(hash_with = "indexset_hash"))]
+    #[educe(Hash(method(indexset_hash)))]
     constraints: IndexSet<StructConstraint>,
 }
 
@@ -827,15 +827,15 @@ impl Display for StructType {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 #[non_exhaustive]
 pub enum StructConstraint {
     Open(bool),
     Ordered(bool),
     DuplicateAttrs(bool),
-    Fields(#[derivative(Hash(hash_with = "indexset_hash"))] IndexSet<StructField>),
+    Fields(#[educe(Hash(method(indexset_hash)))] IndexSet<StructField>),
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -901,8 +901,8 @@ impl From<(&str, PartiqlShape, bool)> for StructField {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct BagType {
     element_type: Box<PartiqlShape>,
@@ -938,8 +938,8 @@ impl Display for BagType {
     }
 }
 
-#[derive(Derivative, Eq, Debug, Clone)]
-#[derivative(PartialEq, Hash)]
+#[derive(Educe, Eq, Debug, Clone)]
+#[educe(PartialEq, Hash)]
 #[allow(dead_code)]
 pub struct ArrayType {
     element_type: Box<PartiqlShape>,

--- a/partiql-value/src/bag.rs
+++ b/partiql-value/src/bag.rs
@@ -196,7 +196,7 @@ impl PartialOrd for Bag {
     }
 }
 
-impl<'a, const NULLS_FIRST: bool> Ord for NullSortedValue<'a, NULLS_FIRST, Bag> {
+impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, Bag> {
     fn cmp(&self, other: &Self) -> Ordering {
         let wrap = NullSortedValue::<{ NULLS_FIRST }, List>;
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -419,7 +419,7 @@ pub trait NullableOrd {
 #[derive(Eq, PartialEq)]
 pub struct EqualityValue<'a, const NULLS_EQUAL: bool, T>(pub &'a T);
 
-impl<'a, const GROUP_NULLS: bool> NullableEq for EqualityValue<'a, GROUP_NULLS, Value> {
+impl<const GROUP_NULLS: bool> NullableEq for EqualityValue<'_, GROUP_NULLS, Value> {
     type Output = Value;
 
     fn eq(&self, rhs: &Self) -> Self::Output {
@@ -905,7 +905,7 @@ where
     }
 }
 
-impl<'a, const NULLS_FIRST: bool> Ord for NullSortedValue<'a, NULLS_FIRST, Value> {
+impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, Value> {
     fn cmp(&self, other: &Self) -> Ordering {
         let wrap_list = NullSortedValue::<{ NULLS_FIRST }, List>;
         let wrap_tuple = NullSortedValue::<{ NULLS_FIRST }, Tuple>;

--- a/partiql-value/src/list.rs
+++ b/partiql-value/src/list.rs
@@ -193,7 +193,7 @@ impl PartialOrd for List {
     }
 }
 
-impl<'a, const NULLS_FIRST: bool> Ord for NullSortedValue<'a, NULLS_FIRST, List> {
+impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, List> {
     fn cmp(&self, other: &Self) -> Ordering {
         let wrap = NullSortedValue::<{ NULLS_FIRST }, _>;
 

--- a/partiql-value/src/pretty.rs
+++ b/partiql-value/src/pretty.rs
@@ -101,7 +101,7 @@ impl PrettyDoc for Tuple {
 
 pub struct StructValuePair<'a>((&'a String, &'a Value));
 
-impl<'a> PrettyDoc for StructValuePair<'a> {
+impl PrettyDoc for StructValuePair<'_> {
     fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
     where
         D: DocAllocator<'b, A>,

--- a/partiql-value/src/tuple.rs
+++ b/partiql-value/src/tuple.rs
@@ -267,7 +267,7 @@ impl Debug for Tuple {
     }
 }
 
-impl<'a, const NULLS_FIRST: bool> Ord for NullSortedValue<'a, NULLS_FIRST, Tuple> {
+impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, Tuple> {
     fn cmp(&self, other: &Self) -> Ordering {
         let wrap = NullSortedValue::<{ NULLS_FIRST }, Value>;
 

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -110,7 +110,7 @@ struct TestDataGen<'a> {
     name: String,
 }
 
-impl<'a> Iterator for TestDataGen<'a> {
+impl Iterator for TestDataGen<'_> {
     type Item = Result<Value, ExtensionResultError>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION

- update nightly toolchain used in CI testing 
- update deny/about for downstream license updates
- backport of https://github.com/partiql/partiql-lang-rust/pull/518 (see below)
- lots of clippy changes, as clippy/rust 1.83 changes some lifetime things to errors

---

Fix the following as reported by `cargo deny check`

```
error[unmaintained]: `derivative` is unmaintained; consider using an alternative
   ┌─ /Users/joshps/work/partiql-lang-rust/Cargo.lock:55:1
   │
55 │ derivative 2.2.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0388
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0388
   ├ The [`derivative`](https://crates.io/crates/derivative) crate is no longer maintained.
     Consider using any alternative, for instance:
     - [derive_more](https://crates.io/crates/derive_more)
     - [derive-where](https://crates.io/crates/derive-where)
     - [educe](https://crates.io/crates/educe)
   ├ Announcement: https://github.com/mcarton/rust-derivative/issues/117
   ├ Solution: No safe upgrade is available!
   ├ derivative v2.2.0
     └── partiql-types v0.11.0
```

Cf. https://github.com/mcarton/rust-derivative/issues/117

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
