### PR TITLE
Add value filtering of paths and subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added lowering and evaluation of graph `MATCH` label negation, conjunction, and disjunction
+- Added lowering and evaluation of graph `MATCH` `WHERE` clauses
 
 ### Removed
 

--- a/partiql-eval/src/eval/graph/result.rs
+++ b/partiql-eval/src/eval/graph/result.rs
@@ -1,4 +1,4 @@
-use crate::eval::graph::plan::{BindSpec, NodeMatch, PathMatch};
+use crate::eval::graph::plan::{BindSpec, NodeMatch, TripleStepMatch};
 use crate::eval::graph::types::GraphTypes;
 use fxhash::FxBuildHasher;
 use indexmap::IndexSet;
@@ -12,10 +12,10 @@ pub struct NodeBinding<GT: GraphTypes> {
     pub binding: Vec<GT::NodeId>,
 }
 
-/// A result of matching against a [`PathMatch`]
+/// A result of matching against a [`TripleStepMatch`]
 #[derive(Debug, Clone)]
 pub struct PathBinding<GT: GraphTypes> {
-    pub matcher: PathMatch<GT>,
+    pub matcher: TripleStepMatch<GT>,
     pub bindings: Vec<Triple<GT>>,
 }
 

--- a/partiql-logical-planner/src/graph.rs
+++ b/partiql-logical-planner/src/graph.rs
@@ -159,13 +159,20 @@ impl GraphToLogical {
         debug_assert!(!paths.is_empty());
         // TODO handle expansion as described in 6.3 of https://arxiv.org/pdf/2112.06217
         // TODO   this will enable alternation and quantifiers
+
         // first, add disjuncts for alternation/union
+        // TODO
+
         // second, fix iterations for quantifiers
+        // TODO
+
         // third, clean-up; delete duplicated anonymous edges and merge
         let mut paths = paths.into_iter();
         let mut path_patterns = vec![paths.next().unwrap()];
         for path in paths {
             if path.head.binder.is_anon() {
+                // if the head of this path has an anonymous binder, it was synthetically inserted;
+                //   Drop the head and merge its tail into the previous path.
                 let current_path = path_patterns.last_mut().unwrap();
                 current_path.tail.extend(path.tail);
                 current_path.filter.extend(path.filter);

--- a/partiql-logical-planner/src/graph.rs
+++ b/partiql-logical-planner/src/graph.rs
@@ -6,7 +6,8 @@ use partiql_common::node::{IdAnnotated, NodeId};
 use partiql_logical::graph::bind_name::FreshBinder;
 use partiql_logical::graph::{
     BindSpec, DirectionFilter, EdgeFilter, EdgeMatch, LabelFilter, NodeFilter, NodeMatch,
-    PathMatch, PathPattern, PathPatternMatch, StepFilter, TripleFilter, ValueFilter,
+    PathPattern, PathPatternMatch, StepFilter, TripleFilter, TripleMatch, TripleSeriesMatch,
+    ValueFilter,
 };
 use partiql_logical::ValueExpr;
 use std::mem::take;
@@ -20,14 +21,14 @@ macro_rules! not_yet_implemented_result {
 
 #[derive(Debug)]
 pub(crate) struct GraphToLogical {
-    graph_id: FreshBinder,
+    id_generator: FreshBinder,
     env: Vec<(NodeId, ValueExpr)>,
 }
 
 impl GraphToLogical {
     pub fn new(env: Vec<(NodeId, ValueExpr)>) -> Self {
         Self {
-            graph_id: Default::default(),
+            id_generator: Default::default(),
             env,
         }
     }
@@ -37,8 +38,7 @@ impl GraphToLogical {
 enum MatchElement {
     Node(NodeMatch),
     Edge(DirectionFilter, EdgeMatch),
-    #[allow(dead_code)] // TODO with sub-graphs in graph MATCH
-    Pattern(Vec<MatchElement>),
+    Pattern(Vec<MatchElement>, ValueFilter),
 }
 
 #[derive(Debug)]
@@ -57,6 +57,8 @@ impl<'a> Normalize<'a> {
         }
     }
 
+    /// 'Normalize' a series of node/edge/subpath match elements into a rigid pattern of
+    ///    (<node> ( <edge> <node>)*)
     pub fn normalize(mut self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
         self.do_normalize(elements)
     }
@@ -88,7 +90,11 @@ impl<'a> Normalize<'a> {
             .map(|(d, e, n)| (d, e, n.unwrap()))
             .collect::<Vec<_>>();
 
-        Some(PathPattern { head, tail })
+        Some(PathPattern {
+            head,
+            tail,
+            filter: ValueFilter::Always,
+        })
     }
 
     fn do_normalize(&mut self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
@@ -120,9 +126,20 @@ impl<'a> Normalize<'a> {
                     }
                     self.tail.push((d, e, None));
                 }
-                MatchElement::Pattern(p) => {
+                MatchElement::Pattern(p, filter) => {
                     path_patterns.extend(self.flush());
-                    path_patterns.extend(self.do_normalize(p)?);
+                    let mut normalized_pattern = self.do_normalize(p)?;
+                    match filter {
+                        ValueFilter::Always => {
+                            path_patterns.extend(normalized_pattern);
+                        }
+                        filter @ ValueFilter::Filter(_) => {
+                            debug_assert!(normalized_pattern.len() == 1);
+                            let mut normalized_pattern = normalized_pattern.remove(0);
+                            normalized_pattern.filter = filter;
+                            path_patterns.push(normalized_pattern);
+                        }
+                    }
                 }
             }
         }
@@ -135,25 +152,41 @@ impl<'a> Normalize<'a> {
 
 impl GraphToLogical {
     fn normalize(&mut self, elements: Vec<MatchElement>) -> Result<Vec<PathPattern>, String> {
-        Normalize::new(&self.graph_id).normalize(elements)
+        Normalize::new(&self.id_generator).normalize(elements)
     }
 
     fn expand(&mut self, paths: Vec<PathPattern>) -> Result<Vec<PathPattern>, String> {
+        debug_assert!(!paths.is_empty());
         // TODO handle expansion as described in 6.3 of https://arxiv.org/pdf/2112.06217
         // TODO   this will enable alternation and quantifiers
-        Ok(paths)
+        // first, add disjuncts for alternation/union
+        // second, fix iterations for quantifiers
+        // third, clean-up; delete duplicated anonymous edges and merge
+        let mut paths = paths.into_iter();
+        let mut path_patterns = vec![paths.next().unwrap()];
+        for path in paths {
+            if path.head.binder.is_anon() {
+                let current_path = path_patterns.last_mut().unwrap();
+                current_path.tail.extend(path.tail);
+                current_path.filter.extend(path.filter);
+            } else {
+                path_patterns.push(path);
+            }
+        }
+
+        Ok(path_patterns)
     }
 
-    fn plan(&mut self, paths: Vec<PathPattern>) -> Result<PathPatternMatch, String> {
+    fn plan(&mut self, mut paths: Vec<PathPattern>) -> Result<PathPatternMatch, String> {
         debug_assert!(paths.len() == 1);
-        let path_pattern = &paths[0];
+        let path_pattern = paths.remove(0);
         // pattern at this point should be a node, or a series of node-[edge-node]+
         debug_assert!((1 + (2 * path_pattern.tail.len())).is_odd());
 
         if path_pattern.tail.is_empty() {
             Ok(PathPatternMatch::Node(path_pattern.head.clone()))
         } else {
-            let mut paths = vec![];
+            let mut triples = vec![];
             let mut head = &path_pattern.head;
             for (d, e, n) in &path_pattern.tail {
                 let binders = (head.binder.clone(), e.binder.clone(), n.binder.clone());
@@ -165,14 +198,22 @@ impl GraphToLogical {
                         rhs: n.spec.clone(),
                     },
                 };
-                paths.push(PathPatternMatch::Match(PathMatch { binders, spec }));
+                triples.push(TripleMatch {
+                    binders,
+                    spec,
+                    filter: ValueFilter::Always,
+                });
                 head = n;
             }
-            if paths.len() == 1 {
-                let path = paths.into_iter().next().unwrap();
-                Ok(path)
+            if triples.len() == 1 {
+                let mut triple = triples.remove(0);
+                triple.filter.extend(path_pattern.filter);
+                Ok(PathPatternMatch::Match(triple))
             } else {
-                Ok(PathPatternMatch::Concat(paths))
+                Ok(PathPatternMatch::Concat(vec![TripleSeriesMatch {
+                    triples,
+                    filter: path_pattern.filter,
+                }]))
             }
         }
     }
@@ -208,9 +249,16 @@ impl GraphToLogical {
         if pattern.keep.is_some() {
             not_yet_implemented_result!("MATCH expression KEEP is not yet supported.");
         }
-        if pattern.where_clause.is_some() {
-            not_yet_implemented_result!("MATCH expression pattern WHERE is not yet supported.");
-        }
+
+        let filter = if let Some(expr) = &pattern.where_clause {
+            let expr = extract_vexpr_by_id(&mut self.env, expr.id());
+            if expr.is_none() {
+                not_yet_implemented_result!("Internal error: expression not found.");
+            }
+            ValueFilter::Filter(vec![expr.unwrap()])
+        } else {
+            ValueFilter::Always
+        };
 
         if pattern.patterns.len() != 1 {
             not_yet_implemented_result!(
@@ -219,7 +267,9 @@ impl GraphToLogical {
         }
 
         let first_pattern = &pattern.patterns[0];
-        self.plan_graph_path_pattern(first_pattern)
+        let planned_first_pattern = self.plan_graph_path_pattern(first_pattern)?;
+
+        Ok(vec![MatchElement::Pattern(planned_first_pattern, filter)])
     }
 
     fn plan_graph_path_pattern(
@@ -246,11 +296,19 @@ impl GraphToLogical {
         if pattern.variable.is_some() {
             not_yet_implemented_result!("MATCH pattern path variables are not yet supported.");
         }
-        if pattern.where_clause.is_some() {
-            not_yet_implemented_result!("MATCH expression subpath WHERE is not yet supported.");
-        }
 
-        self.plan_graph_match_path_pattern(&pattern.path)
+        let filter = if let Some(expr) = &pattern.where_clause {
+            let expr = extract_vexpr_by_id(&mut self.env, expr.id());
+            if expr.is_none() {
+                not_yet_implemented_result!("Internal error: expression not found.");
+            }
+            ValueFilter::Filter(vec![expr.unwrap()])
+        } else {
+            ValueFilter::Always
+        };
+
+        let elts = self.plan_graph_match_path_pattern(&pattern.path)?;
+        Ok(vec![MatchElement::Pattern(elts, filter)])
     }
 
     fn plan_graph_match_path_pattern(
@@ -293,7 +351,7 @@ impl GraphToLogical {
         node: &ast::GraphMatchNode,
     ) -> Result<Vec<MatchElement>, String> {
         let binder = match &node.variable {
-            None => self.graph_id.node(),
+            None => self.id_generator.node(),
             Some(v) => v.value.clone(),
         };
         let label = plan_graph_pattern_label(node.label.as_deref())?;
@@ -302,7 +360,7 @@ impl GraphToLogical {
             if expr.is_none() {
                 not_yet_implemented_result!("Internal error: expression not found.");
             }
-            ValueFilter::Filter(Box::new(expr.unwrap()))
+            ValueFilter::Filter(vec![expr.unwrap()])
         } else {
             ValueFilter::Always
         };
@@ -327,7 +385,7 @@ impl GraphToLogical {
             ast::GraphMatchDirection::LeftOrUndirectedOrRight => DirectionFilter::LUR,
         };
         let binder = match &edge.variable {
-            None => self.graph_id.node(),
+            None => self.id_generator.edge(),
             Some(v) => v.value.clone(),
         };
         let label = plan_graph_pattern_label(edge.label.as_deref())?;
@@ -336,7 +394,7 @@ impl GraphToLogical {
             if expr.is_none() {
                 not_yet_implemented_result!("Internal error: expression not found.");
             }
-            ValueFilter::Filter(Box::new(expr.unwrap()))
+            ValueFilter::Filter(vec![expr.unwrap()])
         } else {
             ValueFilter::Always
         };

--- a/partiql-logical/src/graph/bind_name.rs
+++ b/partiql-logical/src/graph/bind_name.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::Ordering::Relaxed;
 const ANON_PREFIX: char = '\u{FDD0}';
 
 pub trait BindNameExt {
+    /// `true` if a bind name is 'anonymous'. Anonymous bind names are stand-ins in places
+    /// where the graph match expression doesn't explicitly include a bind name variable.
     fn is_anon(&self) -> bool;
 }
 
@@ -31,10 +33,14 @@ impl Default for FreshBinder {
 }
 
 impl FreshBinder {
+    /// Creates an 'anonymous' bind name for a node. Anonymous bind names are stand-ins in places
+    /// where the graph match expression doesn't explicitly include a bind name variable.
     pub fn node(&self) -> String {
         format!("{ANON_PREFIX}🞎{}", self.node.fetch_add(1, Relaxed))
     }
 
+    /// Creates an 'anonymous' bind name for an edge. Anonymous bind names are stand-ins in places
+    /// where the graph match expression doesn't explicitly include a bind name variable.
     pub fn edge(&self) -> String {
         format!("{ANON_PREFIX}⁃{}", self.edge.fetch_add(1, Relaxed))
     }

--- a/partiql-logical/src/graph/bind_name.rs
+++ b/partiql-logical/src/graph/bind_name.rs
@@ -18,7 +18,6 @@ impl<S: AsRef<str>> BindNameExt for S {
 #[derive(Debug)]
 pub struct FreshBinder {
     node: AtomicU32,
-
     edge: AtomicU32,
 }
 

--- a/partiql-logical/src/graph/mod.rs
+++ b/partiql-logical/src/graph/mod.rs
@@ -1,3 +1,4 @@
+use crate::graph::bind_name::BindNameExt;
 use crate::ValueExpr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,12 @@ pub enum DirectionFilter {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BindSpec(pub String);
 
+impl BindSpec {
+    pub fn is_anon(&self) -> bool {
+        self.0.is_anon()
+    }
+}
+
 /// A plan specification for label filtering.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -43,7 +50,28 @@ pub enum LabelFilter {
 pub enum ValueFilter {
     #[default]
     Always,
-    Filter(Box<ValueExpr>),
+    Filter(Vec<ValueExpr>),
+}
+
+impl ValueFilter {
+    pub fn and(mut self, other: ValueFilter) -> ValueFilter {
+        self.extend(other);
+        self
+    }
+
+    pub fn extend(&mut self, other: ValueFilter) {
+        match other {
+            ValueFilter::Always => {}
+            ValueFilter::Filter(rhs) => match self {
+                ValueFilter::Always => {
+                    *self = ValueFilter::Filter(rhs);
+                }
+                ValueFilter::Filter(lhs) => {
+                    lhs.extend(rhs);
+                }
+            },
+        }
+    }
 }
 
 /// A plan specification for node label & value filtering.
@@ -85,6 +113,7 @@ pub struct StepFilter {
 pub struct PathPattern {
     pub head: NodeMatch,
     pub tail: Vec<(DirectionFilter, EdgeMatch, NodeMatch)>,
+    pub filter: ValueFilter,
 }
 
 /// A plan specification for node matching.
@@ -106,16 +135,25 @@ pub struct EdgeMatch {
 /// A plan specification for path (i.e., node, edge, node) matching.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PathMatch {
+pub struct TripleMatch {
     pub binders: (BindSpec, BindSpec, BindSpec),
     pub spec: StepFilter,
+    pub filter: ValueFilter,
 }
 
-/// A plan specification for path patterns (i.e., sequences of [`PathMatch`]s) matching.
+/// A plan specification for path (i.e., node, edge, node) matching.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TripleSeriesMatch {
+    pub triples: Vec<TripleMatch>,
+    pub filter: ValueFilter,
+}
+
+/// A plan specification for path patterns (i.e., sequences of [`TripleMatch`]s) matching.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PathPatternMatch {
     Node(NodeMatch),
-    Match(PathMatch),
-    Concat(Vec<PathPatternMatch>),
+    Match(TripleMatch),
+    Concat(Vec<TripleSeriesMatch>),
 }

--- a/partiql-logical/src/graph/mod.rs
+++ b/partiql-logical/src/graph/mod.rs
@@ -26,6 +26,8 @@ pub enum DirectionFilter {
 pub struct BindSpec(pub String);
 
 impl BindSpec {
+    /// `true` if a bind name is 'anonymous'. Anonymous bind names are stand-ins in places
+    /// where the graph match expression doesn't explicitly include a bind name variable.
     pub fn is_anon(&self) -> bool {
         self.0.is_anon()
     }

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -123,6 +123,9 @@ impl Value {
                 DatumTupleRef::Empty => Cow::Owned(tuple![]),
                 DatumTupleRef::CoercedValue(_, v) => Cow::Owned(tuple![("_1", v.clone())]),
                 DatumTupleRef::SingleKey(k, v) => Cow::Owned(tuple![(k.as_ref(), v.clone())]),
+                DatumTupleRef::Bindings(map) => Cow::Owned(Tuple::from_iter(
+                    map.iter().map(|(k, &v)| (k.as_ref(), v.clone())),
+                )),
             },
             _ => Cow::Owned(self.coerce_to_tuple()),
         }
@@ -141,6 +144,10 @@ impl Value {
                     BindingIter::Single(std::iter::once(value))
                 }
                 DatumTupleRef::SingleKey(_, value) => BindingIter::Single(std::iter::once(value)),
+                DatumTupleRef::Bindings(map) => {
+                    let entries = map.iter().map(|(k, &v)| (Some(k.as_ref()), v));
+                    BindingIter::Dynamic(Box::new(entries))
+                }
             },
             _ => BindingIter::Single(std::iter::once(self)),
         }


### PR DESCRIPTION
Lower & evaluate `WHERE` filters on paths and subpaths in `GRAPH MATCH` expression.

This involves plumbing some context and bind-name information through to the graph evaluator that was not previously necessary.

See new tests that are expected to pass: 

https://github.com/partiql/partiql-tests/pull/137
https://github.com/partiql/partiql-tests/pull/138

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
