### PR TITLE
Add value filtering of nodes and edges

### DIFF
--- a/partiql-eval/src/eval/evaluable.rs
+++ b/partiql-eval/src/eval/evaluable.rs
@@ -53,7 +53,7 @@ pub trait Evaluable: Debug {
 }
 
 /// Represents an evaluation `Scan` operator; `Scan` operator scans the given bindings from its
-/// input and and the environment and outputs a bag of binding tuples for tuples/values matching the
+/// input and the environment and outputs a bag of binding tuples for tuples/values matching the
 /// scan `expr`, e.g. an SQL expression `table1` in SQL expression `FROM table1`.
 pub(crate) struct EvalScan {
     pub(crate) expr: Box<dyn EvalExpr>,

--- a/partiql-eval/src/eval/expr/graph_match.rs
+++ b/partiql-eval/src/eval/expr/graph_match.rs
@@ -28,18 +28,20 @@ impl BindEvalExpr for EvalGraphMatch {
     ) -> Result<Box<dyn EvalExpr>, BindError> {
         // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
         let mut bld = PartiqlNoIdShapeBuilder::default();
-        UnaryValueExpr::create_typed::<{ STRICT }, _>([type_graph!(bld)], args, move |value| {
-            match value {
+        UnaryValueExpr::create_typed_with_ctx::<{ STRICT }, _>(
+            [type_graph!(bld)],
+            args,
+            move |value, ctx| match value {
                 Value::Graph(graph) => match graph.as_ref() {
                     Graph::Simple(g) => {
                         let engine = SimpleGraphEngine::new(g.clone());
                         let ge = GraphEvaluator::new(engine);
-                        ge.eval(&self.pattern)
+                        ge.eval(&self.pattern, ctx)
                     }
                 },
                 _ => Missing,
-            }
-        })
+            },
+        )
     }
 }
 

--- a/partiql-eval/src/eval/graph/engine.rs
+++ b/partiql-eval/src/eval/graph/engine.rs
@@ -1,9 +1,11 @@
 use crate::eval::graph::plan::{
-    DirectionFilter, GraphPlanConvert, NodeFilter, StepFilter, TripleFilter,
+    BindSpec, DirectionFilter, GraphPlanConvert, NodeFilter, NodeMatch, PathMatch, StepFilter,
+    TripleFilter,
 };
 use crate::eval::graph::result::Triple;
 use crate::eval::graph::string_graph::StringGraphTypes;
 use crate::eval::graph::types::GraphTypes;
+use crate::eval::EvalContext;
 use partiql_value::Value;
 
 /// A graph 'engine'; Exposes scanning, node access, and plan conversion to a target graph.
@@ -17,8 +19,8 @@ pub trait GraphEngine<GT: GraphTypes>:
 
 /// A trait to scan paths and nodes for a graph.
 pub trait GraphScan<GT: GraphTypes> {
-    fn scan(&self, spec: &StepFilter<GT>) -> Vec<Triple<GT>>;
-    fn get(&self, spec: &NodeFilter<GT>) -> Vec<GT::NodeId>;
+    fn scan(&self, spec: &PathMatch<GT>, ctx: &dyn EvalContext) -> Vec<Triple<GT>>;
+    fn get(&self, spec: &NodeMatch<GT>, ctx: &dyn EvalContext) -> Vec<GT::NodeId>;
 }
 
 /// A trait to retrieve named nodes and edges for a graph.
