### PR TITLE
Clean-up some clippy and rust warnings

### DIFF
--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -417,7 +417,7 @@ pub enum Expr {
     Call(AstNode<Call>),
     CallAgg(AstNode<CallAgg>),
     /// <expr> MATCH <graph_pattern>
-    GraphMatch(AstNode<GraphMatch>),
+    GraphMatch(Box<AstNode<GraphMatch>>),
 
     /// Query, e.g. `UNION` | `EXCEPT` | `INTERSECT` | `SELECT` and their parts.
     Query(AstNode<Query>),

--- a/partiql-eval/src/plan.rs
+++ b/partiql-eval/src/plan.rs
@@ -498,8 +498,8 @@ impl<'c> EvaluatorPlanner<'c> {
 
                 ("pattern expr", expr)
             }
-            ValueExpr::GraphMatch(GraphMatchExpr { value, pattern }) => {
-                //
+            ValueExpr::GraphMatch(graph_match) => {
+                let GraphMatchExpr { value, pattern } = graph_match.as_ref();
                 let args = plan_args(&[value]);
                 let expr = match self.plan_graph_plan::<{ STRICT }>(pattern) {
                     Ok(pattern) => EvalGraphMatch::new(pattern).bind::<{ STRICT }>(args),

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -1986,10 +1986,10 @@ impl<'ast> Visitor<'ast> for AstToLogical<'_> {
                 );
                 let graph_reference = Box::new(graph_reference.unwrap());
 
-                self.push_vexpr(ValueExpr::GraphMatch(GraphMatchExpr {
+                self.push_vexpr(ValueExpr::GraphMatch(Box::new(GraphMatchExpr {
                     value: graph_reference,
                     pattern,
-                }));
+                })));
                 Traverse::Continue
             }
             Err(e) => {

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -473,7 +473,7 @@ pub enum ValueExpr {
     NullIfExpr(NullIfExpr),
     CoalesceExpr(CoalesceExpr),
     Call(CallExpr),
-    GraphMatch(GraphMatchExpr),
+    GraphMatch(Box<GraphMatchExpr>),
 }
 
 /// Represents a `PartiQL` literal value.

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -358,7 +358,7 @@ ParenGraphMatch: ast::Expr = {
 
 GraphMatch: ast::Expr = {
     <lo:@L> <expr:ExprQuery> "MATCH" <pattern:GraphPattern> <shape:GraphTableShape> <hi:@R>
-        => ast::Expr::GraphMatch(state.node(ast::GraphMatch{expr, pattern, shape}, lo..hi)),
+        => ast::Expr::GraphMatch(Box::new(state.node(ast::GraphMatch{expr, pattern, shape}, lo..hi))),
 }
 
 GraphTableShape: ast::GraphTableShape = {

--- a/partiql-value/src/value.rs
+++ b/partiql-value/src/value.rs
@@ -280,7 +280,6 @@ impl Datum<Value> for Value {
     }
 
     #[inline]
-    #[must_use]
     fn is_sequence(&self) -> bool {
         match self {
             Value::List(_) => true,
@@ -291,7 +290,6 @@ impl Datum<Value> for Value {
     }
 
     #[inline]
-    #[must_use]
     fn is_ordered(&self) -> bool {
         match self {
             Value::List(_) => true,


### PR DESCRIPTION
There are some new lints that came along with rust 1.87.
This PR addresses those.

For example:
```
warning: large size difference between variants
   --> partiql-ast/src/ast/mod.rs:398:1
    |
398 | / pub enum Expr {
399 | |     Lit(AstNode<Lit>),
    | |     ----------------- the second-largest variant contains at least 64 bytes
400 | |     /// Variable reference
401 | |     VarRef(AstNode<VarRef>),
...   |
420 | |     GraphMatch(AstNode<GraphMatch>),
    | |     ------------------------------- the largest variant contains at least 272 bytes
...   |
427 | |     Error,
428 | | }
    | |_^ the entire enum is at least 272 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
note: the lint level is defined here
   --> partiql-ast/src/lib.rs:2:9
    |
2   | #![deny(clippy::all)]
    |         ^^^^^^^^^^^
    = note: `#[warn(clippy::large_enum_variant)]` implied by `#[warn(clippy::all)]`
help: consider boxing the large fields to reduce the total size of the enum
    |
420 -     GraphMatch(AstNode<GraphMatch>),
420 +     GraphMatch(Box<AstNode<GraphMatch>>),
    |
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
