### PR TITLE
Add lowering from AST to logical plan for graph MATCH

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -103,7 +103,7 @@ jobs:
       # to format and use the output.
       - name: Cargo Test of the conformance tests (can fail) and save to json file
         continue-on-error: true
-        run: cargo test --verbose --package partiql-conformance-tests --features "conformance_test" --release -- -Z unstable-options --format json > ${{ env.CARGO_TEST_RESULT_NAME }}
+        run: cargo test --verbose --package partiql-conformance-tests --features "conformance_test, experimental" --release -- -Z unstable-options --format json > ${{ env.CARGO_TEST_RESULT_NAME }}
       # Create a conformance report from the `cargo test` json file
       - run: cargo run --features report_tool --bin generate_cts_report ${{ env.CARGO_TEST_RESULT_NAME }} ${GITHUB_SHA} ${{ env.CONFORMANCE_REPORT_NAME }}
       # Upload conformance report for comparison with future runs

--- a/partiql-ast/src/ast.rs
+++ b/partiql-ast/src/ast.rs
@@ -945,6 +945,7 @@ pub struct GraphMatchEdge {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GraphMatchPattern {
+    /// an optional restrictor for the entire pattern match
     #[visit(skip)]
     pub restrictor: Option<GraphMatchRestrictor>,
     /// an optional quantifier for the entire pattern match

--- a/partiql-eval/src/eval/graph/mod.rs
+++ b/partiql-eval/src/eval/graph/mod.rs
@@ -1,4 +1,3 @@
-pub(crate) mod bind_name;
 pub(crate) mod engine;
 pub(crate) mod evaluator;
 pub(crate) mod plan;

--- a/partiql-eval/src/eval/graph/plan.rs
+++ b/partiql-eval/src/eval/graph/plan.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 /// A plan specification for an edge's direction filtering.
-#[allow(dead_code)] // TODO remove once graph planning is implemented
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy)]
 pub enum DirectionFilter {
@@ -66,27 +65,11 @@ pub struct StepFilter<GT: GraphTypes> {
     pub triple: TripleFilter<GT>,
 }
 
-/// A plan specification for 'path patterns' (i.e., sequences of 'node edge node's) matching.
-#[allow(dead_code)] // TODO remove once graph planning is implemented
-#[derive(Debug, Clone)]
-pub struct PathPatternFilter<GT: GraphTypes> {
-    pub head: NodeFilter<GT>,
-    pub tail: Vec<(DirectionFilter, EdgeFilter<GT>, NodeFilter<GT>)>,
-}
-
 /// A plan specification for node matching.
 #[derive(Debug, Clone)]
 pub struct NodeMatch<GT: GraphTypes> {
     pub binder: BindSpec<GT>,
     pub spec: NodeFilter<GT>,
-}
-
-/// A plan specification for edge matching.
-#[allow(dead_code)] // TODO remove once graph planning is implemented
-#[derive(Debug, Clone)]
-pub struct EdgeMatch<GT: GraphTypes> {
-    pub binder: BindSpec<GT>,
-    pub spec: EdgeFilter<GT>,
 }
 
 /// A plan specification for path (i.e., node, edge, node) matching.
@@ -97,61 +80,11 @@ pub struct PathMatch<GT: GraphTypes> {
 }
 
 /// A plan specification for path patterns (i.e., sequences of [`PathMatch`]s) matching.
-#[allow(dead_code)] // TODO remove once graph planning is implemented
 #[derive(Debug, Clone)]
 pub enum PathPatternMatch<GT: GraphTypes> {
     Node(NodeMatch<GT>),
     Match(PathMatch<GT>),
     Concat(Vec<PathPatternMatch<GT>>),
-}
-
-impl<GT: GraphTypes> From<PathMatch<GT>> for PathPatternMatch<GT> {
-    fn from(value: PathMatch<GT>) -> Self {
-        Self::Match(value)
-    }
-}
-
-impl<GT: GraphTypes> From<NodeMatch<GT>> for PathPatternMatch<GT> {
-    fn from(value: NodeMatch<GT>) -> Self {
-        Self::Node(value)
-    }
-}
-
-#[allow(dead_code)] // TODO remove once graph planning is implemented
-pub trait ElementFilterBuilder<GT: GraphTypes> {
-    fn any() -> Self;
-    fn labeled(label: GT::Label) -> Self;
-}
-
-impl<GT: GraphTypes> ElementFilterBuilder<GT> for NodeFilter<GT> {
-    fn any() -> Self {
-        Self {
-            label: LabelFilter::Always,
-            filter: ValueFilter::Always,
-        }
-    }
-
-    fn labeled(label: GT::Label) -> Self {
-        Self {
-            label: LabelFilter::Named(label),
-            filter: ValueFilter::Always,
-        }
-    }
-}
-
-impl<GT: GraphTypes> ElementFilterBuilder<GT> for EdgeFilter<GT> {
-    fn any() -> Self {
-        Self {
-            label: LabelFilter::Always,
-            filter: ValueFilter::Always,
-        }
-    }
-    fn labeled(label: GT::Label) -> Self {
-        Self {
-            label: LabelFilter::Named(label),
-            filter: ValueFilter::Always,
-        }
-    }
 }
 
 /// A trait for converting between plans parameterized by different [`GraphTypes`]
@@ -211,13 +144,6 @@ pub trait GraphPlanConvert<In: GraphTypes, Out: GraphTypes>: Debug {
         }
     }
 
