### PR TITLE
Update ion tests and add null & nan comparisions

### DIFF
--- a/extension/partiql-extension-ion/Cargo.toml
+++ b/extension/partiql-extension-ion/Cargo.toml
@@ -34,7 +34,7 @@ unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.36"
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental"] }
+ion-rs = { version = "1.0.0-rc.11", features = ["experimental", "experimental-ion-hash", "sha2"] }
 
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"

--- a/extension/partiql-extension-ion/src/boxed_ion.rs
+++ b/extension/partiql-extension-ion/src/boxed_ion.rs
@@ -231,9 +231,8 @@ impl<'a, const NULLS_EQUAL: bool, const NAN_EQUAL: bool> NullableEq
 {
     fn eq(&self, rhs: &Self) -> Value {
         let wrap = IonEqualityValue::<'a, { NULLS_EQUAL }, { NAN_EQUAL }, _>;
-        wrap(&self.0.doc).eq(&wrap(&rhs.0.doc))
+        NullableEq::eq(&wrap(&self.0.doc), &wrap(&rhs.0.doc))
     }
-
     #[inline(always)]
     fn eqg(&self, rhs: &Self) -> Value {
         let wrap = IonEqualityValue::<'_, true, { NAN_EQUAL }, _>;
@@ -648,7 +647,7 @@ impl<'a, const NULLS_EQUAL: bool, const NAN_EQUAL: bool> NullableEq
         let (l, r) = (self.0, other.0);
         let l = l.iter().map(wrap);
         let r = r.iter().map(wrap);
-        let res = l.zip(r).all(|(l, r)| l == r);
+        let res = l.zip(r).all(|(l, r)| l.eqg(&r) == Value::Boolean(true));
         Value::Boolean(res)
     }
 
@@ -667,9 +666,9 @@ impl<'a, const NULLS_EQUAL: bool, const NAN_EQUAL: bool> NullableEq
         let (l, r) = (self.0, other.0);
         let l = l.iter().map(|(s, elt)| (s, wrap(elt)));
         let r = r.iter().map(|(s, elt)| (s, wrap(elt)));
-        let res = l.zip(r).all(|((ls, lelt), (rs, relt))| {
-            ls == rs && NullableEq::eq(&lelt, &relt) == Value::Boolean(true)
-        });
+        let res = l
+            .zip(r)
+            .all(|((ls, lelt), (rs, relt))| ls == rs && lelt.eqg(&relt) == Value::Boolean(true));
         Value::Boolean(res)
     }
 

--- a/partiql-value/src/comparison.rs
+++ b/partiql-value/src/comparison.rs
@@ -1,5 +1,5 @@
-use crate::Value;
 use crate::{util, Bag, List, Tuple};
+use crate::{Value, Variant};
 
 pub trait Comparable {
     fn is_comparable_to(&self, rhs: &Self) -> bool;
@@ -72,6 +72,7 @@ impl<const GROUP_NULLS: bool, const NAN_EQUAL: bool> NullableEq
         let wrap_list = EqualityValue::<'_, { GROUP_NULLS }, { NAN_EQUAL }, List>;
         let wrap_bag = EqualityValue::<'_, { GROUP_NULLS }, { NAN_EQUAL }, Bag>;
         let wrap_tuple = EqualityValue::<'_, { GROUP_NULLS }, { NAN_EQUAL }, Tuple>;
+        let wrap_var = EqualityValue::<'_, { GROUP_NULLS }, { NAN_EQUAL }, Variant>;
         if GROUP_NULLS {
             if let (Value::Missing | Value::Null, Value::Missing | Value::Null) = (self.0, rhs.0) {
                 return Value::Boolean(true);
@@ -110,6 +111,7 @@ impl<const GROUP_NULLS: bool, const NAN_EQUAL: bool> NullableEq
             (Value::List(l), Value::List(r)) => NullableEq::eq(&wrap_list(l), &wrap_list(r)),
             (Value::Bag(l), Value::Bag(r)) => NullableEq::eq(&wrap_bag(l), &wrap_bag(r)),
             (Value::Tuple(l), Value::Tuple(r)) => NullableEq::eq(&wrap_tuple(l), &wrap_tuple(r)),
+            (Value::Variant(l), Value::Variant(r)) => NullableEq::eq(&wrap_var(l), &wrap_var(r)),
             (_, _) => Value::from(self.0 == rhs.0),
         }
     }


### PR DESCRIPTION
This PR builds on #540 & #542 and adds the ability for comparisons to treat NULLs as equal and/or NaNs as equal.
NaN-equality is mostly of interest for testing against expected examplars.
NULL-equality is used likewise, but also important for compliance with PartiQL's specified semantics for `eqg`.

There are still `todo`s and some additional test failures that will be addressed by future PRs that add functionality.

To see the ultimate end-point of this integration, refer to  #536 and note the test coverage and conformance test results.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