@@ -29,14 +31,39 @@ pub trait GraphAccess<GT: GraphTypes> {
 
 /// A train to scan paths and nodes for a triple-based graph.
 pub trait TripleScan<GT: GraphTypes> {
-    fn scan_directed_from_to(&self, spec: &TripleFilter<GT>) -> impl Iterator<Item = Triple<GT>>;
+    fn scan_directed_from_to(
+        &self,
+        binders: &(BindSpec<GT>, BindSpec<GT>, BindSpec<GT>),
+        spec: &TripleFilter<GT>,
+        ctx: &dyn EvalContext,
+    ) -> impl Iterator<Item = Triple<GT>>;
 
-    fn scan_directed_to_from(&self, spec: &TripleFilter<GT>) -> impl Iterator<Item = Triple<GT>>;
+    fn scan_directed_to_from(
+        &self,
+        binders: &(BindSpec<GT>, BindSpec<GT>, BindSpec<GT>),
+        spec: &TripleFilter<GT>,
+        ctx: &dyn EvalContext,
+    ) -> impl Iterator<Item = Triple<GT>>;
 
-    fn scan_directed_both(&self, spec: &TripleFilter<GT>) -> impl Iterator<Item = Triple<GT>>;
+    fn scan_directed_both(
+        &self,
+        binders: &(BindSpec<GT>, BindSpec<GT>, BindSpec<GT>),
+        spec: &TripleFilter<GT>,
+        ctx: &dyn EvalContext,
+    ) -> impl Iterator<Item = Triple<GT>>;
 
-    fn scan_undirected(&self, spec: &TripleFilter<GT>) -> impl Iterator<Item = Triple<GT>>;
-    fn get(&self, spec: &NodeFilter<GT>) -> Vec<GT::NodeId>;
+    fn scan_undirected(
+        &self,
+        binders: &(BindSpec<GT>, BindSpec<GT>, BindSpec<GT>),
+        spec: &TripleFilter<GT>,
+        ctx: &dyn EvalContext,
+    ) -> impl Iterator<Item = Triple<GT>>;
+    fn get(
+        &self,
+        binder: &BindSpec<GT>,
+        spec: &NodeFilter<GT>,
+        ctx: &dyn EvalContext,
+    ) -> Vec<GT::NodeId>;
 }
 
 impl<T, GT> GraphScan<GT> for T
@@ -44,8 +71,11 @@ where
     GT: GraphTypes,
     T: TripleScan<GT>,
 {
-    fn scan(&self, spec: &StepFilter<GT>) -> Vec<Triple<GT>> {
-        let StepFilter { dir, triple } = spec;
+    fn scan(&self, spec: &PathMatch<GT>, ctx: &dyn EvalContext) -> Vec<Triple<GT>> {
+        let PathMatch {
+            binders,
+            spec: StepFilter { dir, triple },
+        } = spec;
         let (to_from, undirected, from_to) = match dir {
             DirectionFilter::L => (true, false, false),
             DirectionFilter::U => (false, true, false),
@@ -58,17 +88,17 @@ where
 
         let mut result = vec![];
         if undirected {
-            result.extend(self.scan_undirected(triple));
+            result.extend(self.scan_undirected(binders, triple, ctx));
         }
         match (from_to, to_from) {
             (true, true) => {
-                result.extend(self.scan_directed_both(triple));
+                result.extend(self.scan_directed_both(binders, triple, ctx));
             }
             (true, false) => {
-                result.extend(self.scan_directed_from_to(triple));
+                result.extend(self.scan_directed_from_to(binders, triple, ctx));
             }
             (false, true) => {
-                result.extend(self.scan_directed_to_from(triple));
+                result.extend(self.scan_directed_to_from(binders, triple, ctx));
             }
             (false, false) => {}
         }
@@ -76,7 +106,8 @@ where
         result
     }
 
-    fn get(&self, spec: &NodeFilter<GT>) -> Vec<GT::NodeId> {
-        TripleScan::get(self, spec)
+    fn get(&self, spec: &NodeMatch<GT>, ctx: &dyn EvalContext) -> Vec<GT::NodeId> {
+        let NodeMatch { binder, spec } = spec;
+        TripleScan::get(self, binder, spec, ctx)
     }
 }

--- a/partiql-eval/src/eval/graph/plan.rs
+++ b/partiql-eval/src/eval/graph/plan.rs
@@ -1,6 +1,8 @@
+use crate::eval::expr::EvalExpr;
 use crate::eval::graph::types::GraphTypes;
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::rc::Rc;
 
 /// A plan specification for an edge's direction filtering.
 #[allow(clippy::upper_case_acronyms)]
@@ -32,11 +34,11 @@ pub enum LabelFilter<GT: GraphTypes> {
 }
 
 /// A plan specification for value filtering.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum ValueFilter {
     #[default]
     Always,
-    // TODO other variant for, e.g., `WHERE` filters
+    Filter(Rc<dyn EvalExpr>),
 }
 
 /// A plan specification for node label & value filtering.
@@ -131,13 +133,13 @@ pub trait GraphPlanConvert<In: GraphTypes, Out: GraphTypes>: Debug {
     fn convert_node_filter(&self, node: &NodeFilter<In>) -> NodeFilter<Out> {
         NodeFilter {
             label: self.convert_label_filter(&node.label),
-            filter: node.filter,
+            filter: node.filter.clone(),
         }
     }
     fn convert_edge_filter(&self, edge: &EdgeFilter<In>) -> EdgeFilter<Out> {
         EdgeFilter {
             label: self.convert_label_filter(&edge.label),
-            filter: edge.filter,
+            filter: edge.filter.clone(),
         }
     }
     fn convert_node_match(&self, node: &NodeMatch<In>) -> NodeMatch<Out> {

--- a/partiql-logical/src/graph/mod.rs
+++ b/partiql-logical/src/graph/mod.rs
@@ -1,3 +1,4 @@
+use crate::ValueExpr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
@@ -42,7 +43,7 @@ pub enum LabelFilter {
 pub enum ValueFilter {
     #[default]
     Always,
-    // TODO other variant for, e.g., `WHERE` filters
+    Filter(Box<ValueExpr>),
 }
 
 /// A plan specification for node label & value filtering.

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -122,6 +122,7 @@ impl Value {
                 },
                 DatumTupleRef::Empty => Cow::Owned(tuple![]),
                 DatumTupleRef::CoercedValue(_, v) => Cow::Owned(tuple![("_1", v.clone())]),
+                DatumTupleRef::SingleKey(k, v) => Cow::Owned(tuple![(k.as_ref(), v.clone())]),
             },
             _ => Cow::Owned(self.coerce_to_tuple()),
         }
@@ -139,6 +140,7 @@ impl Value {
                 DatumTupleRef::CoercedValue(_, value) => {
                     BindingIter::Single(std::iter::once(value))
                 }
+                DatumTupleRef::SingleKey(_, value) => BindingIter::Single(std::iter::once(value)),
             },
             _ => BindingIter::Single(std::iter::once(self)),
         }


### PR DESCRIPTION
Lower & evaluate `WHERE` filters on node and edge pattern matches in a `GRAPH MATCH` expression.

This involves plumbing some context and bind-name information through to the graph evaluator that was not previously necessary.

See new tests that are expected to pass: 

https://github.com/partiql/partiql-tests/pull/136

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
