### PR TITLE
Introduce Datum, an interface to introspecting Values

### DIFF
--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -171,6 +171,7 @@ mod tests {
     use partiql_eval::eval::BasicContext;
     use partiql_eval::plan::EvaluationMode;
     use partiql_parser::{Parsed, ParserResult};
+    use partiql_value::datum::Datum;
     use partiql_value::{bag, tuple, DateTime, Value};
 
     #[track_caller]
@@ -229,7 +230,7 @@ mod tests {
             .unwrap_or_default();
         let out = evaluate(&catalog, lowered, bindings);
 
-        assert!(out.is_bag());
+        assert!(out.is_sequence());
         assert_eq!(&out, expected);
     }
 

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -111,17 +111,16 @@ impl Evaluable for EvalScan {
             Value::Tuple(t) => bag![*t],
             _ => bag![tuple![]],
         };
-
         let mut value = bag![];
         bindings.iter().for_each(|binding| {
             let binding_tuple = binding.as_tuple_ref();
             let v = self.expr.evaluate(&binding_tuple, ctx).into_owned();
-            let ordered = &v.is_ordered();
             let mut at_index_counter: i64 = 0;
             if let Some(at_key) = &self.at_key {
+                let ordered = v.is_ordered();
                 for t in v {
                     let mut out = Tuple::from([(self.as_key.as_str(), t)]);
-                    let at_id = if *ordered {
+                    let at_id = if ordered {
                         at_index_counter.into()
                     } else {
                         Missing
@@ -1234,7 +1233,6 @@ impl EvalExprQuery {
 impl Evaluable for EvalExprQuery {
     fn evaluate<'a, 'c>(&mut self, ctx: &'c dyn EvalContext<'c>) -> Value {
         let input_value = self.input.take().unwrap_or(Value::Null).coerce_into_tuple();
-
         self.expr.evaluate(&input_value, ctx).into_owned()
     }
 

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -15,6 +15,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 
+use partiql_value::datum::Datum;
 use std::rc::Rc;
 
 #[macro_export]

--- a/partiql-eval/src/eval/expr/coll.rs
+++ b/partiql-eval/src/eval/expr/coll.rs
@@ -14,6 +14,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use crate::eval::eval_expr_wrapper::UnaryValueExpr;
+use partiql_value::datum::Datum;
 use std::ops::ControlFlow;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use operators::*;
 
 use crate::eval::EvalContext;
 
+use partiql_value::datum::DatumLowerError;
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -37,7 +38,7 @@ pub trait EvalExpr: Debug {
         'c: 'a;
 }
 
-#[derive(Error, Debug, Clone, PartialEq)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 /// An error in binding an expression for evaluation
 pub enum BindError {
@@ -51,6 +52,9 @@ pub enum BindError {
     /// Feature has not yet been implemented.
     #[error("Not yet implemented: {0}")]
     NotYetImplemented(String),
+
+    #[error("Error lowering literal value: {0}")]
+    LiteralValue(#[from] DatumLowerError),
 
     /// Any other error.
     #[error("Bind error: unknown error")]

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -19,17 +19,30 @@ use std::fmt::{Debug, Formatter};
 
 use std::marker::PhantomData;
 
+use partiql_value::datum::{
+    DatumCategory, DatumCategoryRef, DatumLowerResult, DatumValue, SequenceDatum, TupleDatum,
+};
 use std::ops::ControlFlow;
 
 /// Represents a literal in (sub)query, e.g. `1` in `a + 1`.
 #[derive(Clone)]
 pub(crate) struct EvalLitExpr {
-    pub(crate) lit: Value,
+    pub(crate) val: Value,
+}
+
+impl EvalLitExpr {
+    pub(crate) fn new(val: Value) -> Self {
+        Self { val }
+    }
+
+    fn lower(&self) -> DatumLowerResult<EvalLitExpr> {
+        self.val.clone().into_lower().map(Self::new)
+    }
 }
 
 impl Debug for EvalLitExpr {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.lit.fmt(f)
+        self.val.fmt(f)
     }
 }
 
@@ -38,7 +51,7 @@ impl BindEvalExpr for EvalLitExpr {
         self,
         _args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
-        Ok(Box::new(self.clone()))
+        Ok(Box::new(self.lower()?))
     }
 }
 
@@ -51,7 +64,7 @@ impl EvalExpr for EvalLitExpr {
     where
         'c: 'a,
     {
-        Cow::Borrowed(&self.lit)
+        Cow::Borrowed(&self.val)
     }
 }
 
@@ -379,10 +392,9 @@ impl BindEvalExpr for EvalFnExists {
         args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         UnaryValueExpr::create_with_any::<{ STRICT }, _>(args, |v| {
-            Value::from(match v {
-                Value::Bag(b) => !b.is_empty(),
-                Value::List(l) => !l.is_empty(),
-                Value::Tuple(t) => !t.is_empty(),
+            Value::from(match v.category() {
+                DatumCategoryRef::Tuple(tuple) => !tuple.is_empty(),
+                DatumCategoryRef::Sequence(seq) => !seq.is_empty(),
                 _ => false,
             })
         })
@@ -430,10 +442,9 @@ impl BindEvalExpr for EvalFnCardinality {
         ]
         .into_any_of(&mut bld);
 
-        UnaryValueExpr::create_typed::<{ STRICT }, _>([collections], args, |v| match v {
-            Value::List(l) => Value::from(l.len()),
-            Value::Bag(b) => Value::from(b.len()),
-            Value::Tuple(t) => Value::from(t.len()),
+        UnaryValueExpr::create_typed::<{ STRICT }, _>([collections], args, |v| match v.category() {
+            DatumCategoryRef::Tuple(tuple) => Value::from(tuple.len()),
+            DatumCategoryRef::Sequence(seq) => Value::from(seq.len()),
             _ => Missing,
         })
     }

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -7,6 +7,10 @@ use partiql_value::Value::Missing;
 use partiql_value::{BindingsName, Tuple, Value};
 
 use partiql_catalog::context::Bindings;
+use partiql_value::datum::{
+    DatumCategory, DatumCategoryOwned, DatumCategoryRef, OwnedSequenceView, OwnedTupleView,
+    RefSequenceView, RefTupleView,
+};
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 
@@ -84,38 +88,43 @@ impl EvalPathComponent {
         value: &'a Value,
         bindings: &'a Tuple,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Option<&'a Value> {
-        match (self, value) {
-            (EvalPathComponent::Key(k), Value::Tuple(tuple)) => tuple.get(k),
-            (EvalPathComponent::Index(idx), Value::List(list)) => list.get(*idx),
-            (EvalPathComponent::KeyExpr(ke), Value::Tuple(tuple)) => {
-                as_name(ke.evaluate(bindings, ctx).borrow()).and_then(|key| tuple.get(&key))
+    ) -> Option<Cow<'a, Value>> {
+        let category = value.category();
+        match (self, category) {
+            (EvalPathComponent::Key(k), DatumCategoryRef::Tuple(tuple)) => tuple.get_val(k),
+            (EvalPathComponent::Index(idx), DatumCategoryRef::Sequence(seq)) => seq.get_val(*idx),
+            (EvalPathComponent::KeyExpr(ke), DatumCategoryRef::Tuple(tuple)) => {
+                as_name(ke.evaluate(bindings, ctx).borrow()).and_then(|key| tuple.get_val(&key))
             }
-            (EvalPathComponent::IndexExpr(ie), Value::List(list)) => {
-                as_int(ie.evaluate(bindings, ctx).borrow()).and_then(|i| list.get(i))
+            (EvalPathComponent::IndexExpr(ie), DatumCategoryRef::Sequence(seq)) => {
+                as_int(ie.evaluate(bindings, ctx).borrow()).and_then(|i| seq.get_val(i))
             }
             _ => None,
         }
     }
 
     #[inline]
-    fn take_val<'c>(
+    fn take_val<'a, 'c>(
         &self,
         value: Value,
         bindings: &Tuple,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Option<Value> {
-        match (self, value) {
-            (EvalPathComponent::Key(k), Value::Tuple(tuple)) => tuple.take_val(k),
-            (EvalPathComponent::Index(idx), Value::List(list)) => list.take_val(*idx),
-            (EvalPathComponent::KeyExpr(ke), Value::Tuple(tuple)) => {
+    ) -> Option<Cow<'a, Value>> {
+        let category = value.into_category();
+        match (self, category) {
+            (EvalPathComponent::Key(k), DatumCategoryOwned::Tuple(tuple)) => tuple.take_val(k),
+            (EvalPathComponent::Index(idx), DatumCategoryOwned::Sequence(seq)) => {
+                seq.take_val(*idx)
+            }
+            (EvalPathComponent::KeyExpr(ke), DatumCategoryOwned::Tuple(tuple)) => {
                 as_name(ke.evaluate(bindings, ctx).borrow()).and_then(|key| tuple.take_val(&key))
             }
-            (EvalPathComponent::IndexExpr(ie), Value::List(list)) => {
-                as_int(ie.evaluate(bindings, ctx).borrow()).and_then(|i| list.take_val(i))
+            (EvalPathComponent::IndexExpr(ie), DatumCategoryOwned::Sequence(seq)) => {
+                as_int(ie.evaluate(bindings, ctx).borrow()).and_then(|i| seq.take_val(i))
             }
             _ => None,
         }
+        .map(Cow::Owned)
     }
 }
 
@@ -128,17 +137,15 @@ impl EvalExpr for EvalPath {
     where
         'c: 'a,
     {
-        let value = self.expr.evaluate(bindings, ctx);
+        let evaluated = self.expr.evaluate(bindings, ctx);
         let mut path_componenents = self.components.iter();
-        match value {
-            Cow::Borrowed(borrowed) => path_componenents
-                .try_fold(borrowed, |v, path| path.get_val(v, bindings, ctx))
-                .map(Cow::Borrowed),
-            Cow::Owned(owned) => path_componenents
-                .try_fold(owned, |v, path| path.take_val(v, bindings, ctx))
-                .map(Cow::Owned),
-        }
-        .unwrap_or(Cow::Owned(Value::Missing))
+
+        path_componenents
+            .try_fold(evaluated, |value, path| match value {
+                Cow::Borrowed(borrowed) => path.get_val(borrowed, bindings, ctx),
+                Cow::Owned(owned) => path.take_val(owned, bindings, ctx),
+            })
+            .unwrap_or(Cow::Owned(Value::Missing))
     }
 }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -25,7 +25,6 @@ use crate::eval::expr::{
 use crate::eval::EvalPlan;
 use partiql_catalog::catalog::{Catalog, FunctionEntryFunction};
 use partiql_value::Value;
-use partiql_value::Value::Null;
 
 #[macro_export]
 macro_rules! correct_num_args_or_err {
@@ -361,6 +360,9 @@ impl<'c> EvaluatorPlanner<'c> {
                     }
                     BindError::NotYetImplemented(name) => PlanningError::NotYetImplemented(name),
                     BindError::ArgumentConstraint(msg) => PlanningError::IllegalState(msg),
+                    BindError::LiteralValue(err) => {
+                        PlanningError::IllegalState(format!("Literal error: {}", err))
+                    }
                 };
 
                 self.err(err)
@@ -392,10 +394,7 @@ impl<'c> EvaluatorPlanner<'c> {
             ),
             ValueExpr::Lit(lit) => (
                 "literal",
-                EvalLitExpr {
-                    lit: Value::from(lit.as_ref().clone()),
-                }
-                .bind::<{ STRICT }>(vec![]),
+                EvalLitExpr::new(Value::from(lit.as_ref().clone())).bind::<{ STRICT }>(vec![]),
             ),
             ValueExpr::Path(expr, components) => (
                 "path",
@@ -515,7 +514,7 @@ impl<'c> EvaluatorPlanner<'c> {
                     // If no `ELSE` clause is specified, use implicit `ELSE NULL` (see section 6.9, pg 142 of SQL-92 spec)
                     None => self.unwrap_bind(
                         "simple case default",
-                        EvalLitExpr { lit: Null }.bind::<{ STRICT }>(vec![]),
+                        EvalLitExpr::new(Value::Null).bind::<{ STRICT }>(vec![]),
                     ),
                     Some(def) => self.plan_value::<{ STRICT }>(def),
                 };
@@ -540,7 +539,7 @@ impl<'c> EvaluatorPlanner<'c> {
                     // If no `ELSE` clause is specified, use implicit `ELSE NULL` (see section 6.9, pg 142 of SQL-92 spec)
                     None => self.unwrap_bind(
                         "searched case default",
-                        EvalLitExpr { lit: Null }.bind::<{ STRICT }>(vec![]),
+                        EvalLitExpr::new(Value::Null).bind::<{ STRICT }>(vec![]),
                     ),
                     Some(def) => self.plan_value::<{ STRICT }>(def.as_ref()),
                 };

--- a/partiql-value/src/datum.rs
+++ b/partiql-value/src/datum.rs
@@ -1,0 +1,257 @@
+use crate::{Bag, BindingsName, List, Tuple, Value};
+use std::borrow::Cow;
+use std::error::Error;
+
+pub type DatumLowerError = Box<dyn Error>;
+pub type DatumLowerResult<T> = Result<T, DatumLowerError>;
+
+pub trait Datum<D>
+where
+    D: Datum<D>,
+{
+    #[inline]
+    /// Returns true if and only if Value is to be interpreted as `NULL`
+    #[must_use]
+    fn is_null(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    /// Returns true if and only if Value is to be interpreted as `MISSING`
+    #[must_use]
+    fn is_missing(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    /// Returns true if and only if Value is null or missing
+    #[must_use]
+    fn is_absent(&self) -> bool {
+        self.is_null() || self.is_missing()
+    }
+
+    /// Returns true if and only if Value is an integer, real, or decimal
+    #[must_use]
+    fn is_number(&self) -> bool;
+
+    #[inline]
+    /// Returns true if Value is neither null nor missing
+    #[must_use]
+    fn is_present(&self) -> bool {
+        !self.is_absent()
+    }
+
+    #[must_use]
+    fn is_sequence(&self) -> bool;
+
+    #[must_use]
+    fn is_ordered(&self) -> bool;
+}
+
+pub trait DatumValue<D>: Clone + Datum<D>
+where
+    D: Datum<D>,
+{
+    fn into_lower(self) -> DatumLowerResult<D>;
+}
+
+pub trait DatumCategory<'a> {
+    fn category(&'a self) -> DatumCategoryRef<'a>;
+    fn into_category(self) -> DatumCategoryOwned;
+}
+
+#[derive(Debug)]
+pub enum DatumCategoryRef<'a> {
+    Null,
+    Missing,
+    Tuple(DatumTupleRef<'a>),
+    Sequence(DatumSeqRef<'a>),
+    Scalar(DatumValueRef<'a>),
+}
+
+#[derive(Debug)]
+pub enum DatumCategoryOwned {
+    Null,
+    Missing,
+    Tuple(DatumTupleOwned),
+    Sequence(DatumSeqOwned),
+    Scalar(DatumValueOwned),
+}
+
+#[derive(Debug)]
+pub enum DatumTupleRef<'a> {
+    Tuple(&'a Tuple),
+}
+
+#[derive(Debug)]
+pub enum DatumSeqRef<'a> {
+    List(&'a List),
+    Bag(&'a Bag),
+}
+
+#[derive(Debug)]
+pub enum DatumValueRef<'a> {
+    Value(&'a Value),
+}
+
+#[derive(Debug)]
+pub enum DatumTupleOwned {
+    Tuple(Box<Tuple>),
+}
+
+#[derive(Debug)]
+pub enum DatumSeqOwned {
+    List(Box<List>),
+    Bag(Box<Bag>),
+}
+
+#[derive(Debug)]
+pub enum DatumValueOwned {
+    Value(Value),
+}
+
+impl<'a> DatumCategory<'a> for Value {
+    fn category(&'a self) -> DatumCategoryRef<'a> {
+        match self {
+            Value::Null => DatumCategoryRef::Null,
+            Value::Missing => DatumCategoryRef::Missing,
+            Value::List(list) => DatumCategoryRef::Sequence(DatumSeqRef::List(list)),
+            Value::Bag(bag) => DatumCategoryRef::Sequence(DatumSeqRef::Bag(bag)),
+            Value::Tuple(tuple) => DatumCategoryRef::Tuple(DatumTupleRef::Tuple(tuple.as_ref())),
+            val => DatumCategoryRef::Scalar(DatumValueRef::Value(val)),
+        }
+    }
+
+    fn into_category(self) -> DatumCategoryOwned {
+        match self {
+            Value::Null => DatumCategoryOwned::Null,
+            Value::Missing => DatumCategoryOwned::Missing,
+            Value::List(list) => DatumCategoryOwned::Sequence(DatumSeqOwned::List(list)),
+            Value::Bag(bag) => DatumCategoryOwned::Sequence(DatumSeqOwned::Bag(bag)),
+            Value::Tuple(tuple) => DatumCategoryOwned::Tuple(DatumTupleOwned::Tuple(tuple)),
+            val => DatumCategoryOwned::Scalar(DatumValueOwned::Value(val)),
+        }
+    }
+}
+
+pub trait TupleDatum {
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+pub trait RefTupleView<'a, DV: DatumValue<DV>>: TupleDatum {
+    fn get_val(&self, k: &BindingsName<'_>) -> Option<Cow<'a, DV>>;
+}
+
+pub trait OwnedTupleView<D: Datum<D>>: TupleDatum {
+    fn take_val(self, k: &BindingsName<'_>) -> Option<D>;
+    fn take_val_boxed(self: Box<Self>, k: &BindingsName<'_>) -> Option<D>;
+}
+
+impl TupleDatum for DatumTupleRef<'_> {
+    fn len(&self) -> usize {
+        match self {
+            DatumTupleRef::Tuple(tuple) => tuple.len(),
+        }
+    }
+}
+
+impl<'a> RefTupleView<'a, Value> for DatumTupleRef<'a> {
+    fn get_val(&self, k: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
+        match self {
+            DatumTupleRef::Tuple(tuple) => Tuple::get(tuple, k).map(Cow::Borrowed),
+        }
+    }
+}
+
+impl TupleDatum for DatumTupleOwned {
+    fn len(&self) -> usize {
+        match self {
+            DatumTupleOwned::Tuple(tuple) => tuple.len(),
+        }
+    }
+}
+
+impl OwnedTupleView<Value> for DatumTupleOwned {
+    fn take_val(self, k: &BindingsName<'_>) -> Option<Value> {
+        match self {
+            DatumTupleOwned::Tuple(tuple) => Tuple::take_val(*tuple, k),
+        }
+    }
+
+    fn take_val_boxed(self: Box<Self>, k: &BindingsName<'_>) -> Option<Value> {
+        (*self).take_val(k)
+    }
+}
+
+pub trait SequenceDatum {
+    fn is_ordered(&self) -> bool;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+pub trait RefSequenceView<'a, DV: DatumValue<DV>>: SequenceDatum {
+    fn get_val(&self, k: i64) -> Option<Cow<'a, DV>>;
+}
+
+pub trait OwnedSequenceView<D: Datum<D>>: SequenceDatum {
+    fn take_val(self, k: i64) -> Option<D>;
+    fn take_val_boxed(self: Box<Self>, k: i64) -> Option<D>;
+}
+
+impl SequenceDatum for DatumSeqRef<'_> {
+    fn is_ordered(&self) -> bool {
+        match self {
+            DatumSeqRef::List(_) => true,
+            DatumSeqRef::Bag(_) => false,
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            DatumSeqRef::List(l) => l.len(),
+            DatumSeqRef::Bag(b) => b.len(),
+        }
+    }
+}
+
+impl<'a> RefSequenceView<'a, Value> for DatumSeqRef<'a> {
+    fn get_val(&self, k: i64) -> Option<Cow<'a, Value>> {
+        match self {
+            DatumSeqRef::List(l) => List::get(l, k).map(Cow::Borrowed),
+            DatumSeqRef::Bag(_) => {
+                todo!("TODO RefSequenceView: Bag::get")
+            }
+        }
+    }
+}
+
+impl SequenceDatum for DatumSeqOwned {
+    fn is_ordered(&self) -> bool {
+        match self {
+            DatumSeqOwned::List(_) => true,
+            DatumSeqOwned::Bag(_) => false,
+        }
+    }
+
+    fn len(&self) -> usize {
+        todo!()
+    }
+}
+
+impl OwnedSequenceView<Value> for DatumSeqOwned {
+    fn take_val(self, k: i64) -> Option<Value> {
+        match self {
+            DatumSeqOwned::List(l) => l.take_val(k),
+            DatumSeqOwned::Bag(_) => todo!("TODO OwnedSequenceView: Bag::get"),
+        }
+    }
+
+    fn take_val_boxed(self: Box<Self>, k: i64) -> Option<Value> {
+        self.take_val(k)
+    }
+}

--- a/partiql-value/src/datum.rs
+++ b/partiql-value/src/datum.rs
@@ -223,9 +223,7 @@ impl<'a> RefSequenceView<'a, Value> for DatumSeqRef<'a> {
     fn get_val(&self, k: i64) -> Option<Cow<'a, Value>> {
         match self {
             DatumSeqRef::List(l) => List::get(l, k).map(Cow::Borrowed),
-            DatumSeqRef::Bag(_) => {
-                todo!("TODO RefSequenceView: Bag::get")
-            }
+            DatumSeqRef::Bag(_) => None,
         }
     }
 }
@@ -247,7 +245,7 @@ impl OwnedSequenceView<Value> for DatumSeqOwned {
     fn take_val(self, k: i64) -> Option<Value> {
         match self {
             DatumSeqOwned::List(l) => l.take_val(k),
-            DatumSeqOwned::Bag(_) => todo!("TODO OwnedSequenceView: Bag::get"),
+            DatumSeqOwned::Bag(_) => None,
         }
     }
 

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -5,6 +5,7 @@ mod bag;
 mod bindings;
 pub mod comparison;
 mod datetime;
+pub mod datum;
 mod list;
 mod pretty;
 mod sort;

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -14,6 +14,7 @@ mod iter;
 mod logic;
 mod math;
 
+use crate::datum::{Datum, DatumLowerResult, DatumValue};
 pub use iter::*;
 pub use logic::*;
 pub use math::*;
@@ -40,56 +41,6 @@ pub enum Value {
 }
 
 impl Value {
-    #[inline]
-    #[must_use]
-    pub fn is_tuple(&self) -> bool {
-        matches!(self, Value::Tuple(_))
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn is_list(&self) -> bool {
-        matches!(self, Value::List(_))
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn is_bag(&self) -> bool {
-        matches!(self, Value::Bag(_))
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn is_sequence(&self) -> bool {
-        self.is_bag() || self.is_list()
-    }
-
-    #[inline]
-    /// Returns true if and only if Value is an integer, real, or decimal
-    #[must_use]
-    pub fn is_number(&self) -> bool {
-        matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
-    }
-    #[inline]
-    /// Returns true if and only if Value is null or missing
-    #[must_use]
-    pub fn is_absent(&self) -> bool {
-        matches!(self, Value::Missing | Value::Null)
-    }
-
-    #[inline]
-    /// Returns true if Value is neither null nor missing
-    #[must_use]
-    pub fn is_present(&self) -> bool {
-        !self.is_absent()
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn is_ordered(&self) -> bool {
-        self.is_list()
-    }
-
     #[inline]
     #[must_use]
     pub fn coerce_into_tuple(self) -> Tuple {
@@ -205,6 +156,46 @@ impl Value {
         } else {
             None
         }
+    }
+}
+
+impl DatumValue<Value> for Value {
+    fn into_lower(self) -> DatumLowerResult<Value> {
+        Ok(self)
+    }
+}
+
+impl Datum<Value> for Value {
+    #[inline]
+    fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    #[inline]
+    fn is_missing(&self) -> bool {
+        matches!(self, Value::Missing)
+    }
+
+    #[inline]
+    fn is_absent(&self) -> bool {
+        matches!(self, Value::Missing | Value::Null)
+    }
+
+    #[inline]
+    fn is_number(&self) -> bool {
+        matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
+    }
+
+    #[inline]
+    #[must_use]
+    fn is_sequence(&self) -> bool {
+        matches!(self, Value::List(_) | Value::Bag(_))
+    }
+
+    #[inline]
+    #[must_use]
+    fn is_ordered(&self) -> bool {
+        matches!(self, Value::List(_))
     }
 }
 

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
+use assert_matches::assert_matches;
 use std::error::Error;
-
 use thiserror::Error;
 
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
@@ -20,6 +20,7 @@ use partiql_value::{bag, tuple, DateTime, Value};
 
 use crate::common::{lower, parse, TestError};
 use partiql_logical as logical;
+use partiql_value::datum::{DatumCategory, DatumCategoryRef, SequenceDatum};
 
 mod common;
 #[derive(Debug)]
@@ -195,8 +196,9 @@ fn test_context() -> Result<(), TestError<'static>> {
     };
     let ctx: [(String, &dyn Any); 1] = [("counter".to_string(), &counter)];
     let out = evaluate(&catalog, lowered, bindings, &ctx);
+    let out_cat = out.category();
 
-    assert!(out.is_bag());
+    assert_matches!(out_cat, DatumCategoryRef::Sequence(seq) if !seq.is_ordered());
     assert_eq!(&out, &expected);
     assert_eq!(*counter.data.borrow(), 0);
 


### PR DESCRIPTION
This PR introduces `Datum` and `DatumCategory`. These serve as interfaces for abstracting certain properties of PartiQL `Value`s without introspecting the `Value` directly.

This forms part of the basis for supporting external `Variant`s. 

Cf. https://github.com/partiql/partiql-lang-rust/pull/529

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
