### PR TITLE
Refactor Plan and Expression evaluation to be stateless and remove explicit lifetimes.

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -1,6 +1,6 @@
 name: CI Build
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 env:
   CARGO_TEST_RESULT_NAME: cargo_test_results.json
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
       - name: Remove MSys64 MingW64 Binaries
@@ -32,7 +32,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy, rustfmt
-      - name: Cargo Build 
+      - name: Cargo Build
         run: cargo build --verbose --workspace
       - name: Cargo Test excluding conformance tests
         run: cargo test --verbose --workspace
@@ -92,7 +92,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-10-17
+          toolchain: nightly-2025-04-03
       - uses: actions/cache@v3
         id: restore-build
         with:
@@ -122,7 +122,7 @@ jobs:
   conformance-report-comparison:
     name: Create comparison report for `pull_request` event
     runs-on: ubuntu-latest
-    needs: [conformance-report]
+    needs: [ conformance-report ]
     if: github.event_name == 'pull_request'
     steps:
       # Pull down cached `cargo build` and conformance report
@@ -132,7 +132,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-10-17
+          toolchain: nightly-2025-04-03
       - uses: actions/cache@v3
         id: restore-build-and-conformance
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- *BREAKING* Heavily refactors evaluation to be stateless
+- *BREAKING* Heavily refactors Session & Evaluation Contexts to no longer require lifetime parameters
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ homepage = "https://github.com/partiql/partiql-lang-rust"
 repository = "https://github.com/partiql/partiql-lang-rust"
 version = "0.12.0"
 edition = "2021"
+rust-version = "1.86.0"
 
 [workspace]
 resolver = "2"

