### PR TITLE
Lower & evaluate Graph Match Modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added lowering and evaluation of graph `MATCH` label negation, conjunction, and disjunction
 - Added lowering and evaluation of graph `MATCH` `WHERE` clauses
+- Added lowering and evaluation of graph `MATCH` modes (i.e., `WALK`, `TRAIL`, `ACYCLIC`, `SIMPLE`)
 
 ### Removed
 

--- a/partiql-ast/src/ast/graph.rs
+++ b/partiql-ast/src/ast/graph.rs
@@ -24,7 +24,7 @@ pub struct GraphMatch {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GraphPattern {
     #[visit(skip)]
-    pub mode: Option<GraphMatchMode>,
+    pub match_mode: Option<GraphMatchMode>,
     pub patterns: Vec<AstNode<GraphPathPattern>>,
     #[visit(skip)]
     pub keep: Option<GraphPathPrefix>,
@@ -34,7 +34,9 @@ pub struct GraphPattern {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GraphMatchMode {
+    /// Edges are not allowed to bind to more than one edge variable in a path
     DifferentEdges,
+    /// No restrictions on binding of edges or vertices
     RepeatableElements,
 }
 
@@ -89,8 +91,9 @@ pub enum GraphTableExport {
 }
 
 /// The direction of an edge
+///
 /// | Orientation               | Edge pattern | Abbreviation |
-/// |---------------------------+--------------+--------------|
+/// |---------------------------|--------------|--------------|
 /// | Pointing left             | <−[ spec ]−  | <−           |
 /// | Undirected                | ~[ spec ]~   | ~            |
 /// | Pointing right            | −[ spec ]−>  | −>           |
@@ -118,20 +121,17 @@ pub struct GraphMatchQuantifier {
     pub upper: Option<NonZeroU32>,
 }
 
-/// A path mode
-/// | Keyword        | Description
-/// |----------------+--------------
-/// | WALK           |
-/// | TRAIL          | No repeated edges.
-/// | ACYCLIC        | No repeated nodes.
-/// | SIMPLE         | No repeated nodes, except that the ﬁrst and last nodes may be the same.
-
+/// Filters paths. Options other than `Walk` ensure a finite number of matches.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GraphPathMode {
+    /// No filtering of edges/nodes.
     Walk,
+    /// No repeated edges.
     Trail,
+    /// No repeated nodes.
     Acyclic,
+    /// No repeated nodes, except that the ﬁrst and last nodes may be the same.
     Simple,
 }
 

--- a/partiql-ast/src/pretty/graph.rs
+++ b/partiql-ast/src/pretty/graph.rs
@@ -184,14 +184,14 @@ impl PrettyDoc for GraphPattern {
         A: Clone,
     {
         let GraphPattern {
-            mode,
+            match_mode,
             patterns,
             keep,
             where_clause,
         } = &self;
         let patterns = pretty_list(patterns, PRETTY_INDENT_MINOR_NEST, arena).group();
         let parts = [
-            mode.as_ref().map(|inner| inner.pretty_doc(arena)),
+            match_mode.as_ref().map(|inner| inner.pretty_doc(arena)),
             Some(patterns),
             keep.as_ref().map(|keep| {
                 arena.intersperse([arena.text("KEEP"), keep.pretty_doc(arena)], arena.space())

--- a/partiql-eval/src/eval/expr/graph_match.rs
+++ b/partiql-eval/src/eval/expr/graph_match.rs
@@ -49,7 +49,7 @@ impl BindEvalExpr for EvalGraphMatch {
 mod tests {
     use crate::eval::expr::{BindEvalExpr, EvalGlobalVarRef, EvalGraphMatch};
     use crate::eval::graph::plan::{
-        BindSpec, DirectionFilter, EdgeFilter, LabelFilter, NodeFilter, NodeMatch,
+        BindSpec, DirectionFilter, EdgeFilter, LabelFilter, NodeFilter, NodeMatch, PathMode,
         PathPatternMatch, TripleFilter, TripleStepFilter, TripleStepMatch, ValueFilter,
     };
     use crate::eval::graph::string_graph::StringGraphTypes;
@@ -202,6 +202,7 @@ mod tests {
             binders,
             spec,
             filter: ValueFilter::Always,
+            path_mode: PathMode::Walk,
         };
 
         test_graph(matcher.into(), "<<  >>")
@@ -230,6 +231,7 @@ mod tests {
             binders,
             spec,
             filter: ValueFilter::Always,
+            path_mode: PathMode::Walk,
         };
 
         test_graph(matcher.into(), "<<  >>")
@@ -256,6 +258,7 @@ mod tests {
             binders,
             spec,
             filter: ValueFilter::Always,
+            path_mode: PathMode::Walk,
         };
 
         test_graph(matcher.into(), "<< {'x': 2, 'z': 1.2, 'y': 1} >>")
@@ -284,6 +287,7 @@ mod tests {
             binders,
             spec,
             filter: ValueFilter::Always,
+            path_mode: PathMode::Walk,
         };
 
         test_graph(matcher.into(), "<< {  }, {  } >>")
@@ -312,6 +316,7 @@ mod tests {
             binders,
             spec,
             filter: ValueFilter::Always,
+            path_mode: PathMode::Walk,
         };
 
         test_graph(
@@ -340,6 +345,7 @@ mod tests {
             binders,
             spec,
             filter: Default::default(),
+            path_mode: PathMode::Walk,
         };
 
         let binders = (
@@ -359,6 +365,7 @@ mod tests {
             binders,
             spec,
             filter: Default::default(),
+            path_mode: PathMode::Walk,
         };
 
         let pattern_match = PathPatternMatch::Concat(
@@ -367,6 +374,7 @@ mod tests {
                 PathPatternMatch::Match(matcher2),
             ],
             Default::default(),
+            PathMode::Walk,
         );
 
         test_graph(
@@ -397,6 +405,7 @@ mod tests {
             binders,
             spec,
             filter: Default::default(),
+            path_mode: PathMode::Walk,
         };
 
         let binders = (
@@ -416,6 +425,7 @@ mod tests {
             binders,
             spec,
             filter: Default::default(),
+            path_mode: PathMode::Walk,
         };
 
         let pattern_match = PathPatternMatch::Concat(
@@ -424,6 +434,7 @@ mod tests {
                 PathPatternMatch::Match(matcher2),
             ],
             Default::default(),
+            PathMode::Walk,
         );
         test_graph(
             pattern_match,

--- a/partiql-eval/src/eval/graph/evaluator.rs
+++ b/partiql-eval/src/eval/graph/evaluator.rs
@@ -8,7 +8,7 @@ use fxhash::FxBuildHasher;
 use indexmap::IndexMap;
 use itertools::Itertools;
 
-use crate::eval::graph::plan::{BindSpec, NodeMatch, PathPatternMatch, TripleStepMatch};
+use crate::eval::graph::plan::{BindSpec, NodeMatch, PathMode, PathPatternMatch, TripleStepMatch};
 use crate::eval::graph::string_graph::StringGraphTypes;
 use crate::eval::graph::types::GraphTypes;
 use crate::eval::EvalContext;
@@ -119,11 +119,11 @@ impl<GT: GraphTypes, G: GraphEngine<GT>> GraphEvaluator<GT, G> {
 
                 PathBinding { matcher, bindings }.into()
             }
-            PathPatternMatch::Concat(ms, filter) => {
+            PathPatternMatch::Concat(ms, filter, path_mode) => {
                 let PathPatternBinding { binders, bindings } = ms
                     .into_iter()
                     .map(|p| self.eval_path_pattern(p, ctx))
-                    .tree_reduce(|l, r| join_bindings(l, r))
+                    .tree_reduce(|l, r| join_bindings(l, r, path_mode))
                     .unwrap();
 
                 let bindings = self
@@ -140,48 +140,98 @@ impl<GT: GraphTypes, G: GraphEngine<GT>> GraphEvaluator<GT, G> {
 fn join_bindings<GT: GraphTypes>(
     l: PathPatternBinding<GT>,
     r: PathPatternBinding<GT>,
+    path_mode: PathMode,
 ) -> PathPatternBinding<GT> {
     debug_assert!(l.binders.len() >= 3);
     debug_assert!(r.binders.len() >= 3);
-    debug_assert_eq!(l.bindings.len(), l.bindings.len());
-    debug_assert_eq!(r.bindings.len(), r.bindings.len());
     debug_assert_eq!(l.binders.last().unwrap(), r.binders.first().unwrap());
 
     let lcount = l.binders.len();
+    // map l binders to integers and dedup
+    //  e.g., (a) -[b]-> (c) - (a) - (z) will result in something like [(a, 0), (b,1), (c,2), (z, 4)]
     let lidx = l
         .binders
         .iter()
         .enumerate()
         .dedup_by(|(_, x), (_, y)| x == y);
+
+    // map r binders to integers and dedup, starting at 1+ highest lidx
+    //  e.g., (q) -[r]-> (s) - (q) - (z) will result in something like [(q, 5), (r,6), (s,7), (z, 9)]
     let ridx = r
         .binders
         .iter()
         .enumerate()
         .map(|(i, e)| (i + lcount, e))
         .dedup_by(|(_, x), (_, y)| x == y);
+
+    // collect the integers corresponding to matching binders on which to join from lidx & ridx.
+    // e.g., In the above examples, both l & r mention `z` (at `4` and `9`, respectively): vec![(4, 9)]
     let join_on: Vec<_> = lidx
         .cartesian_product(ridx)
         .filter_map(|((li, le), (ri, re))| (le == re).then_some((li, ri)))
         .collect();
 
-    let binders = l
-        .binders
-        .into_iter()
-        .chain(r.binders.into_iter().skip(1))
-        .collect();
+    // cartesian product of all bindings in l with all bindings in r (cross join)
+    let lbindings = l.bindings.iter();
+    let rbindings = r.bindings.iter();
+    let bindings = lbindings.cartesian_product(rbindings);
 
-    let bindings = l
-        .bindings
-        .iter()
-        .cartesian_product(r.bindings.iter())
+    let bindings = bindings
         .filter_map(|(l, r)| {
             let elts = l.iter().chain(r.iter()).collect::<Vec<_>>();
+            // for all pairs that are expected to match, filter out those that do not
             for (i, j) in &join_on {
                 if elts[*i] != elts[*j] {
                     return None;
                 }
             }
 
+            // Filter according to path_mode
+            let path_elts = l.iter().chain(r.iter().skip(1));
+            match path_mode {
+                PathMode::Walk => (),
+                PathMode::Trail => {
+                    // No duplicate edges allowed
+                    if path_elts
+                        .filter(|elt| matches!(elt, GraphElement::Edge(_)))
+                        .duplicates()
+                        .any(|_| true)
+                    {
+                        return None;
+                    }
+                }
+                PathMode::Acyclic => {
+                    // No duplicate nodes allowed
+                    if path_elts
+                        .filter(|elt| matches!(elt, GraphElement::Node(_)))
+                        .duplicates()
+                        .any(|_| true)
+                    {
+                        return None;
+                    }
+                }
+                PathMode::Simple => {
+                    // No duplicate nodes allowed except that first&last nodes in the pattern may match each other
+                    let path_elts = path_elts.collect_vec();
+                    // all elements except the first
+                    let tail = path_elts
+                        .iter()
+                        .skip(1)
+                        .filter(|elt| matches!(elt, GraphElement::Node(_)));
+                    let head = path_elts
+                        .iter()
+                        .rev()
+                        .skip(1)
+                        .rev()
+                        .filter(|elt| matches!(elt, GraphElement::Node(_)));
+
+                    if tail.duplicates().any(|_| true) || head.duplicates().any(|_| true) {
+                        return None;
+                    }
+                }
+            }
+
+            // join condition has succeeded; join l & r at l.tail.last() == r.head()
             Some(PathPatternNodes {
                 head: l.head.clone(),
                 tail: l
@@ -192,6 +242,13 @@ fn join_bindings<GT: GraphTypes>(
                     .collect(),
             })
         })
+        .collect();
+
+    // l binders followed by r tail binders (l.last() and r.first() are expected to be identical)
+    let binders: Vec<_> = l
+        .binders
+        .into_iter()
+        .chain(r.binders.into_iter().skip(1))
         .collect();
 
     PathPatternBinding { binders, bindings }

--- a/partiql-eval/src/eval/graph/simple_graph/engine.rs
+++ b/partiql-eval/src/eval/graph/simple_graph/engine.rs
@@ -133,6 +133,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
             BindSpec<SimpleGraphTypes>,
         ),
         spec: &TripleFilter<SimpleGraphTypes>,
+        allow_repeated_nodes: bool,
         filter: &ValueFilter,
         ctx: &dyn EvalContext,
     ) -> impl Iterator<Item = Triple<SimpleGraphTypes>> {
@@ -140,6 +141,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
         self.graph
             .g_dir
             .iter()
+            .filter(move |(n1, _, n2)| allow_repeated_nodes || n1 != n2)
             .map(build_triple)
             .filter(move |t| self.triple_matches(binders, spec, t, filter, ctx))
     }
@@ -152,6 +154,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
             BindSpec<SimpleGraphTypes>,
         ),
         spec: &TripleFilter<SimpleGraphTypes>,
+        allow_repeated_nodes: bool,
         filter: &ValueFilter,
         ctx: &dyn EvalContext,
     ) -> impl Iterator<Item = Triple<SimpleGraphTypes>> {
@@ -159,6 +162,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
         self.graph
             .g_dir
             .iter()
+            .filter(move |(n1, _, n2)| allow_repeated_nodes || n1 != n2)
             .map(reverse_triple)
             .filter(move |t| self.triple_matches(binders, spec, t, filter, ctx))
     }
@@ -171,6 +175,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
             BindSpec<SimpleGraphTypes>,
         ),
         spec: &TripleFilter<SimpleGraphTypes>,
+        allow_repeated_nodes: bool,
         filter: &ValueFilter,
         ctx: &dyn EvalContext,
     ) -> impl Iterator<Item = Triple<SimpleGraphTypes>> {
@@ -179,6 +184,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
         self.graph
             .g_dir
             .iter()
+            .filter(move |(n1, _, n2)| allow_repeated_nodes || n1 != n2)
             .filter(|(lhs, e, rhs)| {
                 let triple = Triple {
                     lhs: *lhs,
@@ -214,6 +220,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
             BindSpec<SimpleGraphTypes>,
         ),
         spec: &TripleFilter<SimpleGraphTypes>,
+        allow_repeated_nodes: bool,
         filter: &ValueFilter,
         ctx: &dyn EvalContext,
     ) -> impl Iterator<Item = Triple<SimpleGraphTypes>> {
@@ -222,6 +229,7 @@ impl TripleScan<SimpleGraphTypes> for SimpleGraphEngine {
         self.graph
             .g_undir
             .iter()
+            .filter(move |(n1, _, n2)| allow_repeated_nodes || n1 != n2)
             .filter(|(lhs, e, rhs)| {
                 let triple = Triple {
                     lhs: *lhs,

--- a/partiql-logical/src/graph/mod.rs
+++ b/partiql-logical/src/graph/mod.rs
@@ -20,6 +20,20 @@ pub enum DirectionFilter {
     LUR, //  -
 }
 
+/// A plan specification for a path's matching mode.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PathMode {
+    /// No filtering of edges/nodes.
+    Walk,
+    /// No repeated edges.
+    Trail,
+    /// No repeated nodes.
+    Acyclic,
+    /// No repeated nodes, except that the ﬁrst and last nodes may be the same.
+    Simple,
+}
+
 /// A plan specification for bind names.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -116,6 +130,7 @@ pub struct PathPattern {
     pub head: NodeMatch,
     pub tail: Vec<(DirectionFilter, EdgeMatch, NodeMatch)>,
     pub filter: ValueFilter,
+    pub mode: PathMode,
 }
 
 /// A plan specification for node matching.
@@ -141,6 +156,7 @@ pub struct TripleMatch {
     pub binders: (BindSpec, BindSpec, BindSpec),
     pub spec: StepFilter,
     pub filter: ValueFilter,
+    pub path_mode: PathMode,
 }
 
 /// A plan specification for path (i.e., node, edge, node) matching.
@@ -149,6 +165,7 @@ pub struct TripleMatch {
 pub struct TripleSeriesMatch {
     pub triples: Vec<TripleMatch>,
     pub filter: ValueFilter,
+    pub path_mode: PathMode,
 }
 
 /// A plan specification for path patterns (i.e., sequences of [`TripleMatch`]s) matching.
@@ -157,5 +174,5 @@ pub struct TripleSeriesMatch {
 pub enum PathPatternMatch {
     Node(NodeMatch),
     Match(TripleMatch),
-    Concat(Vec<TripleSeriesMatch>),
+    Concat(Vec<TripleSeriesMatch>, PathMode),
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -416,8 +416,8 @@ GraphReference = <GraphName>;
 // 10.4
 
 GraphPattern: ast::AstNode<ast::GraphPattern> = {
-    <lo:@L> <mode:GraphMatchMode?> <patterns:CommaSepPlus<GraphPathPattern>> <keep:GraphKeepClause?> <where_clause:GraphPatternWhereClause?> <hi:@R> => {
-        state.node(ast::GraphPattern{mode, patterns, keep, where_clause}, lo..hi)
+    <lo:@L> <match_mode:GraphMatchMode?> <patterns:CommaSepPlus<GraphPathPattern>> <keep:GraphKeepClause?> <where_clause:GraphPatternWhereClause?> <hi:@R> => {
+        state.node(ast::GraphPattern{match_mode, patterns, keep, where_clause}, lo..hi)
     },
 }
 


### PR DESCRIPTION
Lower & evaluate Graph Match Modes (`WALK`, `TRAIL`, `ACYCLIC`, `SIMPLE`) on paths and subpaths in `GRAPH MATCH` expression.

See new tests that are expected to pass: 

https://github.com/partiql/partiql-tests/pull/139

 ---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
