### PR TITLE
Add AST source NodeId to lower's expression stack

### DIFF
--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -11,7 +11,7 @@
 use rust_decimal::Decimal as RustDecimal;
 
 use partiql_ast_macros::Visit;
-use partiql_common::node::NodeId;
+use partiql_common::node::{IdAnnotated, NodeId};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -33,6 +33,12 @@ impl<T> Deref for AstNode<T> {
 
     fn deref(&self) -> &T {
         &self.node
+    }
+}
+
+impl<T> IdAnnotated<NodeId> for AstNode<T> {
+    fn id(&self) -> NodeId {
+        self.id
     }
 }
 
@@ -419,6 +425,30 @@ pub enum Expr {
     /// Indicates an error occurred during query processing; The exact error details are out of band of the AST
     #[visit(skip)]
     Error,
+}
+
+impl IdAnnotated<NodeId> for Expr {
+    fn id(&self) -> NodeId {
+        match self {
+            Expr::Lit(l) => l.id(),
+            Expr::VarRef(v) => v.id(),
+            Expr::BinOp(b) => b.id(),
+            Expr::UniOp(u) => u.id(),
+            Expr::Like(l) => l.id(),
+            Expr::Between(l) => l.id(),
+            Expr::In(l) => l.id(),
+            Expr::Case(c) => c.id(),
+            Expr::Struct(s) => s.id(),
+            Expr::Bag(b) => b.id(),
+            Expr::List(l) => l.id(),
+            Expr::Path(p) => p.id(),
+            Expr::Call(c) => c.id(),
+            Expr::CallAgg(c) => c.id(),
+            Expr::GraphMatch(g) => g.id(),
+            Expr::Query(q) => q.id(),
+            Expr::Error => unreachable!(),
+        }
+    }
 }
 
 /// `Lit` is mostly inspired by SQL-92 Literals standard and `PartiQL` specification.

--- a/partiql-common/src/node.rs
+++ b/partiql-common/src/node.rs
@@ -6,9 +6,19 @@ use serde::{Deserialize, Serialize};
 
 pub type NodeMap<T> = IndexMap<NodeId, T>;
 
+pub trait IdAnnotated<T: Copy> {
+    fn id(&self) -> T;
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeId(pub u32);
+
+impl IdAnnotated<NodeId> for NodeId {
+    fn id(&self) -> NodeId {
+        *self
+    }
+}
 
 #[derive(Debug)]
 /// Auto-incrementing [`NodeIdGenerator`]

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -213,8 +213,8 @@ pub(crate) fn pass_eval(
         Ok(v) => {
             assert_eq!(&TestValue::from(v), expected)
         },
-        Err(TestError::Parse(_)) => {
-            panic!("When evaluating (mode = {mode:#?}) `{statement}`, unexpected parse error")
+        Err(TestError::Parse(err)) => {
+            panic!("When evaluating (mode = {mode:#?}) `{statement}`, unexpected parse error: {err:#?}")
         }
         Err(TestError::Lower(err)) => panic!("When evaluating (mode = {mode:#?}) `{statement}`, unexpected lowering error `{err:?}`"),
         Err(TestError::Plan(err)) => panic!("When evaluating (mode = {mode:#?}) `{statement}`, unexpected planning error `{err:?}`"),


### PR DESCRIPTION
This PR:
- stores the AST node id of the source of the expression along with the transformed expression during lowering
- adds a helper to remove an expression from the set of expressions by the id of the source

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