-    #[allow(dead_code)] // TODO remove once graph planning is implemented
-    fn convert_edge_match(&self, edge: &EdgeMatch<In>) -> EdgeMatch<Out> {
-        EdgeMatch {
-            binder: self.convert_binder(&edge.binder),
-            spec: self.convert_edge_filter(&edge.spec),
-        }
-    }
     fn convert_label_filter(&self, node: &LabelFilter<In>) -> LabelFilter<Out>;
     fn convert_binder(&self, binder: &BindSpec<In>) -> BindSpec<Out>;
 }

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -794,37 +794,37 @@ impl<'c> EvaluatorPlanner<'c> {
 }
 
 fn plan_graph_plan(
-    pattern: &partiql_logical::PathPatternMatch,
+    pattern: &logical::graph::PathPatternMatch,
 ) -> Result<eval::graph::plan::PathPatternMatch<StringGraphTypes>, PlanningError> {
     use eval::graph::plan as physical;
     use partiql_logical as logical;
 
     fn plan_bind_spec(
-        pattern: &logical::BindSpec,
+        pattern: &logical::graph::BindSpec,
     ) -> Result<physical::BindSpec<StringGraphTypes>, PlanningError> {
         Ok(physical::BindSpec(pattern.0.clone()))
     }
 
     fn plan_label_filter(
-        pattern: &logical::LabelFilter,
+        pattern: &logical::graph::LabelFilter,
     ) -> Result<physical::LabelFilter<StringGraphTypes>, PlanningError> {
         Ok(match pattern {
-            logical::LabelFilter::Always => physical::LabelFilter::Always,
-            logical::LabelFilter::Never => physical::LabelFilter::Never,
-            logical::LabelFilter::Named(n) => physical::LabelFilter::Named(n.clone()),
+            logical::graph::LabelFilter::Always => physical::LabelFilter::Always,
+            logical::graph::LabelFilter::Never => physical::LabelFilter::Never,
+            logical::graph::LabelFilter::Named(n) => physical::LabelFilter::Named(n.clone()),
         })
     }
 
     fn plan_value_filter(
-        pattern: &logical::ValueFilter,
+        pattern: &logical::graph::ValueFilter,
     ) -> Result<physical::ValueFilter, PlanningError> {
         Ok(match pattern {
-            logical::ValueFilter::Always => physical::ValueFilter::Always,
+            logical::graph::ValueFilter::Always => physical::ValueFilter::Always,
         })
     }
 
     fn plan_node_filter(
-        pattern: &logical::NodeFilter,
+        pattern: &logical::graph::NodeFilter,
     ) -> Result<physical::NodeFilter<StringGraphTypes>, PlanningError> {
         Ok(physical::NodeFilter {
             label: plan_label_filter(&pattern.label)?,
@@ -833,7 +833,7 @@ fn plan_graph_plan(
     }
 
     fn plan_edge_filter(
-        pattern: &logical::EdgeFilter,
+        pattern: &logical::graph::EdgeFilter,
     ) -> Result<physical::EdgeFilter<StringGraphTypes>, PlanningError> {
         Ok(physical::EdgeFilter {
             label: plan_label_filter(&pattern.label)?,
@@ -842,16 +842,16 @@ fn plan_graph_plan(
     }
 
     fn plan_step_filter(
-        pattern: &logical::StepFilter,
+        pattern: &logical::graph::StepFilter,
     ) -> Result<physical::StepFilter<StringGraphTypes>, PlanningError> {
         let dir = match pattern.dir {
-            logical::DirectionFilter::L => physical::DirectionFilter::L,
-            logical::DirectionFilter::R => physical::DirectionFilter::R,
-            logical::DirectionFilter::U => physical::DirectionFilter::U,
-            logical::DirectionFilter::LU => physical::DirectionFilter::LU,
-            logical::DirectionFilter::UR => physical::DirectionFilter::UR,
-            logical::DirectionFilter::LR => physical::DirectionFilter::LR,
-            logical::DirectionFilter::LUR => physical::DirectionFilter::LUR,
+            logical::graph::DirectionFilter::L => physical::DirectionFilter::L,
+            logical::graph::DirectionFilter::R => physical::DirectionFilter::R,
+            logical::graph::DirectionFilter::U => physical::DirectionFilter::U,
+            logical::graph::DirectionFilter::LU => physical::DirectionFilter::LU,
+            logical::graph::DirectionFilter::UR => physical::DirectionFilter::UR,
+            logical::graph::DirectionFilter::LR => physical::DirectionFilter::LR,
+            logical::graph::DirectionFilter::LUR => physical::DirectionFilter::LUR,
         };
         Ok(physical::StepFilter {
             dir,
@@ -860,7 +860,7 @@ fn plan_graph_plan(
     }
 
     fn plan_triple_filter(
-        pattern: &logical::TripleFilter,
+        pattern: &logical::graph::TripleFilter,
     ) -> Result<physical::TripleFilter<StringGraphTypes>, PlanningError> {
         Ok(physical::TripleFilter {
             lhs: plan_node_filter(&pattern.lhs)?,
@@ -870,7 +870,7 @@ fn plan_graph_plan(
     }
 
     fn plan_node_match(
-        pattern: &logical::NodeMatch,
+        pattern: &logical::graph::NodeMatch,
     ) -> Result<physical::NodeMatch<StringGraphTypes>, PlanningError> {
         Ok(physical::NodeMatch {
             binder: plan_bind_spec(&pattern.binder)?,
@@ -879,7 +879,7 @@ fn plan_graph_plan(
     }
 
     fn plan_path_match(
-        pattern: &logical::PathMatch,
+        pattern: &logical::graph::PathMatch,
     ) -> Result<physical::PathMatch<StringGraphTypes>, PlanningError> {
         let (l, m, r) = &pattern.binders;
         let binders = (plan_bind_spec(l)?, plan_bind_spec(m)?, plan_bind_spec(r)?);
@@ -890,16 +890,16 @@ fn plan_graph_plan(
     }
 
     fn plan_path_pattern_match(
-        pattern: &logical::PathPatternMatch,
+        pattern: &logical::graph::PathPatternMatch,
     ) -> Result<physical::PathPatternMatch<StringGraphTypes>, PlanningError> {
         Ok(match pattern {
-            logical::PathPatternMatch::Node(n) => {
+            logical::graph::PathPatternMatch::Node(n) => {
                 physical::PathPatternMatch::Node(plan_node_match(n)?)
             }
-            logical::PathPatternMatch::Match(m) => {
+            logical::graph::PathPatternMatch::Match(m) => {
                 physical::PathPatternMatch::Match(plan_path_match(m)?)
             }
-            logical::PathPatternMatch::Concat(ms) => {
+            logical::graph::PathPatternMatch::Concat(ms) => {
                 let ms: Result<Vec<_>, _> = ms.iter().map(plan_path_pattern_match).collect();
                 physical::PathPatternMatch::Concat(ms?)
             }

--- a/partiql-logical-planner/src/graph.rs
+++ b/partiql-logical-planner/src/graph.rs
@@ -1,0 +1,294 @@
+use num::Integer;
+use partiql_ast::ast;
+use partiql_ast::ast::{GraphMatchDirection, GraphMatchPatternPart};
+use partiql_logical::graph::bind_name::FreshBinder;
+use partiql_logical::graph::{
+    BindSpec, DirectionFilter, EdgeFilter, EdgeMatch, LabelFilter, NodeFilter, NodeMatch,
+    PathMatch, PathPattern, PathPatternMatch, StepFilter, TripleFilter, ValueFilter,
+};
+use std::mem::take;
+
+#[macro_export]
+macro_rules! not_yet_implemented_result {
+    ($msg:expr) => {
+        return std::result::Result::Err($msg.to_string());
+    };
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GraphToLogical {
+    graph_id: FreshBinder,
+}
+
+#[derive(Debug, Clone)]
+enum MatchElement {
+    Node(NodeMatch),
+    Edge(DirectionFilter, EdgeMatch),
+    #[allow(dead_code)] // TODO with sub-graphs in graph MATCH
+    Pattern(Vec<MatchElement>),
+}
+
+#[derive(Debug)]
+struct Normalize<'a> {
+    head: Option<NodeMatch>,
+    tail: Vec<(DirectionFilter, EdgeMatch, Option<NodeMatch>)>,
+    fresh_binder: &'a FreshBinder,
+}
+
+impl<'a> Normalize<'a> {
+    pub fn new(fresh_binder: &'a FreshBinder) -> Self {
+        Self {
+            head: Default::default(),
+            tail: Default::default(),
+            fresh_binder,
+        }
+    }
+
+    pub fn normalize(mut self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
+        self.do_normalize(elements)
+    }
+
+    fn fresh_node(&mut self) -> NodeMatch {
+        NodeMatch {
+            binder: BindSpec(self.fresh_binder.node()),
+            spec: NodeFilter {
+                label: LabelFilter::Always,
+                filter: ValueFilter::Always,
+            },
+        }
+    }
+
+    fn flush(&mut self) -> Option<PathPattern> {
+        if self.head.is_none() {
+            debug_assert!(self.tail.is_empty());
+            return None;
+        }
+
+        if !self.tail.is_empty() && self.tail.last().unwrap().2.is_none() {
+            let fresh = self.fresh_node();
+            self.tail.last_mut().unwrap().2 = Some(fresh);
+        }
+
+        let head = self.head.take().unwrap();
+        let tail = take(&mut self.tail)
+            .into_iter()
+            .map(|(d, e, n)| (d, e, n.unwrap()))
+            .collect::<Vec<_>>();
+
+        Some(PathPattern { head, tail })
+    }
+
+    fn do_normalize(&mut self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
+        let mut path_patterns = vec![];
+
+        for elt in elements {
+            match elt {
+                MatchElement::Node(n) => {
+                    if self.head.is_none() {
+                        self.head = Some(n);
+                    } else {
+                        match self.tail.last_mut() {
+                            Some((_td, _te, tn)) => {
+                                if tn.is_none() {
+                                    *tn = Some(n);
+                                } else {
+                                    todo!("Deal with adjacent nodes")
+                                }
+                            }
+                            None => {
+                                todo!("Deal with adjacent nodes")
+                            }
+                        }
+                    }
+                }
+                MatchElement::Edge(d, e) => {
+                    if self.head.is_none() {
+                        self.head = Some(self.fresh_node());
+                    }
+                    self.tail.push((d, e, None));
+                }
+                MatchElement::Pattern(p) => {
+                    path_patterns.extend(self.flush());
+                    path_patterns.extend(self.do_normalize(p)?);
+                }
+            }
+        }
+
+        path_patterns.extend(self.flush());
+
+        Ok(path_patterns)
+    }
+}
+
+impl GraphToLogical {
+    fn normalize(&self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
+        Normalize::new(&self.graph_id).normalize(elements)
+    }
+
+    fn expand(&self, paths: Vec<PathPattern>) -> Result<Vec<PathPattern>, String> {
+        // TODO handle expansion as described in 6.3 of https://arxiv.org/pdf/2112.06217
+        // TODO   this will enable alternation and quantifiers
+        Ok(paths)
+    }
+
+    fn plan(&self, paths: Vec<PathPattern>) -> Result<PathPatternMatch, String> {
+        debug_assert!(paths.len() == 1);
+        let path_pattern = &paths[0];
+        // pattern at this point should be a node, or a series of node-[edge-node]+
+        debug_assert!((1 + (2 * path_pattern.tail.len())).is_odd());
+
+        if path_pattern.tail.is_empty() {
+            Ok(PathPatternMatch::Node(path_pattern.head.clone()))
+        } else {
+            let mut paths = vec![];
+            let mut head = &path_pattern.head;
+            for (d, e, n) in &path_pattern.tail {
+                let binders = (head.binder.clone(), e.binder.clone(), n.binder.clone());
+                let spec = StepFilter {
+                    dir: d.clone(),
+                    triple: TripleFilter {
+                        lhs: head.spec.clone(),
+                        e: e.spec.clone(),
+                        rhs: n.spec.clone(),
+                    },
+                };
+                paths.push(PathPatternMatch::Match(PathMatch { binders, spec }));
+                head = n;
+            }
+            if paths.len() == 1 {
+                let path = paths.into_iter().next().unwrap();
+                Ok(path)
+            } else {
+                Ok(PathPatternMatch::Concat(paths))
+            }
+        }
+    }
+    pub(crate) fn plan_graph_match(
+        &self,
+        match_expr: &ast::GraphMatchExpr,
+    ) -> Result<PathPatternMatch, String> {
+        if match_expr.selector.is_some() {
+            not_yet_implemented_result!("MATCH expression selectors are not yet supported.");
+        }
+
+        if match_expr.patterns.len() != 1 {
+            not_yet_implemented_result!(
+                "MATCH expression with multiple patterns are not yet supported."
+            );
+        }
+
+        let first_pattern = &match_expr.patterns[0].node;
+        let pattern = self.plan_graph_pattern(first_pattern)?;
+        let normalized = self.normalize(pattern)?;
+        let expanded = self.expand(normalized)?;
+        self.plan(expanded)
+    }
+
+    fn plan_graph_pattern(
+        &self,
+        pattern: &ast::GraphMatchPattern,
+    ) -> Result<Vec<MatchElement>, String> {
+        if pattern.restrictor.is_some() {
+            not_yet_implemented_result!("MATCH pattern restrictors are not yet supported.");
+        }
+        if pattern.quantifier.is_some() {
+            not_yet_implemented_result!("MATCH pattern quantifiers are not yet supported.");
+        }
+        if pattern.prefilter.is_some() {
+            not_yet_implemented_result!("MATCH pattern prefilters are not yet supported.");
+        }
+        if pattern.variable.is_some() {
+            not_yet_implemented_result!("MATCH pattern path variables are not yet supported.");
+        }
+
+        let parts = pattern
+            .parts
+            .iter()
+            .map(|p| self.plan_graph_pattern_part(p));
+        let result: Result<Vec<_>, _> = parts.collect();
+
+        result.map(|r| r.into_iter().flatten().collect())
+    }
+
+    fn plan_graph_pattern_part(
+        &self,
+        part: &ast::GraphMatchPatternPart,
+    ) -> Result<Vec<MatchElement>, String> {
+        match part {
+            GraphMatchPatternPart::Node(n) => self.plan_graph_pattern_part_node(&n.node),
+            GraphMatchPatternPart::Edge(e) => self.plan_graph_pattern_part_edge(&e.node),
+            GraphMatchPatternPart::Pattern(pattern) => self.plan_graph_pattern(&pattern.node),
+        }
+    }
+
+    fn plan_graph_pattern_label(
+        &self,
+        label: &Option<Vec<ast::SymbolPrimitive>>,
+    ) -> Result<LabelFilter, String> {
+        match label {
+            None => Ok(LabelFilter::Always),
+            Some(labels) => {
+                if labels.len() != 1 {
+                    not_yet_implemented_result!(
+                        "MATCH expression with multiple patterns are not yet supported."
+                    );
+                }
+                Ok(LabelFilter::Named(labels[0].value.clone()))
+            }
+        }
+    }
+
+    fn plan_graph_pattern_part_node(
+        &self,
+        node: &ast::GraphMatchNode,
+    ) -> Result<Vec<MatchElement>, String> {
+        if node.prefilter.is_some() {
+            not_yet_implemented_result!("MATCH node prefilters are not yet supported.");
+        }
+        let binder = match &node.variable {
+            None => self.graph_id.node(),
+            Some(v) => v.value.clone(),
+        };
+        let node_match = NodeMatch {
+            binder: BindSpec(binder),
+            spec: NodeFilter {
+                label: self.plan_graph_pattern_label(&node.label)?,
+                filter: ValueFilter::Always,
+            },
+        };
+        Ok(vec![MatchElement::Node(node_match)])
+    }
+
+    fn plan_graph_pattern_part_edge(
+        &self,
+        edge: &ast::GraphMatchEdge,
+    ) -> Result<Vec<MatchElement>, String> {
+        if edge.quantifier.is_some() {
+            not_yet_implemented_result!("MATCH edge quantifiers are not yet supported.");
+        }
+        if edge.prefilter.is_some() {
+            not_yet_implemented_result!("MATCH edge prefilters are not yet supported.");
+        }
+        let direction = match &edge.direction {
+            GraphMatchDirection::Left => DirectionFilter::L,
+            GraphMatchDirection::Undirected => DirectionFilter::U,
+            GraphMatchDirection::Right => DirectionFilter::R,
+            GraphMatchDirection::LeftOrUndirected => DirectionFilter::LU,
+            GraphMatchDirection::UndirectedOrRight => DirectionFilter::UR,
+            GraphMatchDirection::LeftOrRight => DirectionFilter::LR,
+            GraphMatchDirection::LeftOrUndirectedOrRight => DirectionFilter::LUR,
+        };
+        let binder = match &edge.variable {
+            None => self.graph_id.node(),
+            Some(v) => v.value.clone(),
+        };
+        let edge_match = EdgeMatch {
+            binder: BindSpec(binder),
+            spec: EdgeFilter {
+                label: self.plan_graph_pattern_label(&edge.label)?,
+                filter: ValueFilter::Always,
+            },
+        };
+        Ok(vec![MatchElement::Edge(direction, edge_match)])
+    }
+}

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -12,6 +12,7 @@ use partiql_catalog::catalog::{Catalog, PartiqlCatalog};
 
 mod builtins;
 mod functions;
+mod graph;
 mod lower;
 mod typer;
 

--- a/partiql-logical/src/graph/bind_name.rs
+++ b/partiql-logical/src/graph/bind_name.rs
@@ -15,11 +15,10 @@ impl<S: AsRef<str>> BindNameExt for S {
 }
 
 /// Creates 'fresh' bind names
+#[derive(Debug)]
 pub struct FreshBinder {
-    #[allow(dead_code)] // TODO remove once graph planning is implemented
     node: AtomicU32,
 
-    #[allow(dead_code)] // TODO remove once graph planning is implemented
     edge: AtomicU32,
 }
 
@@ -33,12 +32,10 @@ impl Default for FreshBinder {
 }
 
 impl FreshBinder {
-    #[allow(dead_code)] // TODO remove once graph planning is implemented
     pub fn node(&self) -> String {
         format!("{ANON_PREFIX}🞎{}", self.node.fetch_add(1, Relaxed))
     }
 
-    #[allow(dead_code)] // TODO remove once graph planning is implemented
     pub fn edge(&self) -> String {
         format!("{ANON_PREFIX}⁃{}", self.edge.fetch_add(1, Relaxed))
     }

--- a/partiql-logical/src/graph/mod.rs
+++ b/partiql-logical/src/graph/mod.rs
@@ -2,6 +2,8 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
+pub mod bind_name;
+
 /// A plan specification for an edge's direction filtering.
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -76,9 +78,9 @@ pub struct StepFilter {
 /// A plan specification for 'path patterns' (i.e., sequences of 'node edge node's) matching.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PathPatternFilter {
-    pub head: NodeFilter,
-    pub tail: Vec<(DirectionFilter, EdgeFilter, NodeFilter)>,
+pub struct PathPattern {
+    pub head: NodeMatch,
+    pub tail: Vec<(DirectionFilter, EdgeMatch, NodeMatch)>,
 }
 
 /// A plan specification for node matching.

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -15,8 +15,7 @@
 
 mod util;
 
-mod graph;
-pub use graph::*;
+pub mod graph;
 
 use ordered_float::OrderedFloat;
 use partiql_common::catalog::ObjectId;
@@ -609,7 +608,7 @@ pub struct LikeNonStringNonLiteralMatch {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GraphMatchExpr {
     pub value: Box<ValueExpr>,
-    pub pattern: PathPatternMatch,
+    pub pattern: graph::PathPatternMatch,
 }
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
This PR:
- Builds on #548 and #549
- enables the `experimental` conformance tests which include the GPML tests
- Refactors some types and traits into non-`pub` modules.
- Fixes some minor graph evaluation edge case bugs
- Adds lowering from the AST to the logical plan for graph match stuff.

---

Some of the graph conformance tests are still failing; These are largely tests that specify only an edge and have implicit start and end nodes (e.g., `( graph MATCH -> )`).

The current grammar cannot parse such a construction. I intend to tackle this in follow-up work, perhaps including modernizing the grammar to follow SQL '23.


---



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
