### PR TITLE
Remove SExp from AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *BREAKING* Heavily refactors evaluation to be stateless
 - *BREAKING* Heavily refactors Session & Evaluation Contexts to no longer require lifetime parameters
+- *BREAKING* partiql-ast: Removes disused `Sexp` AST node
 
 ### Added
 

--- a/extension/partiql-extension-visualize/src/ast_to_dot.rs
+++ b/extension/partiql-extension-visualize/src/ast_to_dot.rs
@@ -159,7 +159,6 @@ impl ToDot<ast::Expr> for AstToDot {
             Expr::Struct(_) => todo!(),
             Expr::Bag(_) => todo!(),
             Expr::List(_) => todo!(),
-            Expr::Sexp(_) => todo!(),
             Expr::Path(p) => self.to_dot(&mut expr_subgraph, p),
             Expr::Call(c) => self.to_dot(&mut expr_subgraph, c),
             Expr::CallAgg(c) => self.to_dot(&mut expr_subgraph, c),

--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -406,7 +406,6 @@ pub enum Expr {
     Struct(AstNode<Struct>),
     Bag(AstNode<Bag>),
     List(AstNode<List>),
-    Sexp(AstNode<Sexp>),
     /// Other expression types
     Path(AstNode<Path>),
     Call(AstNode<Call>),
@@ -644,12 +643,6 @@ pub struct Bag {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct List {
-    pub values: Vec<Box<Expr>>,
-}
-
-#[derive(Visit, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Sexp {
     pub values: Vec<Box<Expr>>,
 }
 
@@ -940,7 +933,6 @@ pub enum Type {
     StructType,
     TupleType,
     ListType,
-    SexpType,
     BagType,
     AnyType,
 

--- a/partiql-ast/src/pretty/mod.rs
+++ b/partiql-ast/src/pretty/mod.rs
@@ -315,7 +315,6 @@ impl PrettyDoc for Expr {
             Expr::Struct(inner) => inner.pretty_doc(arena),
             Expr::Bag(inner) => inner.pretty_doc(arena),
             Expr::List(inner) => inner.pretty_doc(arena),
-            Expr::Sexp(inner) => inner.pretty_doc(arena),
             Expr::Path(inner) => inner.pretty_doc(arena),
             Expr::Call(inner) => inner.pretty_doc(arena),
             Expr::CallAgg(inner) => inner.pretty_doc(arena),
@@ -444,7 +443,6 @@ impl PrettyDoc for Type {
             Type::StructType => arena.text("STRUCT"),
             Type::TupleType => arena.text("TUPLE"),
             Type::ListType => arena.text("LIST"),
-            Type::SexpType => arena.text("SEXP"),
             Type::BagType => arena.text("BAG"),
             Type::AnyType => arena.text("ANY"),
         }
@@ -782,17 +780,6 @@ impl PrettyDoc for ListLit {
         A: Clone,
     {
         pretty_seq(&self.values, "[", "]", ",", PRETTY_INDENT_MINOR_NEST, arena)
-    }
-}
-
-impl PrettyDoc for Sexp {
-    fn pretty_doc<'b, D, A>(&'b self, _arena: &'b D) -> DocBuilder<'b, D, A>
-    where
-        D: DocAllocator<'b, A>,
-        D::Doc: Clone,
-        A: Clone,
-    {
-        todo!("remove s-expr from ast?");
     }
 }
 

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -399,12 +399,6 @@ pub trait Visitor<'ast> {
     fn exit_list(&mut self, _list: &'ast ast::List) -> Traverse {
         Traverse::Continue
     }
-    fn enter_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Traverse {
-        Traverse::Continue
-    }
-    fn exit_sexp(&mut self, _sexp: &'ast ast::Sexp) -> Traverse {
-        Traverse::Continue
-    }
     fn enter_call(&mut self, _call: &'ast ast::Call) -> Traverse {
         Traverse::Continue
     }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -10,7 +10,7 @@ use partiql_ast::ast::{
     GroupingStrategy, Insert, InsertValue, Item, Join, JoinKind, JoinSpec, Like, List, Lit,
     NullOrderingSpec, OnConflict, OrderByExpr, OrderingSpec, Path, PathStep, ProjectExpr,
     Projection, ProjectionKind, Query, QuerySet, Remove, SearchedCase, Select, Set, SetQuantifier,
-    Sexp, SimpleCase, SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
+    SimpleCase, SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
 };
 use partiql_ast::visit::{Traverse, Visit, Visitor};
 use partiql_logical as logical;
@@ -1263,15 +1263,6 @@ impl<'ast> Visitor<'ast> for AstToLogical<'_> {
         let elements = self.exit_env();
         self.push_vexpr(ValueExpr::ListExpr(ListExpr { elements }));
         Traverse::Continue
-    }
-
-    fn enter_sexp(&mut self, _sexp: &'ast Sexp) -> Traverse {
-        self.enter_env();
-        Traverse::Continue
-    }
-
-    fn exit_sexp(&mut self, _sexp: &'ast Sexp) -> Traverse {
-        not_yet_implemented_fault!(self, "Sexp".to_string());
     }
 
     fn enter_call_agg(&mut self, _call_agg: &'ast CallAgg) -> Traverse {


### PR DESCRIPTION
Minor cleanup to remove no-longer used s-expression AST nodes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
