### PR TITLE
Fix conformance test name generation for mixed camel-/snake-case

### DIFF
--- a/extension/partiql-extension-ion/src/decode.rs
+++ b/extension/partiql-extension-ion/src/decode.rs
@@ -354,9 +354,7 @@ fn has_annotation(
     reader: &impl IonReader<Item = StreamItem, Symbol = Symbol>,
     annot: &str,
 ) -> bool {
-    reader
-        .annotations()
-        .any(|a| a.map_or(false, |a| a == annot))
+    reader.annotations().any(|a| a.is_ok_and(|a| a == annot))
 }
 
 static TIME_PARTS_PATTERN_SET: Lazy<RegexSet> =

--- a/partiql-conformance-test-generator/Cargo.toml
+++ b/partiql-conformance-test-generator/Cargo.toml
@@ -27,3 +27,4 @@ Inflector = "0.11"
 miette = { version = "7", features = ["fancy"] }
 thiserror = "1.0"
 quote = "1"
+itertools = "0.14"


### PR DESCRIPTION
The test name in the input source are sometimes camelCase, somtimes snake_case, sometimes include ALLCAPS, and sometimes just space separated. This attempts to handle all these cases, as well as them being mixed, when generating output test function names.

The best place to see an example of the changes is in the new tests:
https://github.com/partiql/partiql-lang-rust/pull/531/files#diff-32bd33373ab1201cb93b5adcb18518713148844aef6b0807f26a221b792d031cR110-R121

Cf #511 


I do expect the conformance test report for this PR to potentially show changes due to this renaming, though I'm not sure it actually tracks tests that are removed or added, which is what this will appear as.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
