### PR TITLE
Add Boxed Variant interface & Boxed Ion implementation

### DIFF
--- a/extension/partiql-extension-ion-functions/Cargo.toml
+++ b/extension/partiql-extension-ion-functions/Cargo.toml
@@ -31,7 +31,7 @@ itertools = "0.13"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.7", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.10", features = ["experimental"] }
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"
 regex = "1.10"

--- a/extension/partiql-extension-ion-functions/src/lib.rs
+++ b/extension/partiql-extension-ion-functions/src/lib.rs
@@ -171,7 +171,6 @@ mod tests {
     use partiql_eval::eval::BasicContext;
     use partiql_eval::plan::EvaluationMode;
     use partiql_parser::{Parsed, ParserResult};
-    use partiql_value::datum::Datum;
     use partiql_value::{bag, tuple, DateTime, Value};
 
     #[track_caller]
@@ -230,7 +229,7 @@ mod tests {
             .unwrap_or_default();
         let out = evaluate(&catalog, lowered, bindings);
 
-        assert!(out.is_sequence());
+        assert!(out.is_bag());
         assert_eq!(&out, expected);
     }
 

--- a/extension/partiql-extension-ion/Cargo.toml
+++ b/extension/partiql-extension-ion/Cargo.toml
@@ -23,6 +23,7 @@ bench = false
 [dependencies]
 partiql-value = { path = "../../partiql-value", version = "0.11.*" }
 partiql-common = { path = "../../partiql-common", version = "0.11.*" }
+partiql-types = { path = "../../partiql-types", version = "0.11.*" }
 
 serde = { version = "1", features = ["derive"], optional = true }
 typetag = { version = "0.2", optional = true }

--- a/extension/partiql-extension-ion/Cargo.toml
+++ b/extension/partiql-extension-ion/Cargo.toml
@@ -22,20 +22,33 @@ bench = false
 
 [dependencies]
 partiql-value = { path = "../../partiql-value", version = "0.11.*" }
+partiql-common = { path = "../../partiql-common", version = "0.11.*" }
+
+serde = { version = "1", features = ["derive"], optional = true }
+typetag = { version = "0.2", optional = true }
+
 ordered-float = "4"
 itertools = "0.13"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.36"
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.7", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.10", features = ["experimental"] }
+
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"
 regex = "1.10"
 thiserror = "1.0"
 delegate = "0.13"
+peekmore = "1.3"
 
 [dev-dependencies]
 
 [features]
 default = []
+serde = [
+    "dep:serde",
+    "dep:typetag",
+    "partiql-value/serde",
+    "partiql-common/serde"
+]

