### PR TITLE
Make `bind` consuming

### DIFF
--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -36,7 +36,7 @@ pub(crate) enum EvalCollFn {
 
 impl BindEvalExpr for EvalCollFn {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         fn create<const STRICT: bool, F>(
@@ -70,7 +70,7 @@ impl BindEvalExpr for EvalCollFn {
             PartiqlShapeBuilder::init_or_get().new_static(Static::Bag(BagType::new_any())),
         ])];
 
-        match *self {
+        match self {
             EvalCollFn::Count(setq) => {
                 create::<{ STRICT }, _>(any_elems, args, move |it| it.coll_count(setq))
             }

--- a/partiql-eval/src/eval/expr/datetime.rs
+++ b/partiql-eval/src/eval/expr/datetime.rs
@@ -32,7 +32,7 @@ pub(crate) enum EvalExtractFn {
 
 impl BindEvalExpr for EvalExtractFn {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         #[inline]

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -18,10 +18,10 @@ use std::ops::ControlFlow;
 
 impl BindEvalExpr for ScalarFnCallSpec {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
-        let plan = self.output.clone();
+        let plan = self.output;
         Ok(Box::new(EvalExprFnScalar::<{ STRICT }> { plan, args }))
     }
 }

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -60,7 +60,7 @@ pub enum BindError {
 /// A trait for binding an expression to its arguments into an `EvalExpr`
 pub trait BindEvalExpr: Debug {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError>;
 }

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -35,7 +35,7 @@ impl Debug for EvalLitExpr {
 
 impl BindEvalExpr for EvalLitExpr {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         _args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         Ok(Box::new(self.clone()))
@@ -77,7 +77,7 @@ pub(crate) enum EvalOpUnary {
 
 impl BindEvalExpr for EvalOpUnary {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let any_num = PartiqlShapeBuilder::init_or_get().any_of(type_numeric!());
@@ -177,7 +177,7 @@ impl<const STRICT: bool, OnMissing: ArgShortCircuit> ArgChecker
 impl BindEvalExpr for EvalOpBinary {
     #[inline]
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         type AndCheck = BoolShortCircuitArgChecker<false, PropagateNull<false>>;
@@ -345,7 +345,7 @@ pub(crate) struct EvalBetweenExpr {}
 
 impl BindEvalExpr for EvalBetweenExpr {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let types = [type_dynamic!(), type_dynamic!(), type_dynamic!()];
@@ -363,7 +363,7 @@ pub(crate) struct EvalFnExists {}
 
 impl BindEvalExpr for EvalFnExists {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         UnaryValueExpr::create_with_any::<{ STRICT }, _>(args, |v| {
@@ -383,7 +383,7 @@ pub(crate) struct EvalFnAbs {}
 
 impl BindEvalExpr for EvalFnAbs {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let nums = PartiqlShapeBuilder::init_or_get().any_of(type_numeric!());
@@ -404,7 +404,7 @@ pub(crate) struct EvalFnCardinality {}
 
 impl BindEvalExpr for EvalFnCardinality {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let shape_builder = PartiqlShapeBuilder::init_or_get();

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -178,7 +178,7 @@ pub(crate) enum EvalVarRef {
 
 impl BindEvalExpr for EvalVarRef {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         _: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         Ok(match self {

--- a/partiql-eval/src/eval/expr/pattern_match.rs
+++ b/partiql-eval/src/eval/expr/pattern_match.rs
@@ -43,7 +43,7 @@ impl EvalLikeMatch {
 
 impl BindEvalExpr for EvalLikeMatch {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let pattern = self.pattern.clone();
@@ -63,7 +63,7 @@ pub(crate) struct EvalLikeNonStringNonLiteralMatch {}
 
 impl BindEvalExpr for EvalLikeNonStringNonLiteralMatch {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let types = [type_string!(), type_string!(), type_string!()];

--- a/partiql-eval/src/eval/expr/strings.rs
+++ b/partiql-eval/src/eval/expr/strings.rs
@@ -28,7 +28,7 @@ pub(crate) enum EvalStringFn {
 impl BindEvalExpr for EvalStringFn {
     #[inline]
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         #[inline]
@@ -69,7 +69,7 @@ pub(crate) enum EvalTrimFn {
 
 impl BindEvalExpr for EvalTrimFn {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         let create = |f: for<'a> fn(&'a str, &'a str) -> &'a str| {
@@ -107,7 +107,7 @@ pub(crate) struct EvalFnPosition {}
 
 impl BindEvalExpr for EvalFnPosition {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         BinaryValueExpr::create_typed::<STRICT, _>(
@@ -129,7 +129,7 @@ pub(crate) struct EvalFnSubstring {}
 
 impl BindEvalExpr for EvalFnSubstring {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         match args.len() {
@@ -179,7 +179,7 @@ pub(crate) struct EvalFnOverlay {}
 
 impl BindEvalExpr for EvalFnOverlay {
     fn bind<const STRICT: bool>(
-        &self,
+        self,
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         fn overlay(value: &str, replacement: &str, offset: i64, length: usize) -> Value {

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -755,7 +755,7 @@ impl<'c> EvaluatorPlanner<'c> {
 
                                             Ok(Box::new(ErrorNode::new()) as Box<dyn EvalExpr>)
                                         }
-                                        Some(overload) => overload.bind::<{ STRICT }>(args),
+                                        Some(overload) => overload.clone().bind::<{ STRICT }>(args),
                                     }
                                 }
                                 FunctionEntryFunction::Aggregate() => {


### PR DESCRIPTION
Optimization: Make `bind` consume.
The values were never re-used anywhere anyway, and this reduces `clone`s.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