--- a/extension/partiql-extension-csv/src/lib.rs
+++ b/extension/partiql-extension-csv/src/lib.rs
@@ -132,7 +132,7 @@ impl BaseTableExpr for EvalFnScanCsv {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {

--- a/extension/partiql-extension-csv/tests/scan.rs
+++ b/extension/partiql-extension-csv/tests/scan.rs
@@ -36,13 +36,13 @@ pub(crate) fn evaluate(
     let mut planner =
         partiql_eval::plan::EvaluatorPlanner::new(EvaluationMode::Permissive, catalog);
 
-    let mut plan = planner.compile(&logical).expect("Expect no plan error");
+    let plan = planner.compile(&logical).expect("Expect no plan error");
 
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    let value = if let Ok(out) = plan.execute_mut(&ctx) {
+    let value = if let Ok(out) = plan.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/extension/partiql-extension-ion-functions/src/read_ion.rs
+++ b/extension/partiql-extension-ion-functions/src/read_ion.rs
@@ -55,7 +55,7 @@ impl BaseTableExpr for EvalFnReadIon {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {

--- a/extension/partiql-extension-ion-functions/src/scan_ion.rs
+++ b/extension/partiql-extension-ion-functions/src/scan_ion.rs
@@ -65,7 +65,7 @@ impl BaseTableExpr for EvalFnScanIon {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {

--- a/extension/partiql-extension-ion-functions/tests/scan.rs
+++ b/extension/partiql-extension-ion-functions/tests/scan.rs
@@ -36,13 +36,13 @@ pub(crate) fn evaluate(
     let mut planner =
         partiql_eval::plan::EvaluatorPlanner::new(EvaluationMode::Permissive, catalog);
 
-    let mut plan = planner.compile(&logical).expect("Expect no plan error");
+    let plan = planner.compile(&logical).expect("Expect no plan error");
 
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    let value = if let Ok(out) = plan.execute_mut(&ctx) {
+    let value = if let Ok(out) = plan.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/extension/partiql-extension-ion/src/boxed_ion.rs
+++ b/extension/partiql-extension-ion/src/boxed_ion.rs
@@ -11,7 +11,8 @@ use partiql_value::boxed_variant::{
 use partiql_value::datum::{
     Datum, DatumCategoryOwned, DatumCategoryRef, DatumLower, DatumLowerResult, DatumSeqOwned,
     DatumSeqRef, DatumTupleOwned, DatumTupleRef, DatumValueOwned, DatumValueRef, OwnedFieldView,
-    OwnedSequenceView, OwnedTupleView, RefSequenceView, RefTupleView, SequenceDatum, TupleDatum,
+    OwnedSequenceView, OwnedTupleView, RefFieldView, RefSequenceView, RefTupleView, SequenceDatum,
+    TupleDatum,
 };
 use partiql_value::{Bag, BindingsName, List, NullableEq, Tuple, Value, Variant};
 use peekmore::{PeekMore, PeekMoreIterator};
@@ -419,6 +420,10 @@ impl<'a> RefTupleView<'a, Value> for BoxedIon {
             }
         }
         None
+    }
+
+    fn tuple_fields_iter(&'a self) -> Box<dyn Iterator<Item = RefFieldView<'a, Value>> + 'a> {
+        todo!()
     }
 }
 

--- a/extension/partiql-extension-ion/src/boxed_ion.rs
+++ b/extension/partiql-extension-ion/src/boxed_ion.rs
@@ -414,6 +414,7 @@ impl<'a> RefTupleView<'a, Value> for BoxedIon {
             if let Ok(strct) = elt.expect_struct() {
                 for (k, elt) in strct {
                     if k.text().is_some_and(|k| matcher.matches(k)) {
+                        // TODO remove clone via ion-rs's new lazy element?
                         return Some(Cow::Owned(Self::new_value(elt.clone(), ctx.clone())));
                     }
                 }
@@ -423,7 +424,18 @@ impl<'a> RefTupleView<'a, Value> for BoxedIon {
     }
 
     fn tuple_fields_iter(&'a self) -> Box<dyn Iterator<Item = RefFieldView<'a, Value>> + 'a> {
-        todo!()
+        let Self { doc, ctx } = self;
+        if let BoxedIonValue::Value(elt) = doc {
+            if let Some(strct) = elt.as_struct() {
+                return Box::new(strct.iter().map(|(name, value)| {
+                    let name = name.text();
+                    let value = Cow::Owned(Self::new_value(value.clone(), ctx.clone()));
+                    // TODO remove clone via ion-rs's new lazy element?
+                    RefFieldView { name, value }
+                }));
+            }
+        }
+        Box::new(std::iter::empty())
     }
 }
 

--- a/extension/partiql-extension-value-functions/src/lib.rs
+++ b/extension/partiql-extension-value-functions/src/lib.rs
@@ -50,7 +50,7 @@ impl ScalarFnExpr for TupleUnionFnExpr {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> ScalarFnExprResult<'c> {
         let mut t = Tuple::default();
         for arg in args {
@@ -83,7 +83,7 @@ impl ScalarFnExpr for TupleConcatFnExpr {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> ScalarFnExprResult<'c> {
         let result = args
             .iter()

--- a/partiql-catalog/src/context.rs
+++ b/partiql-catalog/src/context.rs
@@ -1,3 +1,4 @@
+use partiql_value::datum::RefTupleView;
 use partiql_value::{BindingsName, DateTime, Tuple, Value};
 use std::any::Any;
 use std::fmt::Debug;
@@ -6,12 +7,21 @@ pub trait Bindings<T>: Debug
 where
     T: Debug,
 {
-    fn get(&self, name: &BindingsName<'_>) -> Option<&T>;
+    fn get<'a>(&'a self, name: &BindingsName<'a>) -> Option<&'a T>;
 }
 
 impl Bindings<Value> for Tuple {
-    fn get(&self, name: &BindingsName<'_>) -> Option<&Value> {
+    fn get<'a>(&'a self, name: &BindingsName<'a>) -> Option<&'a Value> {
         self.get(name)
+    }
+}
+
+impl<'x, T> Bindings<Value> for &T
+where
+    T: RefTupleView<'x, Value>,
+{
+    fn get<'a>(&'a self, name: &BindingsName<'a>) -> Option<&'a Value> {
+        self.get_val(name).map(|c|c.as_ref())
     }
 }
 

--- a/partiql-catalog/src/context.rs
+++ b/partiql-catalog/src/context.rs
@@ -4,24 +4,24 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
-pub trait Bindings<'a, T>: Debug
+pub trait Bindings<T>: Debug
 where
     T: Clone + Debug,
 {
-    fn get(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>>;
+    fn get<'a>(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>>;
 }
 
-impl<'a> Bindings<'a, Value> for Tuple {
-    fn get(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
+impl Bindings<Value> for Tuple {
+    fn get<'a>(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
         self.get(name).map(Cow::Borrowed)
     }
 }
 
-impl<'a, T> Bindings<'a, Value> for &T
+impl<T> Bindings<Value> for &T
 where
-    T: RefTupleView<'a, Value>,
+    for<'a> T: RefTupleView<'a, Value>,
 {
-    fn get(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
+    fn get<'a>(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, Value>> {
         self.get_val(name)
     }
 }
@@ -32,7 +32,7 @@ pub struct SystemContext {
 }
 
 /// Represents a session context that is used during evaluation of a plan.
-pub trait SessionContext<'a>: Debug {
+pub trait SessionContext: Debug {
     fn system_context(&self) -> &SystemContext;
 
     fn user_context(&self, name: &str) -> Option<&(dyn Any)>;

--- a/partiql-catalog/src/scalar_fn.rs
+++ b/partiql-catalog/src/scalar_fn.rs
@@ -15,7 +15,7 @@ pub trait ScalarFnExpr: DynClone + Debug {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        ctx: &'c dyn SessionContext<'c>,
+        ctx: &'c dyn SessionContext,
     ) -> ScalarFnExprResult<'c>;
 }
 

--- a/partiql-catalog/src/table_fn.rs
+++ b/partiql-catalog/src/table_fn.rs
@@ -13,7 +13,7 @@ pub trait BaseTableExpr: Debug {
     fn evaluate<'c>(
         &self,
         args: &[Cow<'_, Value>],
-        ctx: &'c dyn SessionContext<'c>,
+        ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c>;
 }
 

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn compile(
 
 #[track_caller]
 #[inline]
-pub(crate) fn evaluate<'c>(plan: EvalPlan, ctx: &'c dyn EvalContext<'c>) -> EvalResult {
+pub(crate) fn evaluate(plan: EvalPlan, ctx: &dyn EvalContext) -> EvalResult {
     plan.execute(ctx)
 }
 

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -72,8 +72,8 @@ pub(crate) fn compile(
 
 #[track_caller]
 #[inline]
-pub(crate) fn evaluate<'c>(mut plan: EvalPlan, ctx: &'c dyn EvalContext<'c>) -> EvalResult {
-    plan.execute_mut(ctx)
+pub(crate) fn evaluate<'c>(plan: EvalPlan, ctx: &'c dyn EvalContext<'c>) -> EvalResult {
+    plan.execute(ctx)
 }
 
 #[track_caller]

--- a/partiql-eval/benches/bench_eval.rs
+++ b/partiql-eval/benches/bench_eval.rs
@@ -135,12 +135,12 @@ fn eval_plan(logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
     planner.compile(logical).expect("Expect no plan error")
 }
 
-fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> Value {
+fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> Value {
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    if let Ok(out) = plan.execute_mut(&ctx) {
+    if let Ok(out) = plan.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -137,13 +137,6 @@ pub mod basic {
                 Some(v) => Some(v),
                 None => self.parent.get(name),
             }
-
-            /*
-            self.bindings
-                .get(name)
-                .or_else(move || self.parent.get(name))
-
-             */
         }
     }
 }

--- a/partiql-eval/src/env.rs
+++ b/partiql-eval/src/env.rs
@@ -42,12 +42,12 @@ pub mod basic {
         }
     }
 
-    impl<'a, T> Bindings<'a, T> for MapBindings<T>
+    impl<T> Bindings<T> for MapBindings<T>
     where
         T: Clone + Debug,
     {
         #[inline]
-        fn get(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>> {
+        fn get<'a>(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>> {
             let idx = match name {
                 BindingsName::CaseSensitive(s) => self.sensitive.get(s.as_ref()),
                 BindingsName::CaseInsensitive(s) => {
@@ -62,7 +62,7 @@ pub mod basic {
         fn from(value: &'a dyn RefTupleView<'a, Value>) -> Self {
             let mut bindings = MapBindings::default();
             for RefFieldView { name, value } in value.tuple_fields_iter() {
-                bindings.insert(name.unwrap_or("_1"), value.clone());
+                bindings.insert(name.unwrap_or("_1"), value.into_owned());
             }
             bindings
         }
@@ -116,23 +116,23 @@ pub mod basic {
         T: Debug,
     {
         bindings: MapBindings<T>,
-        parent: &'a dyn Bindings<'a, T>,
+        parent: &'a dyn Bindings<T>,
     }
 
     impl<'a, T> NestedBindings<'a, T>
     where
         T: Debug,
     {
-        pub fn new(bindings: MapBindings<T>, parent: &'a dyn Bindings<'a, T>) -> Self {
+        pub fn new(bindings: MapBindings<T>, parent: &'a dyn Bindings<T>) -> Self {
             Self { bindings, parent }
         }
     }
 
-    impl<'a, T> Bindings<'a, T> for NestedBindings<'a, T>
+    impl<'b, T> Bindings<T> for NestedBindings<'b, T>
     where
-        T: Clone + Debug + 'a,
+        T: Clone + Debug + 'b,
     {
-        fn get(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>> {
+        fn get<'a>(&'a self, name: &BindingsName<'_>) -> Option<Cow<'a, T>> {
             match self.bindings.get(name) {
                 Some(v) => Some(v),
                 None => self.parent.get(name),

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -2,7 +2,8 @@ use crate::eval::evaluable::Evaluable;
 use crate::eval::expr::EvalExpr;
 use crate::eval::EvalContext;
 use partiql_catalog::extension::ExtensionResultError;
-use partiql_value::{Tuple, Value};
+use partiql_value::datum::RefTupleView;
+use partiql_value::Value;
 use std::borrow::Cow;
 use thiserror::Error;
 
@@ -67,9 +68,9 @@ impl Evaluable for ErrorNode {
 }
 
 impl EvalExpr for ErrorNode {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        _bindings: &'a Tuple,
+        _bindings: &'a dyn RefTupleView<'a, Value>,
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -61,11 +61,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate<'a, 'c>(&mut self, _ctx: &'c dyn EvalContext<'c>) -> Value {
-        panic!("ErrorNode will not be evaluated")
-    }
-
-    fn update_input(&mut self, _input: Value, _branch_num: u8, _ctx: &dyn EvalContext<'_>) {
+    fn evaluate<'a, 'c>(&mut self, _: [Option<Value>; 2], _ctx: &'c dyn EvalContext<'c>) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 }

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -62,7 +62,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate<'a, 'o>(&self, _: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, _: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 }

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -62,7 +62,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate<'a, 'c>(&mut self, _: [Option<Value>; 2], _ctx: &'c dyn EvalContext<'c>) -> Value {
+    fn evaluate<'a, 'c, 'o>(&self, _: [Option<Value>; 2], _ctx: &'c dyn EvalContext<'c>) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 }
@@ -70,11 +70,12 @@ impl Evaluable for ErrorNode {
 impl EvalExpr for ErrorNode {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
-        _bindings: &'a dyn RefTupleView<'a, Value>,
-        _ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+        bindings: &'a dyn RefTupleView<'a, Value>,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         panic!("ErrorNode will not be evaluated")
     }

--- a/partiql-eval/src/error.rs
+++ b/partiql-eval/src/error.rs
@@ -62,7 +62,7 @@ impl ErrorNode {
 }
 
 impl Evaluable for ErrorNode {
-    fn evaluate<'a, 'c, 'o>(&self, _: [Option<Value>; 2], _ctx: &'c dyn EvalContext<'c>) -> Value {
+    fn evaluate<'a, 'o>(&self, _: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         panic!("ErrorNode will not be evaluated")
     }
 }
@@ -70,8 +70,8 @@ impl Evaluable for ErrorNode {
 impl EvalExpr for ErrorNode {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        _bindings: &'a dyn RefTupleView<'a, Value>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -425,11 +425,12 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
-        if STRICT && ctx.has_errors() {
+        if STRICT & &ctx.has_errors() {
             return Cow::Owned(Missing);
         }
         match self.evaluate_args(bindings, ctx) {

--- a/partiql-eval/src/eval/eval_expr_wrapper.rs
+++ b/partiql-eval/src/eval/eval_expr_wrapper.rs
@@ -103,7 +103,7 @@ pub(crate) trait ExecuteEvalExpr<const N: usize>: Debug {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         args: [Cow<'a, Value>; N],
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a;
@@ -299,7 +299,7 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
     pub fn evaluate_args<'a, 'c>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> ControlFlow<Value, [Cow<'a, Value>; N]>
     where
         'c: 'a,
@@ -341,7 +341,7 @@ pub(crate) fn evaluate_and_validate_args<
     args: &'a [Box<dyn EvalExpr>],
     types: F,
     bindings: &'a dyn RefTupleView<'a, Value>,
-    ctx: &'c dyn EvalContext<'c>,
+    ctx: &'c dyn EvalContext,
 ) -> ControlFlow<Value, Vec<Cow<'a, Value>>>
 where
     'c: 'a,
@@ -424,13 +424,13 @@ impl<const STRICT: bool, const N: usize, E: ExecuteEvalExpr<N>, ArgC: ArgChecker
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
         'a: 'o,
     {
-        if STRICT & &ctx.has_errors() {
+        if STRICT && (ctx.has_errors()) {
             return Cow::Owned(Missing);
         }
         match self.evaluate_args(bindings, ctx) {
@@ -485,7 +485,7 @@ where
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         args: [Cow<'a, Value>; 1],
-        _ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a,
@@ -549,7 +549,7 @@ where
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         args: [Cow<'a, Value>; 2],
-        _ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a,
@@ -613,7 +613,7 @@ where
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         args: [Cow<'a, Value>; 3],
-        _ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a,
@@ -677,7 +677,7 @@ where
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         args: [Cow<'a, Value>; 4],
-        _ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -103,7 +103,7 @@ impl EvalScan {
 }
 
 impl Evaluable for EvalScan {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = inputs[0].take().unwrap_or(Missing);
 
         let bindings = match input_value {
@@ -193,7 +193,7 @@ impl EvalJoin {
 }
 
 impl Evaluable for EvalJoin {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         /// Creates a `Tuple` with attributes `attrs`, each with value `Null`
         #[inline]
         fn tuple_with_null_vals<I, S>(attrs: I) -> Tuple
@@ -648,7 +648,7 @@ impl EvalGroupBy {
 }
 
 impl Evaluable for EvalGroupBy {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let group_as_alias = &self.group_as_alias;
         let input_value = take_input!(inputs[0].take(), ctx);
 
@@ -757,7 +757,7 @@ impl EvalPivot {
 }
 
 impl Evaluable for EvalPivot {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let tuple: Tuple = input_value
@@ -809,7 +809,7 @@ impl EvalUnpivot {
 }
 
 impl Evaluable for EvalUnpivot {
-    fn evaluate<'a, 'o>(&self, _inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, _inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let tuple = match self.expr.evaluate(&DatumTupleRef::Empty, ctx).into_owned() {
             Value::Tuple(tuple) => *tuple,
             other => other.coerce_into_tuple(),
@@ -868,7 +868,7 @@ impl EvalFilter {
 }
 
 impl Evaluable for EvalFilter {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let filtered = input_value
@@ -914,7 +914,7 @@ impl EvalHaving {
 }
 
 impl Evaluable for EvalHaving {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let filtered = input_value
@@ -984,7 +984,7 @@ impl EvalOrderBy {
 }
 
 impl Evaluable for EvalOrderBy {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let values: DatumLowerResult<Vec<_>> =
@@ -1004,7 +1004,7 @@ pub(crate) struct EvalLimitOffset {
 }
 
 impl Evaluable for EvalLimitOffset {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let empty_bindings = DatumTupleRef::Empty;
@@ -1068,7 +1068,7 @@ impl EvalSelectValue {
 }
 
 impl Evaluable for EvalSelectValue {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let ordered = input_value.is_ordered();
@@ -1115,7 +1115,7 @@ impl Debug for EvalSelect {
 }
 
 impl Evaluable for EvalSelect {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let ordered = input_value.is_ordered();
@@ -1155,7 +1155,7 @@ impl EvalSelectAll {
 }
 
 impl Evaluable for EvalSelectAll {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
 
         let ordered = input_value.is_ordered();
@@ -1193,7 +1193,7 @@ impl EvalExprQuery {
 }
 
 impl Evaluable for EvalExprQuery {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input = inputs[0].take().unwrap_or(Value::Null);
         let input = input.as_tuple_ref();
         let input = input.as_ref();
@@ -1213,7 +1213,7 @@ impl EvalDistinct {
 }
 
 impl Evaluable for EvalDistinct {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], ctx: &dyn EvalContext) -> Value {
         let input_value = take_input!(inputs[0].take(), ctx);
         let ordered = input_value.is_ordered();
 
@@ -1229,7 +1229,7 @@ impl Evaluable for EvalDistinct {
 pub(crate) struct EvalSink {}
 
 impl Evaluable for EvalSink {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         inputs[0].take().unwrap_or(Missing)
     }
 }
@@ -1316,7 +1316,7 @@ impl EvalOuterUnion {
 }
 
 impl Evaluable for EvalOuterUnion {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         let lhs = bagop_iter(inputs[0].take().unwrap_or(Missing));
         let rhs = bagop_iter(inputs[1].take().unwrap_or(Missing));
         let chained = lhs.chain(rhs);
@@ -1341,7 +1341,7 @@ impl EvalOuterIntersect {
 }
 
 impl Evaluable for EvalOuterIntersect {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         let lhs = bagop_iter(inputs[0].take().unwrap_or(Missing));
         let rhs = bagop_iter(inputs[1].take().unwrap_or(Missing));
 
@@ -1381,7 +1381,7 @@ impl EvalOuterExcept {
 }
 
 impl Evaluable for EvalOuterExcept {
-    fn evaluate<'a, 'o>(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
+    fn evaluate(&self, mut inputs: [Option<Value>; 2], _ctx: &dyn EvalContext) -> Value {
         let lhs = bagop_iter(inputs[0].take().unwrap_or(Missing));
         let rhs = bagop_iter(inputs[1].take().unwrap_or(Missing));
 

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -1,4 +1,3 @@
-use crate::env::basic::MapBindings;
 use crate::error::EvaluationError;
 use crate::eval::expr::EvalExpr;
 use crate::eval::{EvalContext, EvalPlan, NestedContext};
@@ -8,13 +7,15 @@ use partiql_value::{
     bag, list, tuple, Bag, List, NullSortedValue, Tuple, Value, ValueIntoIterator,
 };
 use rustc_hash::FxHashMap;
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 
+use crate::env::basic::MapBindings;
 use partiql_value::datum::{Datum, DatumLower, DatumLowerResult, DatumTupleRef, RefTupleView};
 use std::rc::Rc;
 
@@ -42,7 +43,7 @@ pub enum EvalType {
 
 /// `Evaluable` represents each evaluation operator in the evaluation plan as an evaluable entity.
 pub trait Evaluable: Debug {
-    fn evaluate<'c>(&mut self, inputs: [Option<Value>; 2], ctx: &'c dyn EvalContext<'c>) -> Value;
+    fn evaluate<'c>(&self, inputs: [Option<Value>; 2], ctx: &'c dyn EvalContext<'c>) -> Value;
     fn get_vars(&self) -> Option<&[String]> {
         None
     }
@@ -102,8 +103,8 @@ impl EvalScan {
 }
 
 impl Evaluable for EvalScan {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -196,8 +197,8 @@ impl EvalJoin {
 }
 
 impl Evaluable for EvalJoin {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -655,8 +656,8 @@ impl EvalGroupBy {
 }
 
 impl Evaluable for EvalGroupBy {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -768,8 +769,8 @@ impl EvalPivot {
 }
 
 impl Evaluable for EvalPivot {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -824,8 +825,8 @@ impl EvalUnpivot {
 }
 
 impl Evaluable for EvalUnpivot {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -887,8 +888,8 @@ impl EvalFilter {
 }
 
 impl Evaluable for EvalFilter {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -937,8 +938,8 @@ impl EvalHaving {
 }
 
 impl Evaluable for EvalHaving {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1011,8 +1012,8 @@ impl EvalOrderBy {
 }
 
 impl Evaluable for EvalOrderBy {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1035,8 +1036,8 @@ pub(crate) struct EvalLimitOffset {
 }
 
 impl Evaluable for EvalLimitOffset {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1103,8 +1104,8 @@ impl EvalSelectValue {
 }
 
 impl Evaluable for EvalSelectValue {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1154,8 +1155,8 @@ impl Debug for EvalSelect {
 }
 
 impl Evaluable for EvalSelect {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1201,8 +1202,8 @@ impl EvalSelectAll {
 }
 
 impl Evaluable for EvalSelectAll {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1243,8 +1244,8 @@ impl EvalExprQuery {
 }
 
 impl Evaluable for EvalExprQuery {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1267,8 +1268,8 @@ impl EvalDistinct {
 }
 
 impl Evaluable for EvalDistinct {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1287,8 +1288,8 @@ impl Evaluable for EvalDistinct {
 pub(crate) struct EvalSink {}
 
 impl Evaluable for EvalSink {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1318,21 +1319,22 @@ impl EvalSubQueryExpr {
 }
 
 impl EvalExpr for EvalSubQueryExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
-        let bindings = MapBindings::from(bindings);
         let value = {
-            let nested_ctx: NestedContext<'_, '_> = NestedContext::new(bindings, ctx);
+            let bindings = MapBindings::from(bindings);
+            let nested_ctx: NestedContext<'_> = NestedContext::new(bindings, ctx);
 
-            let mut plan = self.plan.borrow_mut();
+            let plan = RefCell::borrow(&self.plan);
 
-            match plan.execute_mut(&nested_ctx) {
+            let value = match plan.execute(ctx) {
                 Ok(evaluated) => evaluated.result,
                 Err(err) => {
                     for e in err.errors {
@@ -1340,7 +1342,9 @@ impl EvalExpr for EvalSubQueryExpr {
                     }
                     Missing
                 }
-            }
+            };
+
+            value.clone()
         };
         Cow::Owned(value)
     }
@@ -1375,8 +1379,8 @@ impl EvalOuterUnion {
 }
 
 impl Evaluable for EvalOuterUnion {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1404,8 +1408,8 @@ impl EvalOuterIntersect {
 }
 
 impl Evaluable for EvalOuterIntersect {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Value {
@@ -1448,8 +1452,8 @@ impl EvalOuterExcept {
 }
 
 impl Evaluable for EvalOuterExcept {
-    fn evaluate<'a, 'c>(
-        &mut self,
+    fn evaluate<'a, 'c, 'o>(
+        &self,
         mut inputs: [Option<Value>; 2],
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Value {

--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -691,7 +691,7 @@ impl Evaluable for EvalGroupBy {
 
                     // Add tuple to `GROUP AS` if applicable
                     if let Some(ref mut tuples) = group_as {
-                        tuples.push(Value::from(v.coerce_into_tuple())); // TODO does this work?
+                        tuples.push(Value::from(v.coerce_into_tuple()));
                     }
                 }
 

--- a/partiql-eval/src/eval/expr/base_table.rs
+++ b/partiql-eval/src/eval/expr/base_table.rs
@@ -23,7 +23,7 @@ impl EvalExpr for EvalFnBaseTableExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -34,7 +34,7 @@ impl EvalExpr for EvalFnBaseTableExpr {
             .iter()
             .map(|arg| arg.evaluate(bindings, ctx))
             .collect_vec();
-        let results = self.expr.evaluate(&args, ctx.as_session());
+        let results = self.expr.evaluate(&args, ctx);
         let result = match results {
             Ok(it) => {
                 let bag: Result<Bag, _> = it

--- a/partiql-eval/src/eval/expr/base_table.rs
+++ b/partiql-eval/src/eval/expr/base_table.rs
@@ -24,9 +24,10 @@ impl EvalExpr for EvalFnBaseTableExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         let args = self
             .args

--- a/partiql-eval/src/eval/expr/base_table.rs
+++ b/partiql-eval/src/eval/expr/base_table.rs
@@ -4,9 +4,10 @@ use itertools::Itertools;
 use partiql_catalog::table_fn::BaseTableExpr;
 
 use partiql_value::Value::Missing;
-use partiql_value::{Bag, Tuple, Value};
+use partiql_value::{Bag, Value};
 
 use partiql_catalog::extension::ExtensionResultError;
+use partiql_value::datum::RefTupleView;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
@@ -19,9 +20,9 @@ pub(crate) struct EvalFnBaseTableExpr {
 
 impl EvalExpr for EvalFnBaseTableExpr {
     #[inline]
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where

--- a/partiql-eval/src/eval/expr/control_flow.rs
+++ b/partiql-eval/src/eval/expr/control_flow.rs
@@ -1,7 +1,8 @@
 use crate::eval::expr::EvalExpr;
 use crate::eval::EvalContext;
 
-use partiql_value::{Tuple, Value};
+use partiql_value::datum::RefTupleView;
+use partiql_value::Value;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
@@ -13,9 +14,9 @@ pub(crate) struct EvalSearchedCaseExpr {
 }
 
 impl EvalExpr for EvalSearchedCaseExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where

--- a/partiql-eval/src/eval/expr/control_flow.rs
+++ b/partiql-eval/src/eval/expr/control_flow.rs
@@ -6,7 +6,7 @@ use partiql_value::Value;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
-/// Represents a searched case operator, e.g. CASE [ WHEN <expr> THEN <expr> ]... [ ELSE <expr> ] END.
+/// Represents a searched case operator, e.g. CASE [ WHEN <expr> THEN <expr> ]... [ ELSE<expr> ] END.
 #[derive(Debug)]
 pub(crate) struct EvalSearchedCaseExpr {
     pub(crate) cases: Vec<(Box<dyn EvalExpr>, Box<dyn EvalExpr>)>,
@@ -18,9 +18,10 @@ impl EvalExpr for EvalSearchedCaseExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         for (when_expr, then_expr) in &self.cases {
             let when_expr_evaluated = when_expr.evaluate(bindings, ctx);

--- a/partiql-eval/src/eval/expr/control_flow.rs
+++ b/partiql-eval/src/eval/expr/control_flow.rs
@@ -17,7 +17,7 @@ impl EvalExpr for EvalSearchedCaseExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/expr/data_types.rs
+++ b/partiql-eval/src/eval/expr/data_types.rs
@@ -24,7 +24,7 @@ impl EvalExpr for EvalTupleExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -64,7 +64,7 @@ impl EvalExpr for EvalListExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -90,7 +90,7 @@ impl EvalExpr for EvalBagExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -117,7 +117,7 @@ impl EvalExpr for EvalIsTypeExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/expr/data_types.rs
+++ b/partiql-eval/src/eval/expr/data_types.rs
@@ -25,9 +25,10 @@ impl EvalExpr for EvalTupleExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         let tuple = self
             .attrs
@@ -64,9 +65,10 @@ impl EvalExpr for EvalListExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         let values = self
             .elements
@@ -89,9 +91,10 @@ impl EvalExpr for EvalBagExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         let values = self
             .elements
@@ -115,9 +118,10 @@ impl EvalExpr for EvalIsTypeExpr {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         let expr = self.expr.evaluate(bindings, ctx);
         let result = match (&self.is_type, expr.category()) {

--- a/partiql-eval/src/eval/expr/data_types.rs
+++ b/partiql-eval/src/eval/expr/data_types.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 
 use partiql_logical::Type;
-use partiql_value::datum::{DatumCategory, DatumCategoryRef};
+use partiql_value::datum::{DatumCategory, DatumCategoryRef, RefTupleView};
 use std::ops::Not;
 
 /// Represents an evaluation operator for Tuple expressions such as `{t1.a: t1.b * 2}` in
@@ -21,9 +21,9 @@ pub(crate) struct EvalTupleExpr {
 }
 
 impl EvalExpr for EvalTupleExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where
@@ -60,9 +60,9 @@ pub(crate) struct EvalListExpr {
 }
 
 impl EvalExpr for EvalListExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where
@@ -85,9 +85,9 @@ pub(crate) struct EvalBagExpr {
 }
 
 impl EvalExpr for EvalBagExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where
@@ -111,9 +111,9 @@ pub(crate) struct EvalIsTypeExpr {
 }
 
 impl EvalExpr for EvalIsTypeExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -38,9 +38,10 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         type Check<const STRICT: bool> = DefaultArgChecker<STRICT, PropagateMissing<true>>;
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -37,7 +37,7 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -54,7 +54,7 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
             ctx,
         ) {
             ControlFlow::Break(v) => Cow::Owned(v),
-            ControlFlow::Continue(args) => match self.plan.evaluate(&args, ctx.as_session()) {
+            ControlFlow::Continue(args) => match self.plan.evaluate(&args, ctx) {
                 Ok(v) => v,
                 Err(e) => {
                     ctx.add_error(EvaluationError::ExtensionResultError(e));

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -6,7 +6,7 @@ use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;
 
 use partiql_types::PartiqlNoIdShapeBuilder;
-use partiql_value::{Tuple, Value};
+use partiql_value::Value;
 
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -14,6 +14,7 @@ use std::fmt::Debug;
 use crate::error::EvaluationError;
 use partiql_catalog::call_defs::ScalarFnCallSpec;
 use partiql_catalog::scalar_fn::ScalarFnExpr;
+use partiql_value::datum::RefTupleView;
 use std::ops::ControlFlow;
 
 impl BindEvalExpr for ScalarFnCallSpec {
@@ -33,9 +34,9 @@ pub(crate) struct EvalExprFnScalar<const STRICT: bool> {
 }
 
 impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where

--- a/partiql-eval/src/eval/expr/graph_match.rs
+++ b/partiql-eval/src/eval/expr/graph_match.rs
@@ -57,6 +57,7 @@ mod tests {
     use partiql_catalog::context::SystemContext;
     use partiql_common::pretty::ToPretty;
     use partiql_logical::graph::bind_name::FreshBinder;
+    use partiql_value::datum::DatumTupleRef;
     use partiql_value::{tuple, BindingsName, DateTime, Value};
 
     impl<GT: GraphTypes> From<PathMatch<GT>> for PathPatternMatch<GT> {
@@ -156,6 +157,7 @@ mod tests {
             .expect("graph match bind");
 
         let bindings = tuple![("graph", graph())];
+        let bindings = DatumTupleRef::Tuple(&bindings);
         let ctx = context();
         let res = eval.evaluate(&bindings, &ctx);
         let expected = crate::test_value::parse_partiql_value_str(expected);

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -24,28 +24,21 @@ pub(crate) use operators::*;
 
 use crate::eval::EvalContext;
 
-use partiql_value::datum::DatumLowerError;
-use partiql_value::{Tuple, Value};
+use partiql_value::datum::{DatumLowerError, RefTupleView};
+use partiql_value::Value;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use thiserror::Error;
 
 /// A trait for expressions that require evaluation, e.g. `a + b` or `c > 2`.
 pub trait EvalExpr: Debug {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a Tuple,
+        bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where
         'c: 'a;
-
-    fn evaluate_owned<'a, 'c>(&'a self, bindings: Tuple, ctx: &'c dyn EvalContext<'c>) -> Value
-    where
-        'c: 'a,
-    {
-        self.evaluate(&bindings, ctx).into_owned()
-    }
 }
 
 #[derive(Error, Debug)]

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -35,7 +35,7 @@ pub trait EvalExpr: Debug {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/expr/mod.rs
+++ b/partiql-eval/src/eval/expr/mod.rs
@@ -36,9 +36,10 @@ pub trait EvalExpr: Debug {
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
         ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+    ) -> Cow<'o, Value>
     where
-        'c: 'a;
+        'c: 'a,
+        'a: 'o;
 }
 
 #[derive(Error, Debug)]

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -54,11 +54,12 @@ impl BindEvalExpr for EvalLitExpr {
 impl EvalExpr for EvalLitExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
-        _bindings: &'a dyn RefTupleView<'a, Value>,
-        _ctx: &'c dyn EvalContext<'c>,
-    ) -> Cow<'a, Value>
+        bindings: &'a dyn RefTupleView<'a, Value>,
+        ctx: &'c dyn EvalContext<'c>,
+    ) -> Cow<'o, Value>
     where
         'c: 'a,
+        'a: 'o,
     {
         Cow::Borrowed(&self.val)
     }

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -54,8 +54,8 @@ impl BindEvalExpr for EvalLitExpr {
 impl EvalExpr for EvalLitExpr {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        _bindings: &'a dyn RefTupleView<'a, Value>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -69,7 +69,7 @@ impl ExecuteEvalExpr<0> for Value {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         _args: [Cow<'a, Value>; 0],
-        _ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'a, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/eval/expr/operators.rs
+++ b/partiql-eval/src/eval/expr/operators.rs
@@ -12,14 +12,16 @@ use partiql_types::{
     ShapeBuilderExtensions,
 };
 use partiql_value::Value::{Boolean, Missing, Null};
-use partiql_value::{BinaryAnd, Comparable, EqualityValue, NullableEq, NullableOrd, Tuple, Value};
+use partiql_value::{BinaryAnd, Comparable, EqualityValue, NullableEq, NullableOrd, Value};
 
 use std::borrow::{Borrow, Cow};
 use std::fmt::{Debug, Formatter};
 
 use std::marker::PhantomData;
 
-use partiql_value::datum::{DatumCategory, DatumCategoryRef, SequenceDatum, TupleDatum};
+use partiql_value::datum::{
+    DatumCategory, DatumCategoryRef, RefTupleView, SequenceDatum, TupleDatum,
+};
 use std::ops::ControlFlow;
 
 /// Represents a literal in (sub)query, e.g. `1` in `a + 1`.
@@ -50,9 +52,9 @@ impl BindEvalExpr for EvalLitExpr {
 }
 
 impl EvalExpr for EvalLitExpr {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
-        _bindings: &'a Tuple,
+        _bindings: &'a dyn RefTupleView<'a, Value>,
         _ctx: &'c dyn EvalContext<'c>,
     ) -> Cow<'a, Value>
     where
@@ -63,7 +65,7 @@ impl EvalExpr for EvalLitExpr {
 }
 
 impl ExecuteEvalExpr<0> for Value {
-    fn evaluate<'a, 'c>(
+    fn evaluate<'a, 'c, 'o>(
         &'a self,
         _args: [Cow<'a, Value>; 0],
         _ctx: &'c dyn EvalContext<'c>,

--- a/partiql-eval/src/eval/expr/path.rs
+++ b/partiql-eval/src/eval/expr/path.rs
@@ -6,7 +6,6 @@ use crate::eval::EvalContext;
 use partiql_value::Value::Missing;
 use partiql_value::{BindingsName, Value};
 
-use partiql_catalog::context::Bindings;
 use partiql_value::datum::{
     DatumCategory, DatumCategoryOwned, DatumCategoryRef, OwnedSequenceView, OwnedTupleView,
     RefSequenceView, RefTupleView,
@@ -87,7 +86,7 @@ impl EvalPathComponent {
         &'a self,
         value: &'a Value,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Option<Cow<'a, Value>>
     where
         'c: 'a,
@@ -112,7 +111,7 @@ impl EvalPathComponent {
         &'a self,
         value: Value,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Option<Cow<'a, Value>>
     where
         'c: 'a,
@@ -139,7 +138,7 @@ impl EvalExpr for EvalPath {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -167,7 +166,7 @@ impl EvalExpr for EvalDynamicLookup {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -204,11 +203,6 @@ impl BindEvalExpr for EvalVarRef {
     }
 }
 
-#[inline]
-fn borrow_or_missing(value: Option<&Value>) -> Cow<'_, Value> {
-    value.map_or_else(|| Cow::Owned(Missing), Cow::Borrowed)
-}
-
 /// Represents a local variable reference in a (sub)query, e.g. `b` in `SELECT t.b as a FROM T as t`.
 #[derive(Clone)]
 pub(crate) struct EvalLocalVarRef {
@@ -219,7 +213,7 @@ impl EvalExpr for EvalLocalVarRef {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
         bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        _ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,
@@ -259,8 +253,8 @@ impl Debug for EvalGlobalVarRef {
 impl EvalExpr for EvalGlobalVarRef {
     fn evaluate<'a, 'c, 'o>(
         &'a self,
-        bindings: &'a dyn RefTupleView<'a, Value>,
-        ctx: &'c dyn EvalContext<'c>,
+        _bindings: &'a dyn RefTupleView<'a, Value>,
+        ctx: &'c dyn EvalContext,
     ) -> Cow<'o, Value>
     where
         'c: 'a,

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -33,12 +33,12 @@ mod tests {
     fn evaluate(logical: LogicalPlan<BindingsOp>, bindings: MapBindings<Value>) -> Value {
         let catalog = PartiqlCatalog::default();
         let mut planner = plan::EvaluatorPlanner::new(EvaluationMode::Permissive, &catalog);
-        let mut plan = planner.compile(&logical).expect("Expect no plan error");
+        let plan = planner.compile(&logical).expect("Expect no plan error");
         let sys = SystemContext {
             now: DateTime::from_system_now_utc(),
         };
         let ctx = BasicContext::new(bindings, sys);
-        if let Ok(out) = plan.execute_mut(&ctx) {
+        if let Ok(out) = plan.execute(&ctx) {
             out.result
         } else {
             Missing
@@ -2261,7 +2261,7 @@ mod tests {
             };
             let ctx = BasicContext::new(p0, sys);
 
-            let mut scan = EvalScan::new_with_at_key(
+            let scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
                     name: BindingsName::CaseInsensitive("someOrderedTable".to_string().into()),
                 }),
@@ -2290,7 +2290,7 @@ mod tests {
             };
             let ctx = BasicContext::new(p0, sys);
 
-            let mut scan = EvalScan::new_with_at_key(
+            let scan = EvalScan::new_with_at_key(
                 Box::new(EvalGlobalVarRef {
                     name: BindingsName::CaseInsensitive("someUnorderedTable".to_string().into()),
                 }),
@@ -2330,7 +2330,7 @@ mod tests {
                     EvalPathComponent::Key(BindingsName::CaseInsensitive("a".into())),
                 ],
             };
-            let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");
+            let scan = EvalScan::new(Box::new(path_to_scalar), "x");
 
             let sys = SystemContext {
                 now: DateTime::from_system_now_utc(),
@@ -2358,7 +2358,7 @@ mod tests {
                     EvalPathComponent::Key(BindingsName::CaseInsensitive("c".into())),
                 ],
             };
-            let mut scan = EvalScan::new(Box::new(path_to_scalar), "x");
+            let scan = EvalScan::new(Box::new(path_to_scalar), "x");
 
             let sys = SystemContext {
                 now: DateTime::from_system_now_utc(),
@@ -2390,7 +2390,7 @@ mod tests {
             let mut p0: MapBindings<Value> = MapBindings::default();
             p0.insert("justATuple", just_a_tuple().into());
 
-            let mut unpivot = EvalUnpivot::new(
+            let unpivot = EvalUnpivot::new(
                 Box::new(EvalGlobalVarRef {
                     name: BindingsName::CaseInsensitive("justATuple".to_string().into()),
                 }),
@@ -2417,7 +2417,7 @@ mod tests {
             let mut p0: MapBindings<Value> = MapBindings::default();
             p0.insert("nonTuple", Value::from(1));
 
-            let mut unpivot = EvalUnpivot::new(
+            let unpivot = EvalUnpivot::new(
                 Box::new(EvalGlobalVarRef {
                     name: BindingsName::CaseInsensitive("nonTuple".to_string().into()),
                 }),

--- a/partiql-eval/src/lib.rs
+++ b/partiql-eval/src/lib.rs
@@ -2269,7 +2269,7 @@ mod tests {
                 "y",
             );
 
-            let res = scan.evaluate(&ctx);
+            let res = scan.evaluate([None, None], &ctx);
 
             // <<{ y: 0, x:  { b: 0, a: 0 } },  { x:  { b: 1, a: 1 }, y: 1 }>>
             let expected = bag![
@@ -2298,7 +2298,7 @@ mod tests {
                 "y",
             );
 
-            let res = scan.evaluate(&ctx);
+            let res = scan.evaluate([None, None], &ctx);
 
             // <<{ y: MISSING, x:  { b: 0, a: 0 } },  { x:  { b: 1, a: 1 }, y: MISSING }>>
             let expected = bag![
@@ -2336,7 +2336,7 @@ mod tests {
                 now: DateTime::from_system_now_utc(),
             };
             let ctx = BasicContext::new(p0, sys);
-            let scan_res = scan.evaluate(&ctx);
+            let scan_res = scan.evaluate([None, None], &ctx);
 
             let expected = bag![tuple![("x", 0)]];
             assert_eq!(Value::Bag(Box::new(expected)), scan_res);
@@ -2364,7 +2364,7 @@ mod tests {
                 now: DateTime::from_system_now_utc(),
             };
             let ctx = BasicContext::new(p0, sys);
-            let res = scan.evaluate(&ctx);
+            let res = scan.evaluate([None, None], &ctx);
 
             let expected = bag![tuple![("x", value::Value::Missing)]];
             assert_eq!(Value::Bag(Box::new(expected)), res);
@@ -2402,7 +2402,7 @@ mod tests {
                 now: DateTime::from_system_now_utc(),
             };
             let ctx = BasicContext::new(p0, sys);
-            let res = unpivot.evaluate(&ctx);
+            let res = unpivot.evaluate([None, None], &ctx);
 
             let expected = bag![
                 tuple![("symbol", "tdc"), ("price", 31.06)],
@@ -2429,7 +2429,7 @@ mod tests {
                 now: DateTime::from_system_now_utc(),
             };
             let ctx = BasicContext::new(p0, sys);
-            let res = unpivot.evaluate(&ctx);
+            let res = unpivot.evaluate([None, None], &ctx);
 
             let expected = bag![tuple![("x", 1), ("y", "_1")]];
             assert_eq!(Value::Bag(Box::new(expected)), res);

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -212,7 +212,7 @@ impl<'c> EvaluatorPlanner<'c> {
                 eval::evaluable::EvalHaving::new(self.plan_value::<{ STRICT }>(expr)),
             ),
             BindingsOp::Distinct => Box::new(eval::evaluable::EvalDistinct::new()),
-            BindingsOp::Sink => Box::new(eval::evaluable::EvalSink { input: None }),
+            BindingsOp::Sink => Box::new(eval::evaluable::EvalSink {}),
             BindingsOp::Pivot(logical::Pivot { key, value }) => {
                 Box::new(eval::evaluable::EvalPivot::new(
                     self.plan_value::<{ STRICT }>(key),
@@ -328,13 +328,12 @@ impl<'c> EvaluatorPlanner<'c> {
                         EvalOrderBySortCondition { expr, spec }
                     })
                     .collect_vec();
-                Box::new(EvalOrderBy { cmp, input: None })
+                Box::new(EvalOrderBy { cmp })
             }
             BindingsOp::LimitOffset(logical::LimitOffset { limit, offset }) => {
                 Box::new(eval::evaluable::EvalLimitOffset {
                     limit: limit.as_ref().map(|e| self.plan_value::<{ STRICT }>(e)),
                     offset: offset.as_ref().map(|e| self.plan_value::<{ STRICT }>(e)),
-                    input: None,
                 })
             }
             BindingsOp::BagOp(logical::BagOp {

--- a/partiql-eval/src/test_value.rs
+++ b/partiql-eval/src/test_value.rs
@@ -68,7 +68,7 @@ pub(crate) fn parse_partiql_value_str(contents: &str) -> Value {
         .expect("Expect successful parse");
     let planner = partiql_logical_planner::LogicalPlanner::new(&catalog);
     let logical = planner.lower(&parsed).expect("logical plan");
-    let mut evaluator = EvaluatorPlanner::new(EvaluationMode::Permissive, &catalog)
+    let evaluator = EvaluatorPlanner::new(EvaluationMode::Permissive, &catalog)
         .compile(&logical)
         .expect("Expect no plan error");
     let sys = SystemContext {
@@ -76,7 +76,7 @@ pub(crate) fn parse_partiql_value_str(contents: &str) -> Value {
     };
     let bindings = MapBindings::default();
     let ctx = BasicContext::new(bindings, sys);
-    let value = evaluator.execute_mut(&ctx).expect("evaluation to succeed");
+    let value = evaluator.execute(&ctx).expect("evaluation to succeed");
 
     value.result
 }

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -102,6 +102,15 @@ impl Value {
 
     #[inline]
     #[must_use]
+    pub fn as_datum_tuple_ref(&self) -> DatumTupleRef<'_> {
+        match self.category() {
+            DatumCategoryRef::Tuple(t) => t,
+            _ => DatumTupleRef::CoercedValue(1, self),
+        }
+    }
+
+    #[inline]
+    #[must_use]
     pub fn as_tuple_ref(&self) -> Cow<'_, Tuple> {
         match self.category() {
             DatumCategoryRef::Tuple(t) => match t {
@@ -111,6 +120,8 @@ impl Value {
                     Cow::Owned(Value::Tuple(t)) => Cow::Owned(*t),
                     _ => unreachable!(),
                 },
+                DatumTupleRef::Empty => todo!(),
+                DatumTupleRef::CoercedValue(_, _) => todo!(),
             },
             _ => Cow::Owned(self.coerce_to_tuple()),
         }
@@ -124,6 +135,10 @@ impl Value {
             DatumCategoryRef::Tuple(t) => match t {
                 DatumTupleRef::Tuple(t) => BindingIter::Tuple(t.pairs()),
                 DatumTupleRef::Dynamic(_) => unreachable!(),
+                DatumTupleRef::Empty => BindingIter::Empty,
+                DatumTupleRef::CoercedValue(_, value) => {
+                    BindingIter::Single(std::iter::once(value))
+                }
             },
             _ => BindingIter::Single(std::iter::once(self)),
         }

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use rust_decimal::Decimal as RustDecimal;
 
 use crate::variant::Variant;
-use crate::{Bag, BindingIntoIter, BindingIter, DateTime, Graph, List, Tuple};
+use crate::{tuple, Bag, BindingIntoIter, BindingIter, DateTime, Graph, List, Tuple};
 use rust_decimal::prelude::FromPrimitive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -120,8 +120,8 @@ impl Value {
                     Cow::Owned(Value::Tuple(t)) => Cow::Owned(*t),
                     _ => unreachable!(),
                 },
-                DatumTupleRef::Empty => todo!(),
-                DatumTupleRef::CoercedValue(_, _) => todo!(),
+                DatumTupleRef::Empty => Cow::Owned(tuple![]),
+                DatumTupleRef::CoercedValue(_, v) => Cow::Owned(tuple![("_1", v.clone())]),
             },
             _ => Cow::Owned(self.coerce_to_tuple()),
         }

--- a/partiql/benches/bench_agg.rs
+++ b/partiql/benches/bench_agg.rs
@@ -48,12 +48,12 @@ fn plan(catalog: &dyn Catalog, logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
         .expect("Expect no plan error")
 }
 #[inline]
-pub(crate) fn evaluate(mut eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
+pub(crate) fn evaluate(eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    if let Ok(out) = eval.execute_mut(&ctx) {
+    if let Ok(out) = eval.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/partiql/benches/bench_eval_multi_like.rs
+++ b/partiql/benches/bench_eval_multi_like.rs
@@ -346,12 +346,12 @@ fn plan(catalog: &dyn Catalog, logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
         .expect("Expect no plan error")
 }
 #[inline]
-pub(crate) fn evaluate(mut eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
+pub(crate) fn evaluate(eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    if let Ok(out) = eval.execute_mut(&ctx) {
+    if let Ok(out) = eval.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/partiql/benches/bench_join.rs
+++ b/partiql/benches/bench_join.rs
@@ -45,12 +45,12 @@ fn plan(catalog: &dyn Catalog, logical: &LogicalPlan<BindingsOp>) -> EvalPlan {
         .expect("Expect no plan error")
 }
 #[inline]
-pub(crate) fn evaluate(mut eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
+pub(crate) fn evaluate(eval: EvalPlan, bindings: MapBindings<Value>) -> Value {
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    if let Ok(out) = eval.execute_mut(&ctx) {
+    if let Ok(out) = eval.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/partiql/src/lib.rs
+++ b/partiql/src/lib.rs
@@ -83,12 +83,12 @@ mod tests {
 
     #[track_caller]
     #[inline]
-    fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
+    fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
         let sys = SystemContext {
             now: DateTime::from_system_now_utc(),
         };
         let ctx = BasicContext::new(bindings, sys);
-        plan.execute_mut(&ctx)
+        plan.execute(&ctx)
     }
 
     #[track_caller]

--- a/partiql/src/subquery_tests.rs
+++ b/partiql/src/subquery_tests.rs
@@ -24,7 +24,7 @@ mod tests {
         let mut planner =
             partiql_eval::plan::EvaluatorPlanner::new(EvaluationMode::Strict, catalog);
 
-        let mut plan = planner.compile(logical).expect("Expect no plan error");
+        let plan = planner.compile(logical).expect("Expect no plan error");
 
         let sys = SystemContext {
             now: DateTime::from_system_now_utc(),
@@ -33,7 +33,7 @@ mod tests {
         for (k, v) in ctx_vals {
             ctx.user.insert(k.as_str().into(), *v);
         }
-        plan.execute_mut(&ctx).map(|out| out.result)
+        plan.execute(&ctx).map(|out| out.result)
     }
 
     #[test]

--- a/partiql/tests/common.rs
+++ b/partiql/tests/common.rs
@@ -98,12 +98,12 @@ pub fn compile(
 #[allow(dead_code)]
 #[track_caller]
 #[inline]
-pub fn evaluate(mut plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
+pub fn evaluate(plan: EvalPlan, bindings: MapBindings<Value>) -> EvalResult {
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
     };
     let ctx = BasicContext::new(bindings, sys);
-    plan.execute_mut(&ctx)
+    plan.execute(&ctx)
 }
 
 #[allow(dead_code)]

--- a/partiql/tests/extension_error.rs
+++ b/partiql/tests/extension_error.rs
@@ -88,7 +88,7 @@ impl BaseTableExpr for EvalTestCtxTable {
     fn evaluate<'a, 'c, 'o>(
         &self,
         args: &[Cow<'_, Value>],
-        _ctx: &'c dyn SessionContext<'c>,
+        _ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {

--- a/partiql/tests/extension_error.rs
+++ b/partiql/tests/extension_error.rs
@@ -129,7 +129,7 @@ pub(crate) fn evaluate(
 ) -> Result<Evaluated, EvalErr> {
     let mut planner = partiql_eval::plan::EvaluatorPlanner::new(mode, catalog);
 
-    let mut plan = planner.compile(&logical).expect("Expect no plan error");
+    let plan = planner.compile(&logical).expect("Expect no plan error");
 
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
@@ -139,7 +139,7 @@ pub(crate) fn evaluate(
         ctx.user.insert(k.as_str().into(), *v);
     }
 
-    plan.execute_mut(&ctx)
+    plan.execute(&ctx)
 }
 
 #[test]

--- a/partiql/tests/extension_error.rs
+++ b/partiql/tests/extension_error.rs
@@ -85,7 +85,7 @@ pub enum UserCtxError {
 pub(crate) struct EvalTestCtxTable {}
 
 impl BaseTableExpr for EvalTestCtxTable {
-    fn evaluate<'c>(
+    fn evaluate<'a, 'c, 'o>(
         &self,
         args: &[Cow<'_, Value>],
         _ctx: &'c dyn SessionContext<'c>,

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -86,7 +86,7 @@ impl BaseTableExpr for EvalTestCtxTable {
     fn evaluate<'a, 'c, 'o>(
         &self,
         args: &[Cow<'_, Value>],
-        ctx: &'c dyn SessionContext<'c>,
+        ctx: &'c dyn SessionContext,
     ) -> BaseTableExprResult<'c> {
         if let Some(arg1) = args.first() {
             match arg1.as_ref() {
@@ -104,7 +104,7 @@ impl BaseTableExpr for EvalTestCtxTable {
 }
 
 struct TestDataGen<'a> {
-    ctx: &'a dyn SessionContext<'a>,
+    ctx: &'a dyn SessionContext,
     name: String,
 }
 
@@ -131,7 +131,7 @@ impl Iterator for TestDataGen<'_> {
     }
 }
 
-fn generated_data<'a>(name: String, ctx: &'a dyn SessionContext<'a>) -> BaseTableExprResult<'a> {
+fn generated_data(name: String, ctx: &dyn SessionContext) -> BaseTableExprResult<'_> {
     Ok(Box::new(TestDataGen { ctx, name }))
 }
 

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -151,7 +151,7 @@ pub(crate) fn evaluate(
     let mut planner =
         partiql_eval::plan::EvaluatorPlanner::new(EvaluationMode::Permissive, catalog);
 
-    let mut plan = planner.compile(&logical).expect("Expect no plan error");
+    let plan = planner.compile(&logical).expect("Expect no plan error");
 
     let sys = SystemContext {
         now: DateTime::from_system_now_utc(),
@@ -160,7 +160,7 @@ pub(crate) fn evaluate(
     for (k, v) in ctx_vals {
         ctx.user.insert(k.as_str().into(), *v);
     }
-    if let Ok(out) = plan.execute_mut(&ctx) {
+    if let Ok(out) = plan.execute(&ctx) {
         out.result
     } else {
         Value::Missing

--- a/partiql/tests/user_context.rs
+++ b/partiql/tests/user_context.rs
@@ -83,7 +83,7 @@ pub enum UserCtxError {
 pub(crate) struct EvalTestCtxTable {}
 
 impl BaseTableExpr for EvalTestCtxTable {
-    fn evaluate<'c>(
+    fn evaluate<'a, 'c, 'o>(
         &self,
         args: &[Cow<'_, Value>],
         ctx: &'c dyn SessionContext<'c>,


### PR DESCRIPTION
Refactors:
- evaluation to to be non-mutable over the plan node,
- expression evaluation to use `RefTupleView` where possible,
- context types to remove lifetimes thanks to new features in rust 1.86

Cf. https://blog.rust-lang.org/2025/04/03/Rust-1.86.0/#trait-upcasting

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