--- a/extension/partiql-extension-ion/src/boxed_ion.rs
+++ b/extension/partiql-extension-ion/src/boxed_ion.rs
@@ -1,0 +1,547 @@
+use ion_rs::{
+    AnyEncoding, Element, ElementReader, IonResult, IonType, OwnedSequenceIterator, Reader,
+    Sequence,
+};
+use ion_rs_old::IonReader;
+use partiql_value::boxed_variant::{
+    BoxedVariant, BoxedVariantResult, BoxedVariantType, BoxedVariantValueIntoIterator,
+};
+use partiql_value::datum::{
+    Datum, DatumCategoryOwned, DatumCategoryRef, DatumSeqOwned, DatumSeqRef, DatumTupleOwned,
+    DatumTupleRef, DatumValueOwned, DatumValueRef, OwnedSequenceView, OwnedTupleView,
+    RefSequenceView, RefTupleView, SequenceDatum, TupleDatum,
+};
+use partiql_value::{BindingsName, Value, Variant};
+use peekmore::{PeekMore, PeekMoreIterator};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::fmt::{Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::ops::DerefMut;
+use std::rc::Rc;
+use thiserror::Error;
+
+#[derive(Default, Debug, Copy, Clone)]
+pub struct BoxedIonType {}
+impl BoxedVariantType for BoxedIonType {
+    type Doc = BoxedIon;
+
+    fn construct(&self, bytes: Vec<u8>) -> BoxedVariantResult<Self::Doc> {
+        BoxedIon::parse(bytes, BoxedIonStreamType::SingleTLV).map_err(Into::into)
+    }
+
+    fn name(&self) -> &'static str {
+        "ion"
+    }
+}
+
+/// Errors in boxed Ion.
+///
+/// ### Notes
+/// This is marked `#[non_exhaustive]`, to reserve the right to add more variants in the future.
+#[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum BoxedIonError {
+    /// Ion Writer error.
+    #[error("Expected a sequence, but was `{elt}`")]
+    NotASequence { elt: Box<Element> },
+}
+
+pub type Result<T> = std::result::Result<T, BoxedIonError>;
+
+pub struct ElementIterator<R: ElementReader> {
+    reader: R,
+}
+
+impl<R: ElementReader> Iterator for ElementIterator<R> {
+    type Item = IonResult<Element>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.reader.read_next_element().transpose()
+    }
+}
+
+struct IonContext {
+    reader: PeekMoreIterator<ElementIterator<Reader<AnyEncoding, Vec<u8>>>>,
+}
+
+impl IonContext {
+    pub fn new(data: Vec<u8>) -> IonResult<Self> {
+        let reader = Reader::new(AnyEncoding, data)?;
+        let reader = ElementIterator { reader }.peekmore();
+        Ok(Self { reader })
+    }
+
+    pub fn new_ptr(data: Vec<u8>) -> IonResult<IonContextPtr> {
+        Ok(Rc::new(RefCell::new(Self::new(data)?)))
+    }
+}
+
+pub type IonContextPtr = Rc<RefCell<IonContext>>;
+
+// TODO [EMBDOC] does this serialization work?
+#[derive(Clone)]
+pub struct BoxedIon {
+    ctx: IonContextPtr,
+    doc: BoxedIonValue,
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for BoxedIon {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        todo!()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for BoxedIon {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!()
+    }
+}
+
+impl Hash for BoxedIon {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        todo!("BoxedIon.hash")
+    }
+}
+
+#[cfg_attr(feature = "serde", typetag::serde)]
+impl BoxedVariant for BoxedIon {
+    fn into_dyn_iter(self: Box<Self>) -> BoxedVariantResult<BoxedVariantValueIntoIterator> {
+        let iter = self.try_into_iter()?;
+
+        Ok(Box::new(iter.map(|d| Box::new(d) as Box<dyn BoxedVariant>))
+            as BoxedVariantValueIntoIterator)
+    }
+
+    fn category(&self) -> DatumCategoryRef<'_> {
+        match &self.doc {
+            BoxedIonValue::Stream() => DatumCategoryRef::Sequence(DatumSeqRef::Dynamic(self)),
+            BoxedIonValue::Sequence(seq) => DatumCategoryRef::Sequence(DatumSeqRef::Dynamic(self)),
+            BoxedIonValue::Value(elt) => match elt.ion_type() {
+                IonType::List => DatumCategoryRef::Sequence(DatumSeqRef::Dynamic(self)),
+                IonType::SExp => DatumCategoryRef::Sequence(DatumSeqRef::Dynamic(self)),
+                IonType::Null => DatumCategoryRef::Null,
+                IonType::Struct => DatumCategoryRef::Tuple(DatumTupleRef::Dynamic(self)),
+                _ => DatumCategoryRef::Scalar(DatumValueRef::Value(todo!(
+                    "Boxed Ion DatumCategoryRef::Scalar"
+                ))),
+            },
+        }
+    }
+
+    fn into_category(self: Box<Self>) -> DatumCategoryOwned {
+        match &self.doc {
+            BoxedIonValue::Stream() => DatumCategoryOwned::Sequence(DatumSeqOwned::Dynamic(self)),
+            BoxedIonValue::Sequence(seq) => {
+                DatumCategoryOwned::Sequence(DatumSeqOwned::Dynamic(self))
+            }
+            BoxedIonValue::Value(elt) => match elt.ion_type() {
+                IonType::List => DatumCategoryOwned::Sequence(DatumSeqOwned::Dynamic(self)),
+                IonType::SExp => DatumCategoryOwned::Sequence(DatumSeqOwned::Dynamic(self)),
+                IonType::Null => DatumCategoryOwned::Null,
+                IonType::Struct => DatumCategoryOwned::Tuple(DatumTupleOwned::Dynamic(self)),
+                _ => DatumCategoryOwned::Scalar(DatumValueOwned::Value(self.into_value())),
+            },
+        }
+    }
+}
+
+impl SequenceDatum for BoxedIon {
+    fn is_ordered(&self) -> bool {
+        true
+    }
+
+    fn len(&self) -> usize {
+        match &self.doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => seq.len(),
+            BoxedIonValue::Value(elt) => match elt.expect_sequence() {
+                Ok(seq) => seq.len(), // TODO
+                Err(e) => todo!(),
+            },
+        }
+    }
+}
+
+impl<'a> RefSequenceView<'a, Value> for BoxedIon {
+    fn get_val(&self, k: i64) -> Option<Cow<'a, Value>> {
+        match &self.doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => seq
+                .get(k as usize)
+                .map(|elt| Cow::Owned(self.child_value(elt.clone()))), // TODO remove clone
+            BoxedIonValue::Value(elt) => match elt.expect_sequence() {
+                Ok(seq) => seq
+                    .iter()
+                    .nth(k as usize)
+                    .map(|elt| Cow::Owned(self.child_value(elt.clone()))), // TODO remove clone
+                Err(e) => todo!(),
+            },
+        }
+    }
+}
+
+impl OwnedSequenceView<Value> for BoxedIon {
+    fn take_val(self, k: i64) -> Option<Value> {
+        let Self { doc, ctx } = self;
+        match doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => seq
+                .into_iter()
+                .nth(k as usize)
+                .map(|elt| Self::new_value(elt, ctx)),
+            BoxedIonValue::Value(elt) => match elt.try_into_sequence() {
+                Ok(seq) => seq
+                    .into_iter()
+                    .nth(k as usize)
+                    .map(|elt| Self::new_value(elt, ctx)),
+                Err(e) => todo!(),
+            },
+        }
+    }
+
+    fn take_val_boxed(self: Box<Self>, k: i64) -> Option<Value> {
+        OwnedSequenceView::take_val(*self, k)
+    }
+}
+
+impl TupleDatum for BoxedIon {
+    fn len(&self) -> usize {
+        match &self.doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => {
+                todo!()
+            }
+            BoxedIonValue::Value(elt) => match elt.expect_struct() {
+                Ok(strct) => strct.len(),
+                Err(e) => todo!(),
+            },
+        }
+    }
+}
+
+impl<'a> RefTupleView<'a, Value> for BoxedIon {
+    fn get_val(&self, target_key: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
+        let matcher = target_key.matcher();
+        let Self { doc, ctx } = self;
+        match doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => {
+                todo!()
+            }
+            BoxedIonValue::Value(elt) => match elt.expect_struct() {
+                Ok(strct) => {
+                    for (k, elt) in strct {
+                        if let Some(k) = k.text() {
+                            if matcher.matches(k) {
+                                return Some(Cow::Owned(Self::new_value(elt.clone(), ctx.clone())));
+                            }
+                        }
+                    }
+                    None
+                }
+                Err(e) => todo!(),
+            },
+        }
+    }
+}
+
+impl OwnedTupleView<Value> for BoxedIon {
+    fn take_val(self, k: &BindingsName<'_>) -> Option<Value> {
+        todo!()
+    }
+
+    fn take_val_boxed(self: Box<Self>, target_key: &BindingsName<'_>) -> Option<Value> {
+        let matcher = target_key.matcher();
+        let Self { doc, ctx } = *self;
+        match doc {
+            BoxedIonValue::Stream() => {
+                todo!()
+            }
+            BoxedIonValue::Sequence(seq) => {
+                todo!()
+            }
+            BoxedIonValue::Value(elt) => match elt.try_into_struct() {
+                Ok(strct) => {
+                    for (k, elt) in strct {
+                        if let Some(k) = k.text() {
+                            if matcher.matches(k) {
+                                return Some(Self::new_value(elt, ctx));
+                            }
+                        }
+                    }
+                    None
+                }
+                Err(e) => todo!(),
+            },
+        }
+    }
+}
+
+impl Debug for BoxedIon {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("BoxedIon").field(&self.doc).finish()
+    }
+}
+
+impl Display for BoxedIon {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.doc, f)
+    }
+}
+
+impl BoxedIon {
+    fn into_value(self) -> Value {
+        Value::from(Variant::from(self))
+    }
+
+    pub fn new(doc: impl Into<BoxedIonValue>, ctx: IonContextPtr) -> Self {
+        Self {
+            ctx,
+            doc: doc.into(),
+        }
+    }
+    pub fn new_value(doc: impl Into<BoxedIonValue>, ctx: IonContextPtr) -> Value {
+        Self::new(doc, ctx).into_value()
+    }
+
+    fn child(&self, child: impl Into<BoxedIonValue>) -> Self {
+        Self {
+            ctx: self.ctx.clone(),
+            doc: child.into(),
+        }
+    }
+
+    fn child_value(&self, child: impl Into<BoxedIonValue>) -> Value {
+        self.child(child).into_value()
+    }
+
+    pub fn parse(data: Vec<u8>, expected: BoxedIonStreamType) -> IonResult<Self> {
+        let mut ctx = IonContext::new_ptr(data)?;
+        let doc = Self::init_doc(&mut ctx, expected);
+        Ok(Self::new(doc, ctx))
+    }
+
+    pub fn parse_unknown(data: Vec<u8>) -> IonResult<Self> {
+        Self::parse(data, BoxedIonStreamType::Unknown)
+    }
+    pub fn parse_tlv(data: Vec<u8>) -> IonResult<Self> {
+        Self::parse(data, BoxedIonStreamType::SingleTLV)
+    }
+
+    pub fn parse_stream(data: Vec<u8>) -> IonResult<Self> {
+        Self::parse(data, BoxedIonStreamType::Stream)
+    }
+
+    fn init_doc(ctx: &mut IonContextPtr, expected: BoxedIonStreamType) -> BoxedIonValue {
+        let reader = &mut ctx.borrow_mut().reader;
+        let expected = match expected {
+            BoxedIonStreamType::Unknown => {
+                if reader.peek_nth(1).is_some() {
+                    BoxedIonStreamType::Stream
+                } else {
+                    BoxedIonStreamType::SingleTLV
+                }
+            }
+            other => other,
+        };
+        match expected {
+            BoxedIonStreamType::Unknown => {
+                unreachable!()
+            }
+            BoxedIonStreamType::Stream => BoxedIonValue::Stream(),
+            BoxedIonStreamType::SingleTLV => {
+                let elt = reader.next().expect("ion value"); // TODO [EMBDOC]
+                let elt = elt.expect("ion element"); // TODO [EMBDOC]
+                if reader.peek().is_some() {
+                    // TODO error on stream instead of TLV?
+                }
+
+                match elt.try_into_sequence() {
+                    Err(err) => BoxedIonValue::Value(err.original_value()),
+                    Ok(seq) => BoxedIonValue::Sequence(seq),
+                }
+            }
+        }
+    }
+
+    fn try_into_iter(self) -> Result<BoxedIonIterator> {
+        let BoxedIon { ctx, doc } = self;
+
+        let inner = match doc {
+            BoxedIonValue::Stream() => BoxedIonIterType::Stream(),
+            BoxedIonValue::Value(elt) => match elt.try_into_sequence() {
+                Err(err) => {
+                    // TODO [EMBDOC]
+                    // We could error? But generally PartiQL coerces to a singleton collection...
+                    //Err(BoxedIonError::NotASequence { elt }),
+                    BoxedIonIterType::Sequence(Sequence::new([err.original_value()]).into_iter())
+                }
+                Ok(seq) => BoxedIonIterType::Sequence(seq.into_iter()),
+            },
+            BoxedIonValue::Sequence(seq) => BoxedIonIterType::Sequence(seq.into_iter()),
+        }
+        .into();
+
+        Ok(BoxedIonIterator { ctx, inner })
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum BoxedIonStreamType {
+    Unknown,
+    Stream,
+    SingleTLV,
+}
+
+#[derive(Debug)]
+enum BoxedIonValue {
+    Stream(),
+    Value(Element),
+    Sequence(Sequence),
+}
+
+impl From<Element> for BoxedIonValue {
+    fn from(value: Element) -> Self {
+        BoxedIonValue::Value(value)
+    }
+}
+
+impl From<Sequence> for BoxedIonValue {
+    fn from(value: Sequence) -> Self {
+        BoxedIonValue::Sequence(value)
+    }
+}
+
+impl Clone for BoxedIonValue {
+    fn clone(&self) -> Self {
+        // TODO [EMBDOC]
+        match self {
+            BoxedIonValue::Stream() => {
+                todo!("stream not cloneable? ")
+            }
+            BoxedIonValue::Value(val) => BoxedIonValue::Value(val.clone()),
+            BoxedIonValue::Sequence(seq) => BoxedIonValue::Sequence(seq.clone()),
+        }
+    }
+}
+
+impl Display for BoxedIonValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // TODO [EMBDOC]
+        match self {
+            BoxedIonValue::Stream() => {
+                todo!("stream not displayable? ")
+            }
+            BoxedIonValue::Value(val) => std::fmt::Display::fmt(val, f),
+            BoxedIonValue::Sequence(seq) => std::fmt::Debug::fmt(&seq, f),
+        }
+    }
+}
+
+impl Datum<Value> for BoxedIon {
+    fn is_null(&self) -> bool {
+        match &self.doc {
+            BoxedIonValue::Value(elt) => elt.is_null(),
+            BoxedIonValue::Stream() => false,
+            BoxedIonValue::Sequence(_) => false,
+        }
+    }
+
+    fn is_sequence(&self) -> bool {
+        match &self.doc {
+            BoxedIonValue::Value(elt) => elt.as_sequence().is_some(),
+            BoxedIonValue::Stream() => true,
+            BoxedIonValue::Sequence(_) => true,
+        }
+    }
+
+    fn is_ordered(&self) -> bool {
+        match self.category() {
+            DatumCategoryRef::Sequence(seq) => seq.is_ordered(),
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BoxedIonIterType {
+    Stream(),
+    Sequence(OwnedSequenceIterator),
+}
+
+struct BoxedIonIterator {
+    ctx: IonContextPtr,
+    inner: RefCell<BoxedIonIterType>,
+}
+
+impl Iterator for BoxedIonIterator {
+    type Item = BoxedIon;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let elt = match self.inner.borrow_mut().deref_mut() {
+            BoxedIonIterType::Stream() => {
+                let elt = self.ctx.borrow_mut().deref_mut().reader.next();
+                // TODO [EMBDOC]
+                elt.transpose().expect("ion not error")
+            }
+            BoxedIonIterType::Sequence(seq) => seq.next(),
+        };
+        elt.map(|elt| BoxedIon::new(BoxedIonValue::Value(elt), self.ctx.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flatten_dump(doc: BoxedIon) {
+        if doc.is_sequence() {
+            for c in doc.try_into_iter().expect("TODO [EMBDOC]") {
+                flatten_dump(c)
+            }
+        } else {
+            println!("{:?}", doc);
+        }
+    }
+
+    fn dump(data: Vec<u8>, expected_stream_type: BoxedIonStreamType) {
+        println!("\n===========\n");
+
+        let doc = BoxedIon::parse(data, expected_stream_type).expect("boxed ion create");
+
+        flatten_dump(doc);
+    }
+
+    #[test]
+    fn simple() {
+        let one_elt: Vec<u8> =
+            "[0, {a: 1, b:2, c: [], d: foo::(SYMBOL 3 2 1 {})}, [1,2,3,4]]".into();
+        let stream: Vec<u8> = "0 {a: 1, b:2, c: [], d: foo::(SYMBOL 3 2 1 {})} [1,2,3,4]".into();
+
+        dump(one_elt.clone(), BoxedIonStreamType::SingleTLV);
+        dump(one_elt, BoxedIonStreamType::Unknown);
+        dump(stream.clone(), BoxedIonStreamType::Stream);
+        dump(stream, BoxedIonStreamType::Unknown);
+    }
+}

--- a/extension/partiql-extension-ion/src/encode.rs
+++ b/extension/partiql-extension-ion/src/encode.rs
@@ -132,6 +132,9 @@ where
             Value::List(l) => self.encode_list(l.as_ref()),
             Value::Bag(b) => self.encode_bag(b.as_ref()),
             Value::Tuple(t) => self.encode_tuple(t.as_ref()),
+            Value::Variant(_) => {
+                todo!("ion encode embedded doc")
+            }
         }
     }
 

--- a/extension/partiql-extension-ion/src/lib.rs
+++ b/extension/partiql-extension-ion/src/lib.rs
@@ -1,6 +1,10 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+pub mod boxed_ion;
 mod common;
 pub mod decode;
 pub mod encode;

--- a/extension/partiql-extension-ion/src/lib.rs
+++ b/extension/partiql-extension-ion/src/lib.rs
@@ -8,6 +8,7 @@ pub mod boxed_ion;
 mod common;
 pub mod decode;
 pub mod encode;
+mod util;
 
 pub use common::Encoding;
 

--- a/extension/partiql-extension-ion/src/util.rs
+++ b/extension/partiql-extension-ion/src/util.rs
@@ -1,0 +1,129 @@
+use crate::decode::IonDecodeError;
+use ion_rs::{Decimal, Element, IonResult};
+use partiql_value::datum::DatumLowerResult;
+use partiql_value::{DateTime, Value};
+use std::num::NonZeroU8;
+use std::str::FromStr;
+
+pub enum PartiqlValueTarget<T> {
+    Atom(Value),
+    List(Vec<T>),
+    Bag(Vec<T>),
+    Struct(Vec<(String, T)>),
+}
+
+impl<T, V> From<V> for PartiqlValueTarget<T>
+where
+    V: Into<Value>,
+{
+    fn from(value: V) -> Self {
+        PartiqlValueTarget::Atom(value.into())
+    }
+}
+
+pub trait ToPartiqlValue<T> {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<T>>;
+}
+
+impl ToPartiqlValue<Element> for Element {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        let value = self.into_value();
+        match value {
+            ion_rs::Value::Null(_) => Ok(Value::Null.into()),
+            ion_rs::Value::Bool(inner) => Ok(inner.into()),
+            ion_rs::Value::Int(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Float(inner) => Ok(inner.into()),
+            ion_rs::Value::Decimal(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Timestamp(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Symbol(inner) => inner.into_partiql_value(),
+            ion_rs::Value::String(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Clob(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Blob(inner) => inner.into_partiql_value(),
+            ion_rs::Value::List(inner) => inner.into_partiql_value(),
+            ion_rs::Value::SExp(inner) => inner.into_partiql_value(),
+            ion_rs::Value::Struct(inner) => inner.into_partiql_value(),
+        }
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Int {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        if let Some(n) = self.as_i64() {
+            Ok(Value::from(n).into())
+        } else {
+            let large = self.as_i128().expect("ion int i128");
+            Ok(Value::from(large).into())
+        }
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Decimal {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        let dec = ion_decimal_to_decimal(&self);
+        Ok(dec.expect("ion decimal").into())
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Timestamp {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        let ts = self;
+        let offset = ts.offset();
+        let datetime = DateTime::from_ymdhms_nano_offset_minutes(
+            ts.year() as i32,
+            NonZeroU8::new(ts.month() as u8).ok_or(IonDecodeError::ConversionError(
+                "month outside of range".into(),
+            ))?,
+            ts.day() as u8,
+            ts.hour() as u8,
+            ts.minute() as u8,
+            ts.second() as u8,
+            ts.nanoseconds(),
+            offset,
+        );
+        Ok(datetime.into())
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Symbol {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        Ok(self.expect_text()?.into())
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Str {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        Ok(self.text().into())
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Bytes {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        Ok(Value::Blob(Box::new(self.into())).into())
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Sequence {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        Ok(PartiqlValueTarget::List(
+            self.into_iter().collect::<Vec<_>>(),
+        ))
+    }
+}
+
+impl ToPartiqlValue<Element> for ion_rs::Struct {
+    fn into_partiql_value(self) -> DatumLowerResult<PartiqlValueTarget<Element>> {
+        let data: IonResult<Vec<_>> = self
+            .into_iter()
+            .map(|(sym, elt)| sym.expect_text().map(String::from).map(|s| (s, elt)))
+            .collect();
+        Ok(PartiqlValueTarget::Struct(data?))
+    }
+}
+
+fn ion_decimal_to_decimal(ion_dec: &Decimal) -> Result<rust_decimal::Decimal, rust_decimal::Error> {
+    // TODO ion Decimal doesn't give a lot of functionality to get at the data currently
+    // TODO    and it's not clear whether we'll continue with rust decimal or switch to big decimal
+    let ion_dec_str = format!("{ion_dec}").replace('d', "e");
+    rust_decimal::Decimal::from_str(&ion_dec_str)
+        .or_else(|_| rust_decimal::Decimal::from_scientific(&ion_dec_str))
+}

--- a/partiql-ast-passes/src/error.rs
+++ b/partiql-ast-passes/src/error.rs
@@ -1,14 +1,15 @@
 use partiql_catalog::call_defs::CallLookupError;
+use std::error::Error;
 use thiserror::Error;
 
 /// Contains the errors that occur during AST transformations
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub struct AstTransformationError {
     pub errors: Vec<AstTransformError>,
 }
 
 /// Represents an AST transform Error
-#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum AstTransformError {
     /// Indicates that AST lowering has not yet been implemented for this feature.
@@ -42,6 +43,16 @@ pub enum AstTransformError {
     /// Indicates that a `HAVING` clause was provided without a `GROUP BY`
     #[error("HAVING clause provided without GROUP BY")]
     HavingWithoutGroupBy,
+
+    /// Some other error; likely from a plugin
+    #[error(transparent)]
+    Other(Box<dyn Error>),
+}
+
+impl From<Box<dyn Error>> for AstTransformError {
+    fn from(value: Box<dyn Error>) -> Self {
+        Self::Other(value)
+    }
 }
 
 impl From<CallLookupError> for AstTransformError {

--- a/partiql-ast/src/pretty.rs
+++ b/partiql-ast/src/pretty.rs
@@ -697,28 +697,14 @@ impl PrettyDoc for Struct {
         D::Doc: Clone,
         A: Clone,
     {
-        let wrapped = self.fields.iter().map(|p| unsafe {
-            let x: &'b StructExprPair = std::mem::transmute(p);
-            x
+        let fields = self.fields.iter().map(|expr_pair| {
+            let k = expr_pair.first.pretty_doc(arena);
+            let v = expr_pair.second.pretty_doc(arena);
+            let sep = arena.text(": ");
+
+            k.append(sep).group().append(v).group()
         });
-        pretty_seq(wrapped, "{", "}", ",", PRETTY_INDENT_MINOR_NEST, arena)
-    }
-}
-
-pub struct StructExprPair(pub ExprPair);
-
-impl PrettyDoc for StructExprPair {
-    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
-    where
-        D: DocAllocator<'b, A>,
-        D::Doc: Clone,
-        A: Clone,
-    {
-        let k = self.0.first.pretty_doc(arena);
-        let v = self.0.second.pretty_doc(arena);
-        let sep = arena.text(": ");
-
-        k.append(sep).group().append(v).group()
+        pretty_seq_doc(fields, "{", None, "}", ",", PRETTY_INDENT_MINOR_NEST, arena)
     }
 }
 
@@ -729,28 +715,14 @@ impl PrettyDoc for StructLit {
         D::Doc: Clone,
         A: Clone,
     {
-        let wrapped = self.fields.iter().map(|p| unsafe {
-            let x: &'b StructLitField = std::mem::transmute(p);
-            x
+        let fields = self.fields.iter().map(|expr_pair| {
+            let k = expr_pair.first.pretty_doc(arena);
+            let v = expr_pair.second.pretty_doc(arena);
+            let sep = arena.text(": ");
+
+            k.append(sep).group().append(v).group()
         });
-        pretty_seq(wrapped, "{", "}", ",", PRETTY_INDENT_MINOR_NEST, arena)
-    }
-}
-
-pub struct StructLitField(pub LitField);
-
-impl PrettyDoc for StructLitField {
-    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
-    where
-        D: DocAllocator<'b, A>,
-        D::Doc: Clone,
-        A: Clone,
-    {
-        let k = self.0.first.pretty_doc(arena);
-        let v = self.0.second.pretty_doc(arena);
-        let sep = arena.text(": ");
-
-        k.append(sep).group().append(v).group()
+        pretty_seq_doc(fields, "{", None, "}", ",", PRETTY_INDENT_MINOR_NEST, arena)
     }
 }
 

--- a/partiql-eval/Cargo.toml
+++ b/partiql-eval/Cargo.toml
@@ -21,10 +21,12 @@ edition.workspace = true
 bench = false
 
 [dependencies]
+partiql-common = { path = "../partiql-common", version = "0.11.*" }
 partiql-logical = { path = "../partiql-logical", version = "0.11.*" }
 partiql-value = { path = "../partiql-value", version = "0.11.*" }
 partiql-catalog = { path = "../partiql-catalog", version = "0.11.*" }
 partiql-types = { path = "../partiql-types", version = "0.11.*" }
+partiql-extension-ion = { path = "../extension/partiql-extension-ion", version = "0.11.*" }
 petgraph = "0.6"
 ordered-float = "4"
 itertools = "0.13"

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -36,6 +36,13 @@ pub trait EvalExpr: Debug {
     ) -> Cow<'a, Value>
     where
         'c: 'a;
+
+    fn evaluate_owned<'a, 'c>(&'a self, bindings: Tuple, ctx: &'c dyn EvalContext<'c>) -> Value
+    where
+        'c: 'a,
+    {
+        self.evaluate(&bindings, ctx).into_owned()
+    }
 }
 
 #[derive(Error, Debug)]

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -19,9 +19,7 @@ use std::fmt::{Debug, Formatter};
 
 use std::marker::PhantomData;
 
-use partiql_value::datum::{
-    DatumCategory, DatumCategoryRef, DatumLowerResult, DatumValue, SequenceDatum, TupleDatum,
-};
+use partiql_value::datum::{DatumCategory, DatumCategoryRef, SequenceDatum, TupleDatum};
 use std::ops::ControlFlow;
 
 /// Represents a literal in (sub)query, e.g. `1` in `a + 1`.
@@ -33,10 +31,6 @@ pub(crate) struct EvalLitExpr {
 impl EvalLitExpr {
     pub(crate) fn new(val: Value) -> Self {
         Self { val }
-    }
-
-    fn lower(&self) -> DatumLowerResult<EvalLitExpr> {
-        self.val.clone().into_lower().map(Self::new)
     }
 }
 
@@ -51,7 +45,7 @@ impl BindEvalExpr for EvalLitExpr {
         self,
         _args: Vec<Box<dyn EvalExpr>>,
     ) -> Result<Box<dyn EvalExpr>, BindError> {
-        Ok(Box::new(self.lower()?))
+        Ok(Box::new(self))
     }
 }
 

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -398,7 +398,7 @@ impl<'c> EvaluatorPlanner<'c> {
             ),
             ValueExpr::Lit(lit) => (
                 "literal",
-                match self.plan_lit(lit.as_ref()) {
+                match plan_lit(lit.as_ref()) {
                     Ok(lit) => EvalLitExpr::new(lit).bind::<{ STRICT }>(vec![]),
                     Err(e) => Ok(self.err(e) as Box<dyn EvalExpr>),
                 },
@@ -781,43 +781,43 @@ impl<'c> EvaluatorPlanner<'c> {
 
         self.unwrap_bind(name, bind)
     }
+}
 
-    fn plan_lit(&self, lit: &Lit) -> Result<Value, PlanningError> {
-        let lit_to_val = |lit| self.plan_lit(lit);
-        Ok(match lit {
-            Lit::Null => Value::Null,
-            Lit::Missing => Value::Missing,
-            Lit::Int8(n) => Value::from(*n),
-            Lit::Int16(n) => Value::from(*n),
-            Lit::Int32(n) => Value::from(*n),
-            Lit::Int64(n) => Value::from(*n),
-            Lit::Decimal(d) => Value::from(*d),
-            Lit::Double(f) => Value::from(*f),
-            Lit::Bool(b) => Value::from(*b),
-            Lit::String(s) => Value::from(s.as_ref()),
-            Lit::BoxDocument(contents, _typ) => {
-                let ion_typ = BoxedIonType::default().to_dyn_type_tag();
-                let variant = Variant::new(contents.clone(), ion_typ)
-                    .map_err(|e| PlanningError::IllegalState(e.to_string()));
-                Value::from(variant?)
-            }
-            Lit::Struct(strct) => strct
-                .iter()
-                .map(|(k, v)| lit_to_val(v).map(move |v| (k, v)))
-                .collect::<Result<Tuple, _>>()?
-                .into(),
-            Lit::Bag(bag) => bag
-                .iter()
-                .map(lit_to_val)
-                .collect::<Result<Bag, _>>()?
-                .into(),
-            Lit::List(list) => list
-                .iter()
-                .map(lit_to_val)
-                .collect::<Result<List, _>>()?
-                .into(),
-        })
-    }
+fn plan_lit(lit: &Lit) -> Result<Value, PlanningError> {
+    let lit_to_val = |lit| plan_lit(lit);
+    Ok(match lit {
+        Lit::Null => Value::Null,
+        Lit::Missing => Value::Missing,
+        Lit::Int8(n) => Value::from(*n),
+        Lit::Int16(n) => Value::from(*n),
+        Lit::Int32(n) => Value::from(*n),
+        Lit::Int64(n) => Value::from(*n),
+        Lit::Decimal(d) => Value::from(*d),
+        Lit::Double(f) => Value::from(*f),
+        Lit::Bool(b) => Value::from(*b),
+        Lit::String(s) => Value::from(s.as_ref()),
+        Lit::BoxDocument(contents, _typ) => {
+            let ion_typ = BoxedIonType::default().to_dyn_type_tag();
+            let variant = Variant::new(contents.clone(), ion_typ)
+                .map_err(|e| PlanningError::IllegalState(e.to_string()));
+            Value::from(variant?)
+        }
+        Lit::Struct(strct) => strct
+            .iter()
+            .map(|(k, v)| lit_to_val(v).map(move |v| (k, v)))
+            .collect::<Result<Tuple, _>>()?
+            .into(),
+        Lit::Bag(bag) => bag
+            .iter()
+            .map(lit_to_val)
+            .collect::<Result<Bag, _>>()?
+            .into(),
+        Lit::List(list) => list
+            .iter()
+            .map(lit_to_val)
+            .collect::<Result<List, _>>()?
+            .into(),
+    })
 }
 
 #[cfg(test)]

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -2,7 +2,7 @@ use itertools::{Either, Itertools};
 use partiql_logical as logical;
 use partiql_logical::{
     AggFunc, BagOperator, BinaryOp, BindingsOp, CallName, GroupingStrategy, IsTypeExpr, JoinKind,
-    LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier,
+    Lit, LogicalPlan, OpId, PathComponent, Pattern, PatternMatchExpr, SearchedCase, SetQuantifier,
     SortSpecNullOrder, SortSpecOrder, Type, UnaryOp, ValueExpr, VarRefType,
 };
 use petgraph::prelude::StableGraph;
@@ -24,7 +24,9 @@ use crate::eval::expr::{
 };
 use crate::eval::EvalPlan;
 use partiql_catalog::catalog::{Catalog, FunctionEntryFunction};
-use partiql_value::Value;
+use partiql_extension_ion::boxed_ion::BoxedIonType;
+use partiql_value::boxed_variant::DynBoxedVariantTypeFactory;
+use partiql_value::{Bag, List, Tuple, Value, Variant};
 
 #[macro_export]
 macro_rules! correct_num_args_or_err {
@@ -57,6 +59,24 @@ pub struct EvaluatorPlanner<'c> {
     mode: EvaluationMode,
     catalog: &'c dyn Catalog,
     errors: Vec<PlanningError>,
+}
+
+impl From<(&str, BindError)> for PlanningError {
+    fn from((name, err): (&str, BindError)) -> Self {
+        match err {
+            BindError::ArgNumMismatch { .. } => {
+                PlanningError::IllegalState(format!("Wrong number of arguments for {name}"))
+            }
+            BindError::Unknown => {
+                PlanningError::IllegalState(format!("Unknown error binding {name}"))
+            }
+            BindError::NotYetImplemented(name) => PlanningError::NotYetImplemented(name),
+            BindError::ArgumentConstraint(msg) => PlanningError::IllegalState(msg),
+            BindError::LiteralValue(err) => {
+                PlanningError::IllegalState(format!("Literal error: {}", err))
+            }
+        }
+    }
 }
 
 impl From<&logical::SetQuantifier> for eval::evaluable::SetQuantifier {
@@ -350,23 +370,7 @@ impl<'c> EvaluatorPlanner<'c> {
     ) -> Box<dyn EvalExpr> {
         match op {
             Ok(op) => op,
-            Err(err) => {
-                let err = match err {
-                    BindError::ArgNumMismatch { .. } => {
-                        PlanningError::IllegalState(format!("Wrong number of arguments for {name}"))
-                    }
-                    BindError::Unknown => {
-                        PlanningError::IllegalState(format!("Unknown error binding {name}"))
-                    }
-                    BindError::NotYetImplemented(name) => PlanningError::NotYetImplemented(name),
-                    BindError::ArgumentConstraint(msg) => PlanningError::IllegalState(msg),
-                    BindError::LiteralValue(err) => {
-                        PlanningError::IllegalState(format!("Literal error: {}", err))
-                    }
-                };
-
-                self.err(err)
-            }
+            Err(err) => self.err((name, err).into()),
         }
     }
 
@@ -394,7 +398,10 @@ impl<'c> EvaluatorPlanner<'c> {
             ),
             ValueExpr::Lit(lit) => (
                 "literal",
-                EvalLitExpr::new(Value::from(lit.as_ref().clone())).bind::<{ STRICT }>(vec![]),
+                match self.plan_lit(lit.as_ref()) {
+                    Ok(lit) => EvalLitExpr::new(lit).bind::<{ STRICT }>(vec![]),
+                    Err(e) => Ok(self.err(e) as Box<dyn EvalExpr>),
+                },
             ),
             ValueExpr::Path(expr, components) => (
                 "path",
@@ -472,10 +479,7 @@ impl<'c> EvaluatorPlanner<'c> {
                     Pattern::Like(logical::LikeMatch { pattern, escape }) => {
                         match EvalLikeMatch::create(pattern, escape) {
                             Ok(like) => like.bind::<{ STRICT }>(plan_args(&[value])),
-                            Err(err) => {
-                                self.errors.push(err);
-                                Ok(Box::new(ErrorNode::new()) as Box<dyn EvalExpr>)
-                            }
+                            Err(err) => Ok(self.err(err) as Box<dyn EvalExpr>),
                         }
                     }
                     Pattern::LikeNonStringNonLiteral(logical::LikeNonStringNonLiteralMatch {
@@ -776,6 +780,43 @@ impl<'c> EvaluatorPlanner<'c> {
         };
 
         self.unwrap_bind(name, bind)
+    }
+
+    fn plan_lit(&self, lit: &Lit) -> Result<Value, PlanningError> {
+        let lit_to_val = |lit| self.plan_lit(lit);
+        Ok(match lit {
+            Lit::Null => Value::Null,
+            Lit::Missing => Value::Missing,
+            Lit::Int8(n) => Value::from(*n),
+            Lit::Int16(n) => Value::from(*n),
+            Lit::Int32(n) => Value::from(*n),
+            Lit::Int64(n) => Value::from(*n),
+            Lit::Decimal(d) => Value::from(*d),
+            Lit::Double(f) => Value::from(*f),
+            Lit::Bool(b) => Value::from(*b),
+            Lit::String(s) => Value::from(s.as_ref()),
+            Lit::BoxDocument(contents, _typ) => {
+                let ion_typ = BoxedIonType::default().to_dyn_type_tag();
+                let variant = Variant::new(contents.clone(), ion_typ)
+                    .map_err(|e| PlanningError::IllegalState(e.to_string()));
+                Value::from(variant?)
+            }
+            Lit::Struct(strct) => strct
+                .iter()
+                .map(|(k, v)| lit_to_val(v).map(move |v| (k, v)))
+                .collect::<Result<Tuple, _>>()?
+                .into(),
+            Lit::Bag(bag) => bag
+                .iter()
+                .map(lit_to_val)
+                .collect::<Result<Bag, _>>()?
+                .into(),
+            Lit::List(list) => list
+                .iter()
+                .map(lit_to_val)
+                .collect::<Result<List, _>>()?
+                .into(),
+        })
     }
 }
 

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -36,6 +36,7 @@ use crate::functions::Function;
 use partiql_ast_passes::name_resolver::NameRef;
 use partiql_catalog::catalog::Catalog;
 use partiql_common::node::NodeId;
+
 use partiql_logical::AggFunc::{AggAny, AggAvg, AggCount, AggEvery, AggMax, AggMin, AggSum};
 use partiql_logical::ValueExpr::DynamicLookup;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -1923,6 +1924,7 @@ fn lit_to_lit(lit: &Lit) -> Result<logical::Lit, AstTransformError> {
         Lit::DoubleLit(f) => logical::Lit::Double(OrderedFloat::from(*f)),
         Lit::BoolLit(b) => logical::Lit::Bool(*b),
         Lit::EmbeddedDocLit(s, _) => {
+            // TODO [EMBDOC] fix type
             logical::Lit::BoxDocument(s.clone().into_bytes(), "Ion".to_string())
         }
         Lit::CharStringLit(s) => logical::Lit::String(s.clone()),

--- a/partiql-logical-planner/src/typer.rs
+++ b/partiql-logical-planner/src/typer.rs
@@ -4,9 +4,9 @@ use partiql_ast::ast::{CaseSensitivity, SymbolPrimitive};
 use partiql_catalog::catalog::Catalog;
 use partiql_logical::{BindingsOp, Lit, LogicalPlan, OpId, PathComponent, ValueExpr, VarRefType};
 use partiql_types::{
-    type_array, type_bag, type_bool, type_decimal, type_float64, type_int, type_string,
-    type_struct, ArrayType, BagType, PartiqlShape, PartiqlShapeBuilder, ShapeResultError, Static,
-    StructConstraint, StructField, StructType,
+    type_array, type_bag, type_bool, type_decimal, type_dynamic, type_float64, type_int,
+    type_string, type_struct, ArrayType, BagType, PartiqlShape, PartiqlShapeBuilder,
+    ShapeResultError, Static, StructConstraint, StructField, StructType,
 };
 use partiql_value::BindingsName;
 use petgraph::algo::toposort;
@@ -346,6 +346,7 @@ impl<'c> PlanTyper<'c> {
                     Lit::Double(_) => type_float64!(self.bld),
                     Lit::Bool(_) => type_bool!(self.bld),
                     Lit::String(_) => type_string!(self.bld),
+                    Lit::BoxDocument(_, _) => type_dynamic!(self.bld), // TODO
                     Lit::Struct(_) => type_struct!(self.bld),
                     Lit::Bag(_) => type_bag!(self.bld),
                     Lit::List(_) => type_array!(self.bld),

--- a/partiql-logical/Cargo.toml
+++ b/partiql-logical/Cargo.toml
@@ -23,7 +23,6 @@ bench = false
 [dependencies]
 partiql-value = { path = "../partiql-value", version = "0.11.*" }
 partiql-common = { path = "../partiql-common", version = "0.11.*" }
-partiql-extension-ion = { path = "../extension/partiql-extension-ion", version = "0.11.*" }
 
 ion-rs_old = { version = "0.18", package = "ion-rs" }
 ordered-float = "4"

--- a/partiql-logical/src/util.rs
+++ b/partiql-logical/src/util.rs
@@ -1,8 +1,6 @@
 use crate::Lit;
-use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
-use partiql_extension_ion::Encoding;
+
 use partiql_value::{Bag, List, Tuple, Value};
-use thiserror::Error;
 
 impl From<Value> for Lit {
     fn from(value: Value) -> Self {
@@ -23,6 +21,9 @@ impl From<Value> for Lit {
             Value::List(list) => (*list).into(),
             Value::Bag(bag) => (*bag).into(),
             Value::Tuple(tuple) => (*tuple).into(),
+            Value::Variant(_) => {
+                todo!("Value to Lit: EmbeddedDoc")
+            }
         }
     }
 }
@@ -43,65 +44,6 @@ impl From<Tuple> for Lit {
     fn from(tuple: Tuple) -> Self {
         Lit::Struct(tuple.into_iter().map(|(k, v)| (k, Lit::from(v))).collect())
     }
-}
-
-impl From<Lit> for Value {
-    fn from(lit: Lit) -> Self {
-        match lit {
-            Lit::Null => Value::Null,
-            Lit::Missing => Value::Missing,
-            Lit::Int8(n) => Value::Integer(n.into()),
-            Lit::Int16(n) => Value::Integer(n.into()),
-            Lit::Int32(n) => Value::Integer(n.into()),
-            Lit::Int64(n) => Value::Integer(n),
-            Lit::Decimal(d) => Value::Decimal(d.into()),
-            Lit::Double(f) => Value::Real(f),
-            Lit::Bool(b) => Value::Boolean(b),
-            Lit::String(s) => Value::String(s.into()),
-            Lit::BoxDocument(contents, _typ) => {
-                parse_embedded_ion_str(&String::from_utf8_lossy(contents.as_slice()))
-                    .expect("TODO ion parsing error")
-            }
-            Lit::Struct(strct) => Value::from(Tuple::from_iter(
-                strct.into_iter().map(|(k, v)| (k, Value::from(v))),
-            )),
-            Lit::Bag(bag) => Value::from(Bag::from_iter(bag.into_iter().map(Value::from))),
-            Lit::List(list) => Value::from(List::from_iter(list.into_iter().map(Value::from))),
-        }
-    }
-}
-
-/// Represents a Literal Value Error
-#[derive(Error, Debug, Clone, PartialEq, Eq, Hash)]
-#[non_exhaustive]
-pub enum LiteralError {
-    /// Indicates that there was an error interpreting a literal value.
-    #[error("Error with literal: {literal}: {error}")]
-    Literal { literal: String, error: String },
-}
-
-// TODO remove parsing in favor of embedding
-fn parse_embedded_ion_str(contents: &str) -> Result<Value, LiteralError> {
-    fn lit_err(literal: &str, err: impl std::error::Error) -> LiteralError {
-        LiteralError::Literal {
-            literal: literal.into(),
-            error: err.to_string(),
-        }
-    }
-
-    let reader = ion_rs_old::ReaderBuilder::new()
-        .build(contents)
-        .map_err(|e| lit_err(contents, e))?;
-    let mut iter = IonDecoderBuilder::new(IonDecoderConfig::default().with_mode(Encoding::Ion))
-        .build(reader)
-        .map_err(|e| lit_err(contents, e))?;
-
-    iter.next()
-        .ok_or_else(|| LiteralError::Literal {
-            literal: contents.into(),
-            error: "Contains no value".into(),
-        })?
-        .map_err(|e| lit_err(contents, e))
 }
 
 impl From<bool> for Lit {

--- a/partiql-value/Cargo.toml
+++ b/partiql-value/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 
 [dependencies]
 partiql-common = { path = "../partiql-common", version = "0.11.*" }
+partiql-types = { path = "../partiql-types", version = "0.11.*" }
 delegate = "0.13"
 ordered-float = "4"
 itertools = "0.13"

--- a/partiql-value/Cargo.toml
+++ b/partiql-value/Cargo.toml
@@ -22,16 +22,24 @@ bench = false
 
 [dependencies]
 partiql-common = { path = "../partiql-common", version = "0.11.*" }
+delegate = "0.13"
 ordered-float = "4"
 itertools = "0.13"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.36"
+thiserror = "1.0"
 
 time = { version = "0.3", features = ["macros"] }
 pretty = "0.12"
 
 serde = { version = "1", features = ["derive"], optional = true }
+typetag = { version = "0.2", optional = true }
+
+
+
+dyn-clone = "1"
+dyn-hash = "0.2"
 
 [dev-dependencies]
 
@@ -39,6 +47,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 default = []
 serde = [
     "dep:serde",
+    "dep:typetag",
     "time/serde",
     "rust_decimal/serde-with-str",
     "rust_decimal/serde",

--- a/partiql-value/src/boxed_variant.rs
+++ b/partiql-value/src/boxed_variant.rs
@@ -1,0 +1,91 @@
+use dyn_clone::DynClone;
+use dyn_hash::DynHash;
+use partiql_common::pretty::PrettyDoc;
+use std::error::Error;
+
+use crate::datum::{Datum, DatumCategoryOwned, DatumCategoryRef};
+use crate::Value;
+use pretty::{DocAllocator, DocBuilder};
+use std::fmt::{Debug, Display};
+
+pub type BoxedVariantError = Box<dyn Error>;
+
+pub type BoxedVariantResult<T> = Result<T, BoxedVariantError>;
+pub type BoxedVariantValueIntoIterator = Box<dyn Iterator<Item = DynBoxedVariant>>;
+
+pub type BoxedVariantValueIter<'a> =
+    Box<dyn 'a + Iterator<Item = BoxedVariantResult<&'a DynBoxedVariant>>>;
+
+// dyn
+
+pub type DynBoxedVariantTypeTag = Box<dyn DynBoxedVariantType>;
+
+pub trait DynBoxedVariantType: Debug + DynClone {
+    fn construct(&self, bytes: Vec<u8>) -> BoxedVariantResult<Box<dyn BoxedVariant>>;
+    fn name(&self) -> &'static str;
+}
+
+dyn_clone::clone_trait_object!(DynBoxedVariantType);
+
+pub trait DynBoxedVariantTypeFactory {
+    fn to_dyn_type_tag(self) -> DynBoxedVariantTypeTag;
+}
+
+// typed
+
+pub type BoxedVariantTypeTag<D> = Box<dyn BoxedVariantType<Doc = D>>;
+pub trait BoxedVariantType: Debug + Clone {
+    type Doc: BoxedVariant + 'static;
+
+    fn construct(&self, bytes: Vec<u8>) -> BoxedVariantResult<Self::Doc>;
+    fn name(&self) -> &'static str;
+}
+
+pub type DynBoxedVariant = Box<dyn BoxedVariant>;
+#[cfg_attr(feature = "serde", typetag::serde)]
+pub trait BoxedVariant: Display + Debug + DynHash + DynClone + Datum<Value> {
+    fn into_dyn_iter(self: Box<Self>) -> BoxedVariantResult<BoxedVariantValueIntoIterator>;
+
+    fn category(&self) -> DatumCategoryRef<'_>;
+
+    fn into_category(self: Box<Self>) -> DatumCategoryOwned;
+}
+
+dyn_hash::hash_trait_object!(BoxedVariant);
+dyn_clone::clone_trait_object!(BoxedVariant);
+
+impl PrettyDoc for DynBoxedVariant {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        // todo!("impl PrettyDoc for BoxedVariant")
+        arena.text(format!("{}", self))
+    }
+}
+
+impl<T, D> DynBoxedVariantType for T
+where
+    T: BoxedVariantType<Doc = D>,
+    D: BoxedVariant + 'static,
+{
+    fn construct(&self, bytes: Vec<u8>) -> BoxedVariantResult<Box<dyn BoxedVariant>> {
+        BoxedVariantType::construct(self, bytes).map(|d| Box::new(d) as Box<dyn BoxedVariant>)
+    }
+
+    fn name(&self) -> &'static str {
+        BoxedVariantType::name(self)
+    }
+}
+
+impl<T, D> DynBoxedVariantTypeFactory for T
+where
+    T: BoxedVariantType<Doc = D> + 'static,
+    D: BoxedVariant + 'static,
+{
+    fn to_dyn_type_tag(self) -> DynBoxedVariantTypeTag {
+        Box::new(self)
+    }
+}

--- a/partiql-value/src/boxed_variant.rs
+++ b/partiql-value/src/boxed_variant.rs
@@ -3,7 +3,7 @@ use dyn_hash::DynHash;
 use partiql_common::pretty::PrettyDoc;
 use std::error::Error;
 
-use crate::datum::{Datum, DatumCategoryOwned, DatumCategoryRef};
+use crate::datum::{Datum, DatumCategoryOwned, DatumCategoryRef, DatumLower};
 use crate::Value;
 use pretty::{DocAllocator, DocBuilder};
 use std::fmt::{Debug, Display};
@@ -43,7 +43,9 @@ pub trait BoxedVariantType: Debug + Clone {
 
 pub type DynBoxedVariant = Box<dyn BoxedVariant>;
 #[cfg_attr(feature = "serde", typetag::serde)]
-pub trait BoxedVariant: Display + Debug + DynHash + DynClone + Datum<Value> {
+pub trait BoxedVariant:
+    Display + Debug + DynHash + DynClone + Datum<Value> + DatumLower<Value>
+{
     fn into_dyn_iter(self: Box<Self>) -> BoxedVariantResult<BoxedVariantValueIntoIterator>;
 
     fn category(&self) -> DatumCategoryRef<'_>;

--- a/partiql-value/src/datum.rs
+++ b/partiql-value/src/datum.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use std::borrow::Cow;
 use std::error::Error;
+use std::fmt::Debug;
 
 pub type DatumLowerError = Box<dyn Error>;
 pub type DatumLowerResult<T> = Result<T, DatumLowerError>;
@@ -31,10 +32,6 @@ where
     fn is_absent(&self) -> bool {
         self.is_null() || self.is_missing()
     }
-
-    /// Returns true if and only if Value is an integer, real, or decimal
-    #[must_use]
-    fn is_number(&self) -> bool;
 
     #[inline]
     /// Returns true if Value is neither null nor missing
@@ -83,12 +80,14 @@ pub enum DatumCategoryOwned {
 #[derive(Debug)]
 pub enum DatumTupleRef<'a> {
     Tuple(&'a Tuple),
+    Dynamic(&'a dyn RefTupleView<'a, Value>),
 }
 
 #[derive(Debug)]
 pub enum DatumSeqRef<'a> {
     List(&'a List),
     Bag(&'a Bag),
+    Dynamic(&'a dyn RefSequenceView<'a, Value>),
 }
 
 #[derive(Debug)]
@@ -99,12 +98,14 @@ pub enum DatumValueRef<'a> {
 #[derive(Debug)]
 pub enum DatumTupleOwned {
     Tuple(Box<Tuple>),
+    Dynamic(Box<dyn OwnedTupleView<Value>>),
 }
 
 #[derive(Debug)]
 pub enum DatumSeqOwned {
     List(Box<List>),
     Bag(Box<Bag>),
+    Dynamic(Box<dyn OwnedSequenceView<Value>>),
 }
 
 #[derive(Debug)]
@@ -120,6 +121,7 @@ impl<'a> DatumCategory<'a> for Value {
             Value::List(list) => DatumCategoryRef::Sequence(DatumSeqRef::List(list)),
             Value::Bag(bag) => DatumCategoryRef::Sequence(DatumSeqRef::Bag(bag)),
             Value::Tuple(tuple) => DatumCategoryRef::Tuple(DatumTupleRef::Tuple(tuple.as_ref())),
+            Value::Variant(doc) => doc.category(),
             val => DatumCategoryRef::Scalar(DatumValueRef::Value(val)),
         }
     }
@@ -131,6 +133,7 @@ impl<'a> DatumCategory<'a> for Value {
             Value::List(list) => DatumCategoryOwned::Sequence(DatumSeqOwned::List(list)),
             Value::Bag(bag) => DatumCategoryOwned::Sequence(DatumSeqOwned::Bag(bag)),
             Value::Tuple(tuple) => DatumCategoryOwned::Tuple(DatumTupleOwned::Tuple(tuple)),
+            Value::Variant(doc) => doc.into_category(),
             val => DatumCategoryOwned::Scalar(DatumValueOwned::Value(val)),
         }
     }
@@ -143,11 +146,11 @@ pub trait TupleDatum {
     }
 }
 
-pub trait RefTupleView<'a, DV: DatumValue<DV>>: TupleDatum {
+pub trait RefTupleView<'a, DV: DatumValue<DV>>: TupleDatum + Debug {
     fn get_val(&self, k: &BindingsName<'_>) -> Option<Cow<'a, DV>>;
 }
 
-pub trait OwnedTupleView<D: Datum<D>>: TupleDatum {
+pub trait OwnedTupleView<D: Datum<D>>: TupleDatum + Debug {
     fn take_val(self, k: &BindingsName<'_>) -> Option<D>;
     fn take_val_boxed(self: Box<Self>, k: &BindingsName<'_>) -> Option<D>;
 }
@@ -156,6 +159,7 @@ impl TupleDatum for DatumTupleRef<'_> {
     fn len(&self) -> usize {
         match self {
             DatumTupleRef::Tuple(tuple) => tuple.len(),
+            DatumTupleRef::Dynamic(dynamic) => dynamic.len(),
         }
     }
 }
@@ -164,6 +168,7 @@ impl<'a> RefTupleView<'a, Value> for DatumTupleRef<'a> {
     fn get_val(&self, k: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
         match self {
             DatumTupleRef::Tuple(tuple) => Tuple::get(tuple, k).map(Cow::Borrowed),
+            DatumTupleRef::Dynamic(dynamic) => dynamic.get_val(k),
         }
     }
 }
@@ -172,6 +177,7 @@ impl TupleDatum for DatumTupleOwned {
     fn len(&self) -> usize {
         match self {
             DatumTupleOwned::Tuple(tuple) => tuple.len(),
+            DatumTupleOwned::Dynamic(dynamic) => dynamic.len(),
         }
     }
 }
@@ -180,6 +186,7 @@ impl OwnedTupleView<Value> for DatumTupleOwned {
     fn take_val(self, k: &BindingsName<'_>) -> Option<Value> {
         match self {
             DatumTupleOwned::Tuple(tuple) => Tuple::take_val(*tuple, k),
+            DatumTupleOwned::Dynamic(dynamic) => dynamic.take_val_boxed(k),
         }
     }
 
@@ -196,13 +203,11 @@ pub trait SequenceDatum {
     }
 }
 
-pub trait RefSequenceView<'a, DV: DatumValue<DV> + 'a>:
-    SequenceDatum + IntoIterator<Item = &'a DV>
-{
+pub trait RefSequenceView<'a, DV: DatumValue<DV>>: SequenceDatum + Debug {
     fn get_val(&self, k: i64) -> Option<Cow<'a, DV>>;
 }
 
-pub trait OwnedSequenceView<D: Datum<D>>: SequenceDatum + IntoIterator<Item = D> {
+pub trait OwnedSequenceView<D: Datum<D>>: SequenceDatum + Debug {
     fn take_val(self, k: i64) -> Option<D>;
     fn take_val_boxed(self: Box<Self>, k: i64) -> Option<D>;
 }
@@ -212,6 +217,7 @@ impl SequenceDatum for DatumSeqRef<'_> {
         match self {
             DatumSeqRef::List(_) => true,
             DatumSeqRef::Bag(_) => false,
+            DatumSeqRef::Dynamic(boxed) => boxed.is_ordered(),
         }
     }
 
@@ -219,6 +225,7 @@ impl SequenceDatum for DatumSeqRef<'_> {
         match self {
             DatumSeqRef::List(l) => l.len(),
             DatumSeqRef::Bag(b) => b.len(),
+            DatumSeqRef::Dynamic(boxed) => boxed.len(),
         }
     }
 }
@@ -227,7 +234,10 @@ impl<'a> RefSequenceView<'a, Value> for DatumSeqRef<'a> {
     fn get_val(&self, k: i64) -> Option<Cow<'a, Value>> {
         match self {
             DatumSeqRef::List(l) => List::get(l, k).map(Cow::Borrowed),
-            DatumSeqRef::Bag(_) => None,
+            DatumSeqRef::Bag(_) => {
+                todo!("TODO [EMBDOC]: Bag::get")
+            }
+            DatumSeqRef::Dynamic(boxed) => boxed.get_val(k),
         }
     }
 }
@@ -237,6 +247,7 @@ impl SequenceDatum for DatumSeqOwned {
         match self {
             DatumSeqOwned::List(_) => true,
             DatumSeqOwned::Bag(_) => false,
+            DatumSeqOwned::Dynamic(boxed) => boxed.is_ordered(),
         }
     }
 
@@ -249,7 +260,8 @@ impl OwnedSequenceView<Value> for DatumSeqOwned {
     fn take_val(self, k: i64) -> Option<Value> {
         match self {
             DatumSeqOwned::List(l) => l.take_val(k),
-            DatumSeqOwned::Bag(_) => None,
+            DatumSeqOwned::Bag(_) => todo!("TODO [EMBDOC]: Bag::get"),
+            DatumSeqOwned::Dynamic(boxed) => boxed.take_val_boxed(k),
         }
     }
 
@@ -266,6 +278,9 @@ impl<'a> IntoIterator for DatumSeqRef<'a> {
         match self {
             DatumSeqRef::List(l) => DatumSeqRefIterator::List(l.into_iter()),
             DatumSeqRef::Bag(b) => DatumSeqRefIterator::Bag(b.into_iter()),
+            DatumSeqRef::Dynamic(_) => {
+                todo!()
+            }
         }
     }
 }
@@ -294,6 +309,9 @@ impl IntoIterator for DatumSeqOwned {
         match self {
             DatumSeqOwned::List(l) => DatumSeqOwnedIterator::List(l.into_iter()),
             DatumSeqOwned::Bag(b) => DatumSeqOwnedIterator::Bag(b.into_iter()),
+            DatumSeqOwned::Dynamic(_) => {
+                todo!()
+            }
         }
     }
 }

--- a/partiql-value/src/lib.rs
+++ b/partiql-value/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod bag;
 mod bindings;
+pub mod boxed_variant;
 pub mod comparison;
 mod datetime;
 pub mod datum;
@@ -12,6 +13,7 @@ mod sort;
 mod tuple;
 mod util;
 mod value;
+mod variant;
 
 pub use bag::*;
 pub use bindings::*;
@@ -22,6 +24,7 @@ pub use pretty::*;
 pub use sort::*;
 pub use tuple::*;
 pub use value::*;
+pub use variant::*;
 
 #[cfg(test)]
 mod tests {

--- a/partiql-value/src/pretty.rs
+++ b/partiql-value/src/pretty.rs
@@ -26,6 +26,7 @@ impl PrettyDoc for Value {
             Value::List(inner) => inner.pretty_doc(arena),
             Value::Bag(inner) => inner.pretty_doc(arena),
             Value::Tuple(inner) => inner.pretty_doc(arena),
+            Value::Variant(inner) => inner.pretty_doc(arena),
         }
     }
 }

--- a/partiql-value/src/sort.rs
+++ b/partiql-value/src/sort.rs
@@ -21,6 +21,8 @@ impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, Value> {
         let wrap_list = NullSortedValue::<'_, { NULLS_FIRST }, List>;
         let wrap_tuple = NullSortedValue::<'_, { NULLS_FIRST }, Tuple>;
         let wrap_bag = NullSortedValue::<'_, { NULLS_FIRST }, Bag>;
+        let wrap_value = NullSortedValue::<'_, { NULLS_FIRST }, Value>;
+        let wrap_var = NullSortedValue::<'_, { NULLS_FIRST }, Variant>;
         let null_cond = |order: Ordering| {
             if NULLS_FIRST {
                 order

--- a/partiql-value/src/sort.rs
+++ b/partiql-value/src/sort.rs
@@ -21,8 +21,6 @@ impl<const NULLS_FIRST: bool> Ord for NullSortedValue<'_, NULLS_FIRST, Value> {
         let wrap_list = NullSortedValue::<'_, { NULLS_FIRST }, List>;
         let wrap_tuple = NullSortedValue::<'_, { NULLS_FIRST }, Tuple>;
         let wrap_bag = NullSortedValue::<'_, { NULLS_FIRST }, Bag>;
-        let wrap_value = NullSortedValue::<'_, { NULLS_FIRST }, Value>;
-        let wrap_var = NullSortedValue::<'_, { NULLS_FIRST }, Variant>;
         let null_cond = |order: Ordering| {
             if NULLS_FIRST {
                 order

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 
 use rust_decimal::Decimal as RustDecimal;
 
+use crate::variant::Variant;
 use crate::{Bag, BindingIntoIter, BindingIter, DateTime, List, Tuple};
 use rust_decimal::prelude::FromPrimitive;
 #[cfg(feature = "serde")]
@@ -37,10 +38,36 @@ pub enum Value {
     List(Box<List>),
     Bag(Box<Bag>),
     Tuple(Box<Tuple>),
+    Variant(Box<Variant>),
     // TODO: add other supported PartiQL values -- sexp
 }
 
 impl Value {
+    #[inline]
+    #[must_use]
+    pub fn is_tuple(&self) -> bool {
+        matches!(self, Value::Tuple(_))
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_list(&self) -> bool {
+        matches!(self, Value::List(_))
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn is_bag(&self) -> bool {
+        matches!(self, Value::Bag(_))
+    }
+
+    #[inline]
+    /// Returns true if and only if Value is an integer, real, or decimal
+    #[must_use]
+    pub fn is_number(&self) -> bool {
+        matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
+    }
+
     #[inline]
     #[must_use]
     pub fn coerce_into_tuple(self) -> Tuple {
@@ -161,7 +188,10 @@ impl Value {
 
 impl DatumValue<Value> for Value {
     fn into_lower(self) -> DatumLowerResult<Value> {
-        Ok(self)
+        match self {
+            Value::Variant(doc) => Ok(Value::Variant(Box::new(doc.into_lower()?))),
+            _ => Ok(self),
+        }
     }
 }
 
@@ -182,20 +212,24 @@ impl Datum<Value> for Value {
     }
 
     #[inline]
-    fn is_number(&self) -> bool {
-        matches!(self, Value::Integer(_) | Value::Real(_) | Value::Decimal(_))
-    }
-
-    #[inline]
     #[must_use]
     fn is_sequence(&self) -> bool {
-        matches!(self, Value::List(_) | Value::Bag(_))
+        match self {
+            Value::List(_) => true,
+            Value::Bag(_) => true,
+            Value::Variant(doc) => doc.is_sequence(),
+            _ => false,
+        }
     }
 
     #[inline]
     #[must_use]
     fn is_ordered(&self) -> bool {
-        matches!(self, Value::List(_))
+        match self {
+            Value::List(_) => true,
+            Value::Variant(doc) => doc.is_ordered(),
+            _ => false,
+        }
     }
 }
 
@@ -223,6 +257,7 @@ impl Debug for Value {
             Value::List(l) => l.fmt(f),
             Value::Bag(b) => b.fmt(f),
             Value::Tuple(t) => t.fmt(f),
+            Value::Variant(doc) => doc.fmt(f),
         }
     }
 }
@@ -238,6 +273,9 @@ impl PartialOrd for Value {
 impl Ord for Value {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self, other) {
+            (Value::Variant(_), _) => todo!("Variant Ord"),
+            (_, Value::Variant(_)) => todo!("Variant Ord"),
+
             (Value::Null, Value::Null) => Ordering::Equal,
             (Value::Missing, Value::Null) => Ordering::Equal,
 
@@ -343,17 +381,6 @@ impl Ord for Value {
 
             (Value::Bag(l), Value::Bag(r)) => l.cmp(r),
         }
-    }
-}
-
-impl<T> From<&T> for Value
-where
-    T: Copy,
-    Value: From<T>,
-{
-    #[inline]
-    fn from(t: &T) -> Self {
-        Value::from(*t)
     }
 }
 
@@ -505,5 +532,12 @@ impl From<Bag> for Value {
     #[inline]
     fn from(v: Bag) -> Self {
         Value::Bag(Box::new(v))
+    }
+}
+
+impl From<Variant> for Value {
+    #[inline]
+    fn from(v: Variant) -> Self {
+        Value::Variant(Box::new(v))
     }
 }

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -15,7 +15,7 @@ mod iter;
 mod logic;
 mod math;
 
-use crate::datum::{Datum, DatumLowerResult, DatumValue};
+use crate::datum::{Datum, DatumLower, DatumLowerResult, DatumValue};
 pub use iter::*;
 pub use logic::*;
 pub use math::*;
@@ -186,11 +186,24 @@ impl Value {
     }
 }
 
-impl DatumValue<Value> for Value {
+impl DatumValue<Value> for Value {}
+
+impl DatumLower<Value> for Value {
     fn into_lower(self) -> DatumLowerResult<Value> {
         match self {
-            Value::Variant(doc) => Ok(Value::Variant(Box::new(doc.into_lower()?))),
+            Value::Variant(variant) => variant.into_lower(),
             _ => Ok(self),
+        }
+    }
+
+    fn into_lower_boxed(self: Box<Self>) -> DatumLowerResult<Value> {
+        self.into_lower()
+    }
+
+    fn lower(&self) -> DatumLowerResult<Cow<'_, Value>> {
+        match self {
+            Value::Variant(variant) => variant.lower(),
+            _ => Ok(Cow::Borrowed(self)),
         }
     }
 }
@@ -217,7 +230,7 @@ impl Datum<Value> for Value {
         match self {
             Value::List(_) => true,
             Value::Bag(_) => true,
-            Value::Variant(doc) => doc.is_sequence(),
+            Value::Variant(variant) => variant.is_sequence(),
             _ => false,
         }
     }
@@ -227,7 +240,7 @@ impl Datum<Value> for Value {
     fn is_ordered(&self) -> bool {
         match self {
             Value::List(_) => true,
-            Value::Variant(doc) => doc.is_ordered(),
+            Value::Variant(variant) => variant.is_ordered(),
             _ => false,
         }
     }
@@ -257,7 +270,7 @@ impl Debug for Value {
             Value::List(l) => l.fmt(f),
             Value::Bag(b) => b.fmt(f),
             Value::Tuple(t) => t.fmt(f),
-            Value::Variant(doc) => doc.fmt(f),
+            Value::Variant(variant) => variant.fmt(f),
         }
     }
 }

--- a/partiql-value/src/value/iter.rs
+++ b/partiql-value/src/value/iter.rs
@@ -20,16 +20,8 @@ impl<'a> Iterator for ValueIter<'a> {
         match self {
             ValueIter::List(list) => list.next(),
             ValueIter::Bag(bag) => bag.next(),
-            ValueIter::Embedded(doc) => {
+            ValueIter::Embedded(_) => {
                 todo!()
-                // TODO [EMBDOC] don't just unwrap errors to MISSING; report in strict mode?
-                /*
-                doc.next().map(|res| {
-                    &res.map(|doc| Value::EmbeddedDoc(doc))
-                        .unwrap_or(Value::Missing)
-                })
-
-                 */
             }
             ValueIter::Single(v) => v.take(),
         }
@@ -40,9 +32,8 @@ impl<'a> Iterator for ValueIter<'a> {
         match self {
             ValueIter::List(list) => list.size_hint(),
             ValueIter::Bag(bag) => bag.size_hint(),
-            ValueIter::Embedded(doc) => {
+            ValueIter::Embedded(_) => {
                 todo!()
-                //doc.size_hint(),
             }
             ValueIter::Single(_) => (1, Some(1)),
         }

--- a/partiql-value/src/value/iter.rs
+++ b/partiql-value/src/value/iter.rs
@@ -1,9 +1,14 @@
-use crate::{BagIntoIterator, BagIter, ListIntoIterator, ListIter, Value};
+use crate::{
+    BagIntoIterator, BagIter, ListIntoIterator, ListIter, Value, VariantIntoIterator, VariantIter,
+};
+
+// TODO [EMBDOC] iterate
 
 #[derive(Debug, Clone)]
 pub enum ValueIter<'a> {
     List(ListIter<'a>),
     Bag(BagIter<'a>),
+    Embedded(VariantIter<'a>),
     Single(Option<&'a Value>),
 }
 
@@ -15,6 +20,17 @@ impl<'a> Iterator for ValueIter<'a> {
         match self {
             ValueIter::List(list) => list.next(),
             ValueIter::Bag(bag) => bag.next(),
+            ValueIter::Embedded(doc) => {
+                todo!()
+                // TODO [EMBDOC] don't just unwrap errors to MISSING; report in strict mode?
+                /*
+                doc.next().map(|res| {
+                    &res.map(|doc| Value::EmbeddedDoc(doc))
+                        .unwrap_or(Value::Missing)
+                })
+
+                 */
+            }
             ValueIter::Single(v) => v.take(),
         }
     }
@@ -24,6 +40,10 @@ impl<'a> Iterator for ValueIter<'a> {
         match self {
             ValueIter::List(list) => list.size_hint(),
             ValueIter::Bag(bag) => bag.size_hint(),
+            ValueIter::Embedded(doc) => {
+                todo!()
+                //doc.size_hint(),
+            }
             ValueIter::Single(_) => (1, Some(1)),
         }
     }
@@ -38,6 +58,7 @@ impl IntoIterator for Value {
         match self {
             Value::List(list) => ValueIntoIterator::List(list.into_iter()),
             Value::Bag(bag) => ValueIntoIterator::Bag(bag.into_iter()),
+            Value::Variant(doc) => ValueIntoIterator::Embedded(doc.into_iter()),
             other => ValueIntoIterator::Single(Some(other)),
         }
     }
@@ -46,6 +67,7 @@ impl IntoIterator for Value {
 pub enum ValueIntoIterator {
     List(ListIntoIterator),
     Bag(BagIntoIterator),
+    Embedded(VariantIntoIterator),
     Single(Option<Value>),
 }
 
@@ -57,6 +79,7 @@ impl Iterator for ValueIntoIterator {
         match self {
             ValueIntoIterator::List(list) => list.next(),
             ValueIntoIterator::Bag(bag) => bag.next(),
+            ValueIntoIterator::Embedded(doc) => doc.next().map(|d| Value::Variant(Box::new(d))),
             ValueIntoIterator::Single(v) => v.take(),
         }
     }
@@ -66,6 +89,7 @@ impl Iterator for ValueIntoIterator {
         match self {
             ValueIntoIterator::List(list) => list.size_hint(),
             ValueIntoIterator::Bag(bag) => bag.size_hint(),
+            ValueIntoIterator::Embedded(doc) => doc.size_hint(),
             ValueIntoIterator::Single(_) => (1, Some(1)),
         }
     }

--- a/partiql-value/src/variant.rs
+++ b/partiql-value/src/variant.rs
@@ -3,16 +3,20 @@ use crate::boxed_variant::{
     BoxedVariantValueIter, DynBoxedVariant, DynBoxedVariantTypeTag,
 };
 use crate::datum::{
-    Datum, DatumCategory, DatumCategoryOwned, DatumCategoryRef, DatumLowerResult, DatumValue,
+    Datum, DatumCategory, DatumCategoryOwned, DatumCategoryRef, DatumLower, DatumLowerResult,
+    DatumValue,
 };
 use delegate::delegate;
 use partiql_common::pretty::{pretty_surrounded_doc, PrettyDoc};
 use pretty::{DocAllocator, DocBuilder};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 
+use crate::Value;
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -46,10 +50,19 @@ impl From<DynBoxedVariant> for Variant {
     }
 }
 
-impl DatumValue<Variant> for Variant {
-    fn into_lower(self) -> DatumLowerResult<Variant> {
-        // TODO lower
-        Ok(self)
+impl DatumValue<Value> for Variant {}
+
+impl DatumLower<Value> for Variant {
+    fn into_lower(self) -> DatumLowerResult<Value> {
+        self.variant.into_lower_boxed()
+    }
+
+    fn into_lower_boxed(self: Box<Self>) -> DatumLowerResult<Value> {
+        self.into_lower()
+    }
+
+    fn lower(&self) -> DatumLowerResult<Cow<'_, Value>> {
+        self.variant.lower()
     }
 }
 
@@ -138,7 +151,7 @@ impl Iterator for VariantIntoIterator {
     }
 }
 
-impl Datum<Variant> for Variant {
+impl Datum<Value> for Variant {
     delegate! {
         to self.variant {
             fn is_null(&self) -> bool;
@@ -147,7 +160,6 @@ impl Datum<Variant> for Variant {
             fn is_present(&self) -> bool;
             fn is_sequence(&self) -> bool;
             fn is_ordered(&self) -> bool;
-            //fn into_iter(self) -> ValueIntoIterator;
         }
     }
 }

--- a/partiql-value/src/variant.rs
+++ b/partiql-value/src/variant.rs
@@ -1,0 +1,204 @@
+use crate::boxed_variant::{
+    BoxedVariant, BoxedVariantError, BoxedVariantResult, BoxedVariantValueIntoIterator,
+    BoxedVariantValueIter, DynBoxedVariant, DynBoxedVariantTypeTag,
+};
+use crate::datum::{
+    Datum, DatumCategory, DatumCategoryOwned, DatumCategoryRef, DatumLowerResult, DatumValue,
+};
+use delegate::delegate;
+use partiql_common::pretty::{pretty_surrounded_doc, PrettyDoc};
+use pretty::{DocAllocator, DocBuilder};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+
+use thiserror::Error;
+
+#[derive(Clone, Debug)]
+pub struct Variant {
+    variant: DynBoxedVariant,
+}
+
+impl Variant {
+    pub fn new<B: Into<Vec<u8>>>(
+        contents: B,
+        type_tag: DynBoxedVariantTypeTag,
+    ) -> BoxedVariantResult<Self> {
+        let variant = Unparsed::new(contents, type_tag)?.parse()?;
+        Ok(Self { variant })
+    }
+}
+
+impl<T> From<T> for Variant
+where
+    T: BoxedVariant + 'static,
+{
+    fn from(variant: T) -> Self {
+        let variant = Box::new(variant) as DynBoxedVariant;
+        Self { variant }
+    }
+}
+
+impl From<DynBoxedVariant> for Variant {
+    fn from(variant: DynBoxedVariant) -> Self {
+        Self { variant }
+    }
+}
+
+impl DatumValue<Variant> for Variant {
+    fn into_lower(self) -> DatumLowerResult<Variant> {
+        // TODO lower
+        Ok(self)
+    }
+}
+
+impl<'a> DatumCategory<'a> for Variant {
+    fn category(&'a self) -> DatumCategoryRef<'a> {
+        self.variant.category()
+    }
+
+    fn into_category(self) -> DatumCategoryOwned {
+        self.variant.into_category()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Unparsed {
+    contents: Vec<u8>,
+    type_tag: DynBoxedVariantTypeTag,
+}
+
+impl Unparsed {
+    pub fn new<B: Into<Vec<u8>>>(
+        contents: B,
+        type_tag: DynBoxedVariantTypeTag,
+    ) -> BoxedVariantResult<Self> {
+        Ok(Unparsed {
+            contents: contents.into(),
+            type_tag,
+        })
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum VariantError {
+    #[error("Latent Type Error for Boxed Document {0}")]
+    LatentTypeError(BoxedVariantError, DynBoxedVariantTypeTag),
+}
+
+pub type VariantResult<T> = Result<T, VariantError>;
+
+impl Unparsed {
+    fn parse(self) -> VariantResult<DynBoxedVariant> {
+        let Self { contents, type_tag } = self;
+        match type_tag.construct(contents) {
+            Ok(doc) => Ok(doc),
+            Err(err) => Err(VariantError::LatentTypeError(err, type_tag.clone())),
+        }
+    }
+}
+
+pub struct VariantIter<'a>(BoxedVariantValueIter<'a>);
+impl Debug for VariantIter<'_> {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl Clone for VariantIter<'_> {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl IntoIterator for Variant {
+    type Item = Variant;
+    type IntoIter = VariantIntoIterator;
+
+    fn into_iter(self) -> VariantIntoIterator {
+        let iter = self.variant.into_dyn_iter().expect("TODO [EMBDOC]");
+        VariantIntoIterator(iter)
+    }
+}
+
+pub struct VariantIntoIterator(BoxedVariantValueIntoIterator);
+
+impl Iterator for VariantIntoIterator {
+    type Item = Variant;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Variant::from)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl Datum<Variant> for Variant {
+    delegate! {
+        to self.variant {
+            fn is_null(&self) -> bool;
+            fn is_missing(&self) -> bool;
+            fn is_absent(&self) -> bool;
+            fn is_present(&self) -> bool;
+            fn is_sequence(&self) -> bool;
+            fn is_ordered(&self) -> bool;
+            //fn into_iter(self) -> ValueIntoIterator;
+        }
+    }
+}
+
+impl Hash for Variant {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        todo!()
+    }
+}
+
+impl PartialEq<Self> for Variant {
+    fn eq(&self, _other: &Self) -> bool {
+        todo!()
+    }
+}
+
+impl Eq for Variant {}
+
+#[cfg(feature = "serde")]
+impl Serialize for Variant {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        todo!()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Variant {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        todo!()
+    }
+}
+
+impl PrettyDoc for Variant {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        // TODO [EMBDOC] write out type tag?
+        // TODO [EMBDOC] handle backticks more generally.
+        let doc = self.variant.pretty_doc(arena);
+
+        pretty_surrounded_doc(doc, "`", "`", arena)
+            .append(arena.text("::"))
+            .append(arena.text("ion"))
+    }
+}

--- a/partiql/Cargo.toml
+++ b/partiql/Cargo.toml
@@ -33,6 +33,8 @@ partiql-logical = { path = "../partiql-logical" }
 partiql-logical-planner = { path = "../partiql-logical-planner" }
 partiql-eval = { path = "../partiql-eval" }
 partiql-extension-value-functions = { path = "../extension/partiql-extension-value-functions" }
+partiql-extension-ion = { path = "../extension/partiql-extension-ion" }
+
 
 insta = "1.40.0"
 

--- a/partiql/tests/comparisons.rs
+++ b/partiql/tests/comparisons.rs
@@ -33,10 +33,20 @@ pub fn eval_fail(statement: &str) {
 #[inline]
 pub fn eval_success(statement: &str) {
     let (permissive, strict) = eval_modes(statement);
-
+    dbg!(&permissive);
     assert_matches!(permissive, Ok(_));
     assert_matches!(strict, Ok(_));
     assert_eq!(permissive.unwrap().result, strict.unwrap().result);
+}
+
+#[test]
+fn test1() {
+    eval_success("[{'a': 1},{'b': 2}]")
+}
+
+#[test]
+fn test11() {
+    eval_success("[{'a': 1+1},{'b': 2}]")
 }
 
 #[track_caller]

--- a/partiql/tests/ion.rs
+++ b/partiql/tests/ion.rs
@@ -1,0 +1,58 @@
+use crate::common::{eval_query_with_catalog, TestError};
+use assert_matches::assert_matches;
+use partiql_catalog::catalog::PartiqlCatalog;
+use partiql_catalog::extension::Extension;
+use partiql_common::pretty::ToPretty;
+use partiql_eval::eval::Evaluated;
+use partiql_eval::plan::EvaluationMode;
+use partiql_extension_ion::boxed_ion::BoxedIonType;
+use partiql_extension_value_functions::PartiqlValueFnExtension;
+use partiql_value::boxed_variant::DynBoxedVariantTypeFactory;
+use partiql_value::{Value, Variant};
+
+mod common;
+
+#[track_caller]
+#[inline]
+pub fn eval(statement: &str, mode: EvaluationMode) -> Result<Evaluated, TestError<'_>> {
+    let mut catalog = PartiqlCatalog::default();
+    let ext = PartiqlValueFnExtension::default();
+    ext.load(&mut catalog)?;
+
+    eval_query_with_catalog(statement, &catalog, mode)
+}
+
+#[test]
+fn ion_simple() {
+    let query = "select x from `(1 hi::2)` as x";
+    // << {x: `1`}, {x: `hi::2`}>>
+
+    let res = eval(query, EvaluationMode::Permissive);
+    assert_matches!(res, Ok(_));
+    let result = res.unwrap().result;
+
+    insta::assert_snapshot!(result.to_pretty_string(25).expect("pretty"));
+}
+
+#[test]
+fn ion_paths() {
+    let query = "select x[1].foo from `([{foo:1}, {foo: 2}] ({foo: hi::1} {foo: world::2}))` as x";
+    // << {x: `{foo: 2}`}, {x: `{foo: world::2}`}>>
+
+    let res = eval(query, EvaluationMode::Permissive);
+    assert_matches!(res, Ok(_));
+    let result = res.unwrap().result;
+
+    insta::assert_snapshot!(result.to_pretty_string(25).expect("pretty"));
+}
+
+#[test]
+fn ion_iter() {
+    let contents = "[1,2,3,4]";
+    let ion_typ = BoxedIonType::default().to_dyn_type_tag();
+    let value = Value::Variant(Box::new(Variant::new(contents, ion_typ).expect("doc ctor")));
+
+    let items: Vec<_> = value.into_iter().collect();
+    dbg!(&items);
+    assert_eq!(items.len(), 4);
+}

--- a/partiql/tests/snapshots/ion__ion_paths.snap
+++ b/partiql/tests/snapshots/ion__ion_paths.snap
@@ -1,0 +1,10 @@
+---
+source: partiql/tests/ion.rs
+expression: "result.to_pretty_string(25).expect(\"pretty\")"
+---
+<<
+  { 'foo': `2`::ion },
+  {
+    'foo': `world::2`::ion
+  }
+>>

--- a/partiql/tests/snapshots/ion__ion_simple.snap
+++ b/partiql/tests/snapshots/ion__ion_simple.snap
@@ -1,0 +1,8 @@
+---
+source: partiql/tests/ion.rs
+expression: "result.to_pretty_string(25).expect(\"pretty\")"
+---
+<<
+  { 'x': `1`::ion },
+  { 'x': `hi::2`::ion }
+>>

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
 
-use assert_matches::assert_matches;
 use std::error::Error;
+
 use thiserror::Error;
 
 use partiql_catalog::call_defs::{CallDef, CallSpec, CallSpecArg};
@@ -20,7 +20,6 @@ use partiql_value::{bag, tuple, DateTime, Value};
 
 use crate::common::{lower, parse, TestError};
 use partiql_logical as logical;
-use partiql_value::datum::{DatumCategory, DatumCategoryRef, SequenceDatum};
 
 mod common;
 #[derive(Debug)]
@@ -196,9 +195,8 @@ fn test_context() -> Result<(), TestError<'static>> {
     };
     let ctx: [(String, &dyn Any); 1] = [("counter".to_string(), &counter)];
     let out = evaluate(&catalog, lowered, bindings, &ctx);
-    let out_cat = out.category();
 
-    assert_matches!(out_cat, DatumCategoryRef::Sequence(seq) if !seq.is_ordered());
+    assert!(out.is_bag());
     assert_eq!(&out, &expected);
     assert_eq!(*counter.data.borrow(), 0);
 


### PR DESCRIPTION
This PR roughs in boxed variants and an implementation of ion values that uses the boxed variant interface.

There are still `todo`s and some additional test failures that will be addressed by future PRs that add functionality.

Of note, that there are expected to be ~80 new conformance test failures that will eventually be fixed as well as passing an additional ~12 conformance tests after all features from #536 are incorporated.

To see the ultimate end-point of this integration, refer to  #536 and note the test coverage and conformance test results.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
