### PR TITLE
feat: implement built-in functions for VM evaluator

### DIFF
--- a/docs/VM_CONFORMANCE_PLAN.md
+++ b/docs/VM_CONFORMANCE_PLAN.md
@@ -1,0 +1,274 @@
+# VM Evaluator Conformance Plan
+
+This document tracks the gaps between the new VM evaluator (`partiql-eval/src/engine/`) and the legacy evaluator, prioritized by impact on the conformance test suite.
+
+## How to Run the Analysis
+
+```bash
+# Run VM conformance tests and capture JSON output
+cargo +nightly test --package partiql-conformance-tests \
+  --features "conformance_test, eval_vm, experimental" --release \
+  -- -Z unstable-options --format json > vm_cargo_test_results.json
+
+# The JSON is line-delimited. Each failed test has:
+# {"type":"test","event":"failed","name":"...","stdout":"<panic message>"}
+```
+
+The `stdout` field of failed tests contains the error classification:
+- `unsupported operator: Discriminant(N)` → operator not compiled (see mapping below)
+- `UnsupportedExpr("...")` → expression type not compiled
+- `UdfNotFound` or `not found` → built-in function not registered
+- `unresolved DB object` → global environment binding issue
+- `assertion ... failed` / `left == right` → ran but produced wrong result
+- `IllegalState` → internal bug
+
+### BindingsOp Discriminant Mapping
+
+| Discriminant | Operator | Status |
+|--:|:--|:--|
+| 0 | Scan | Supported |
+| 1 | Pivot | Not supported |
+| 2 | Unpivot | Not supported |
+| 3 | Filter | Supported |
+| 4 | OrderBy | Not supported |
+| 5 | LimitOffset | Supported (LIMIT only, no OFFSET) |
+| 6 | Join | Not supported |
+| 7 | BagOp (UNION/INTERSECT/EXCEPT) | Not supported |
+| 8 | Project | Supported |
+| 9 | ProjectAll | Supported |
+| 10 | ProjectValue | Supported |
+| 11 | ExprQuery | Supported |
+| 12 | Distinct | Not supported |
+| 13 | GroupBy | Not supported |
+| 14 | Having | Not supported |
+
+## Current State (2026-06-01)
+
+- **2,587 passing / 4,084 failing / 6,671 total (38.8% conformant)**
+- Previously 1,117 passing (16.7%) before built-in functions were implemented
+- Only 24 tests produce a wrong result — correctness is high when coverage exists
+- The problem is feature coverage, not logic bugs
+
+## Priority Ranking
+
+| # | Root Cause | Tests Blocked | Cumulative | Key Files |
+|--:|:--|--:|--:|:--|
+| 1 | Missing built-in functions | ~338 remaining | — | `engine/builtins.rs` (DONE for top functions) |
+| 2 | Unresolved DB objects / globals | 1,098 (19.8%) | 52.3% | `engine/compiler.rs`, `eval_vm.rs` |
+| 3 | GROUP BY operator | 688 (12.4%) | 64.7% | `engine/compiler.rs` |
+| 4 | Scan expression types | 273 (4.9%) | 69.6% | `engine/compiler.rs:813-814` |
+| 5 | Unary negation (`-x`) | 191 (3.4%) | 73.0% | `engine/expr.rs:2171` |
+| 6 | Variant/Ion literals | 162 (2.9%) | 75.9% | `engine/expr.rs:2285` |
+| 7 | LIKE (PatternMatchExpr) | 100 (1.8%) | 77.7% | `engine/expr.rs:2214` |
+| 8 | JOIN operator | 84 (1.5%) | 79.2% | `engine/compiler.rs` |
+| 9 | ORDER BY operator | 60 (1.1%) | 80.3% | `engine/compiler.rs` |
+| 10 | UNION/INTERSECT/EXCEPT (BagOp) | 59 (1.1%) | 81.4% | `engine/compiler.rs` |
+| 11 | Typed literals | 58 (1.0%) | 82.4% | `engine/expr.rs` |
+| 12 | Path traversal (PathForEach/Unpivot) | 54+50 (1.9%) | 84.3% | `engine/expr.rs` |
+| 13 | IS TYPE expression | 46 (0.8%) | 85.1% | `engine/expr.rs:2226` |
+| 14 | IllegalState bugs | 44 (0.8%) | 85.9% | Various |
+| 15 | DISTINCT operator | 34 (0.6%) | 86.5% | `engine/compiler.rs` |
+| 16 | NULLIF expression | 26 (0.5%) | 87.0% | `engine/expr.rs:2229` |
+| 17 | BETWEEN expression | 24 (0.4%) | 87.5% | `engine/expr.rs:2211` |
+| 18 | COALESCE expression | 15 (0.3%) | 87.7% | `engine/expr.rs:2232` |
+| 19 | Subquery in project | 15 (0.3%) | 88.0% | `engine/compiler.rs` |
+
+---
+
+## Task Breakdown
+
+### Task 1: Built-in Functions (~338 tests remaining)
+
+The VM dispatches function calls via `UdfRegistry` trait in `engine/builtins.rs`. The `BuiltinFunctions` struct implements this and is wired into `PartiQLVM` (passed to `eval_inst` in the dispatch loop at `plan.rs`).
+
+**Completed:**
+
+- [x] `char_length` / `character_length` — 583 tests
+- [x] `lower` — 274 tests
+- [x] `upper` — 274 tests
+- [x] `substring` — 188 tests
+- [x] `overlay` — 44 tests
+- [x] `cardinality` — 35 tests
+- [x] `mod` — 30 tests
+- [x] `position` — 28 tests
+- [x] `abs` — 11 tests
+- [x] `bit_length` — 11 tests
+- [x] `octet_length` — 11 tests
+
+**Remaining (not yet implemented in `builtins.rs`):**
+
+- [ ] `trim` (LTrim/BTrim/RTrim) — 120 tests
+- [ ] `extract` (ExtractYear/Month/Day/etc.) — 32 tests
+- [ ] `exists` — 18 tests
+
+**Aggregate functions (require GROUP BY first):**
+
+- [ ] `coll_any` / `coll_some` — 52 tests
+- [ ] `coll_every` — 26 tests
+- [ ] `coll_avg` — 16 tests
+- [ ] `coll_count` — 15 tests
+- [ ] `coll_sum` — 14 tests
+- [ ] `coll_max` — 13 tests
+- [ ] `coll_min` — 13 tests
+
+**Key files:**
+- VM built-in implementations: `partiql-eval/src/engine/builtins.rs`
+- Legacy implementations (reference): `partiql-eval/src/eval/expr/strings.rs`, `functions.rs`, `datetime.rs`
+- VM UDF dispatch: `partiql-eval/src/engine/expr.rs` (search for `CallUdf`)
+- VM wiring: `partiql-eval/src/engine/plan.rs` (builtins field on `PartiQLVM`)
+
+**How to add a new built-in:** Add a match arm in `BuiltinFunctions::call()` mapping the `CallName` debug string (e.g., `"LTrim"`) to a handler function. The function receives `&[ValueRef<'a>]` args and returns `Result<ValueRef<'a>>`.
+
+### Task 2: Unresolved DB Objects / Global Environment (1,098 tests)
+
+Many conformance tests pass an environment like `{i: 1, f: 2.0, s: "hello"}` and then query `SELECT i` or just `i`. The VM fails with "unsupported expression: unresolved DB object default.i".
+
+**Root cause:** The VM's `PlanCompiler` doesn't know how to resolve variables that come from the test environment bindings. The logical planner lowers these to `VarRef` with scope `DbId::default()`, and the VM compiler doesn't handle this DB object type.
+
+**Approach:** Look at how `eval_vm.rs` passes the environment into the VM (via `ExecutionCatalog` / `DataSource`). The issue is that expression-only queries (no FROM clause) still reference these bindings, but the compiler expects them to come from a scan.
+
+**Key files:**
+- `partiql-conformance-tests/tests/support/eval_vm.rs` — how environment is provided
+- `partiql-eval/src/engine/compiler.rs` — where "unresolved DB object" error occurs
+- `partiql-logical-planner/src/lower.rs` — how variable references are lowered
+
+### Task 3: GROUP BY Operator (688 tests)
+
+The `GroupBy` and `Having` BindingsOp variants (discriminants 13, 14) aren't compiled.
+
+**Approach:** Implement a grouping operator in the VM that:
+1. Consumes all input rows
+2. Groups them by the key expressions
+3. Applies aggregate functions to each group
+4. Produces one output row per group
+
+**Dependencies:** Aggregate functions (Task 1 sub-tasks) are needed for GROUP BY to be useful.
+
+**Key files:**
+- Legacy implementation: `partiql-eval/src/eval/evaluable.rs` (search for `EvalGroupBy`)
+- VM compiler: `partiql-eval/src/engine/compiler.rs:667` (the catch-all for unsupported ops)
+
+### Task 4: Scan Expression Types (273 tests)
+
+Certain scan source expressions aren't handled. For example, scanning from a literal collection (`SELECT * FROM [1, 2, 3]`) or other non-variable scan sources.
+
+**Key files:**
+- `partiql-eval/src/engine/compiler.rs:813-814` — "unsupported scan expression type"
+
+### Task 5: Unary Negation (191 tests)
+
+The unary `-` operator on expressions isn't compiled. This affects integer/float literals like `-1`, `-3.14` and expressions like `-x`.
+
+**Key files:**
+- `partiql-eval/src/engine/expr.rs:2171` — `Err(EngineError::UnsupportedExpr(format!("unary op {op:?}")))`
+
+### Task 6: Variant/Ion Literals (162 tests)
+
+A `todo!()` panic at `engine/expr.rs:2285` for `Lit::Variant(_, _)`.
+
+### Task 7: LIKE / Pattern Match (100 tests)
+
+`PatternMatchExpr` isn't compiled. This covers SQL `LIKE` and `SIMILAR TO` patterns.
+
+**Key files:**
+- Legacy implementation: `partiql-eval/src/eval/expr/pattern_match.rs`
+- VM: `partiql-eval/src/engine/expr.rs:2214`
+
+### Task 8: JOIN Operator (84 tests)
+
+The `Join` BindingsOp (discriminant 6) isn't compiled. Covers INNER JOIN, LEFT JOIN, CROSS JOIN.
+
+**Key files:**
+- Legacy implementation: `partiql-eval/src/eval/evaluable.rs` (search for `EvalJoin`)
+
+### Task 9: ORDER BY Operator (60 tests)
+
+The `OrderBy` BindingsOp (discriminant 4) isn't compiled.
+
+### Task 10: Set Operations (59 tests)
+
+`BagOp` (discriminant 7) covers UNION, INTERSECT, EXCEPT.
+
+---
+
+## Approach for Working on a Task
+
+1. **Find the relevant error** in `engine/compiler.rs` or `engine/expr.rs`
+2. **Look at the legacy implementation** for the same feature (paths listed above)
+3. **Implement the feature** in the VM, following the existing VM patterns:
+   - Operators → compile to bytecode instructions in `compiler.rs`
+   - Expressions → add `Inst` variants in `expr.rs` and `Expr` enum cases
+4. **Run the conformance tests** to verify:
+   ```bash
+   cargo +nightly test --package partiql-conformance-tests \
+     --features "conformance_test, eval_vm, experimental" --release \
+     -- -Z unstable-options --format json > vm_cargo_test_results.json
+   ```
+5. **Re-run the gap analysis** (python script in this doc's "How to Run" section) to see updated numbers
+
+## Gap Analysis Script
+
+Save as `scripts/vm_gap_analysis.py` or run inline:
+
+```python
+import json, sys, re
+from collections import Counter
+
+disc_map = {
+    '0': 'Scan', '1': 'Pivot', '2': 'Unpivot', '3': 'Filter',
+    '4': 'OrderBy', '5': 'LimitOffset', '6': 'Join', '7': 'BagOp',
+    '8': 'Project', '9': 'ProjectAll', '10': 'ProjectValue',
+    '11': 'ExprQuery', '12': 'Distinct', '13': 'GroupBy', '14': 'Having'
+}
+
+def classify(stdout):
+    if not stdout:
+        return 'Unknown'
+    m = re.search(r'unsupported operator.*?Discriminant\((\d+)\)', stdout)
+    if m:
+        return f'UnsupportedOp::{disc_map.get(m.group(1), "Op#"+m.group(1))}'
+    if 'Variant literals' in stdout: return 'Unimpl::VariantLiterals'
+    if 'UdfNotFound' in stdout or 'not found' in stdout: return 'MissingBuiltinFn'
+    if 'unresolved DB ob' in stdout or 'unresolved var' in stdout: return 'Unimpl::UnresolvedDBObj'
+    if 'unsupported scan expression' in stdout: return 'Unimpl::ScanExpr'
+    if 'unary op Neg' in stdout: return 'Unimpl::UnaryNeg'
+    if 'PatternMatchExpr' in stdout: return 'UnsupportedExpr::LIKE'
+    if 'BetweenExpr' in stdout: return 'UnsupportedExpr::BETWEEN'
+    if 'SearchedCase' in stdout or 'SimpleCase' in stdout: return 'UnsupportedExpr::CASE'
+    if 'IsTypeExpr' in stdout: return 'UnsupportedExpr::IS_TYPE'
+    if 'NullIfExpr' in stdout: return 'UnsupportedExpr::NULLIF'
+    if 'CoalesceExpr' in stdout: return 'UnsupportedExpr::COALESCE'
+    if 'SubQueryExpr' in stdout: return 'UnsupportedExpr::SUBQUERY'
+    if 'GraphMatch' in stdout: return 'UnsupportedExpr::GRAPH'
+    if 'PathUnpivot' in stdout: return 'Unimpl::PathUnpivot'
+    if 'PathForEach' in stdout: return 'Unimpl::PathForEach'
+    if 'dynamic lookup' in stdout: return 'Unimpl::DynamicLookup'
+    if 'offset not supported' in stdout: return 'UnsupportedOp::Offset'
+    if 'Lit::TypedLit' in stdout: return 'Unimpl::TypedLiteral'
+    if 'Subquery within project' in stdout: return 'Unimpl::SubqueryInProject'
+    if 'IllegalState' in stdout: return 'Bug::IllegalState'
+    if 'lowering error' in stdout.lower(): return 'LoweringError'
+    if 'assertion' in stdout and 'failed' in stdout: return 'WrongResult'
+    if 'left ==' in stdout or ('left:' in stdout and 'right:' in stdout): return 'WrongResult'
+    if "expected `Err(_)`" in stdout: return 'ShouldFailButPassed'
+    return 'Other'
+
+passing = failing = 0
+error_counts = Counter()
+for line in sys.stdin:
+    try: obj = json.loads(line.strip())
+    except: continue
+    if obj.get('type') != 'test': continue
+    if obj['event'] == 'ok': passing += 1
+    elif obj['event'] == 'failed':
+        failing += 1
+        error_counts[classify(obj.get('stdout', ''))] += 1
+
+total = passing + failing
+print(f'{passing} passing / {failing} failing / {total} total ({100*passing/total:.1f}%)')
+print()
+for err, count in error_counts.most_common(25):
+    print(f'  {count:5d}  {err}')
+```
+
+Usage: `cat vm_cargo_test_results.json | python3 scripts/vm_gap_analysis.py`

--- a/partiql-eval/src/engine/builtins.rs
+++ b/partiql-eval/src/engine/builtins.rs
@@ -1,0 +1,228 @@
+use crate::engine::arena::Arena;
+use crate::engine::error::{EngineError, Result};
+use crate::engine::expr::UdfRegistry;
+use crate::engine::value::ValueRef;
+
+pub(crate) struct BuiltinFunctions;
+
+impl BuiltinFunctions {
+    pub fn new() -> Self {
+        BuiltinFunctions
+    }
+}
+
+impl UdfRegistry for BuiltinFunctions {
+    fn call<'a>(
+        &self,
+        name: &str,
+        args: &[ValueRef<'a>],
+        arena: &'a Arena,
+    ) -> Result<ValueRef<'a>> {
+        match name {
+            "CharLength" => builtin_char_length(args),
+            "Lower" => builtin_lower(args, arena),
+            "Upper" => builtin_upper(args, arena),
+            "OctetLength" => builtin_octet_length(args),
+            "BitLength" => builtin_bit_length(args),
+            "Substring" => builtin_substring(args, arena),
+            "Position" => builtin_position(args),
+            "Overlay" => builtin_overlay(args, arena),
+            "Abs" => builtin_abs(args),
+            "Mod" => builtin_mod(args),
+            "Cardinality" => builtin_cardinality(args),
+            _ => Err(EngineError::UdfNotFound(name.to_string())),
+        }
+    }
+}
+
+fn builtin_char_length<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Str(s)) => Ok(ValueRef::I64(s.chars().count() as i64)),
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_lower<'a>(args: &[ValueRef<'a>], arena: &'a Arena) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Str(s)) => {
+            let lowered = s.to_lowercase();
+            let bytes = arena.alloc_slice(lowered.as_bytes());
+            let s = unsafe { std::str::from_utf8_unchecked(bytes) };
+            Ok(ValueRef::Str(s))
+        }
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_upper<'a>(args: &[ValueRef<'a>], arena: &'a Arena) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Str(s)) => {
+            let uppered = s.to_uppercase();
+            let bytes = arena.alloc_slice(uppered.as_bytes());
+            let s = unsafe { std::str::from_utf8_unchecked(bytes) };
+            Ok(ValueRef::Str(s))
+        }
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_octet_length<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Str(s)) => Ok(ValueRef::I64(s.len() as i64)),
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_bit_length<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Str(s)) => Ok(ValueRef::I64((s.len() * 8) as i64)),
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_substring<'a>(args: &[ValueRef<'a>], arena: &'a Arena) -> Result<ValueRef<'a>> {
+    match args.len() {
+        2 => match (&args[0], &args[1]) {
+            (ValueRef::Str(s), ValueRef::I64(offset)) => {
+                let offset = (std::cmp::max(*offset, 1) - 1) as usize;
+                let substring: String = s.chars().skip(offset).collect();
+                let bytes = arena.alloc_slice(substring.as_bytes());
+                let result = unsafe { std::str::from_utf8_unchecked(bytes) };
+                Ok(ValueRef::Str(result))
+            }
+            (ValueRef::Null, _) | (_, ValueRef::Null) => Ok(ValueRef::Null),
+            (ValueRef::Missing, _) | (_, ValueRef::Missing) => Ok(ValueRef::Missing),
+            _ => Ok(ValueRef::Missing),
+        },
+        3 => match (&args[0], &args[1], &args[2]) {
+            (ValueRef::Str(s), ValueRef::I64(offset), ValueRef::I64(length)) => {
+                let (skip, take) = if *length < 1 {
+                    (0, 0)
+                } else if *offset < 1 {
+                    let take = std::cmp::max(offset + (length - 1), 0) as usize;
+                    (0, take)
+                } else {
+                    ((*offset - 1) as usize, *length as usize)
+                };
+                let substring: String = s.chars().skip(skip).take(take).collect();
+                let bytes = arena.alloc_slice(substring.as_bytes());
+                let result = unsafe { std::str::from_utf8_unchecked(bytes) };
+                Ok(ValueRef::Str(result))
+            }
+            _ if args.iter().any(|a| matches!(a, ValueRef::Null)) => Ok(ValueRef::Null),
+            _ if args.iter().any(|a| matches!(a, ValueRef::Missing)) => Ok(ValueRef::Missing),
+            _ => Ok(ValueRef::Missing),
+        },
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_position<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match (args.first(), args.get(1)) {
+        (Some(ValueRef::Str(needle)), Some(ValueRef::Str(haystack))) => {
+            let pos = haystack.find(needle).map_or(0, |l| l + 1) as i64;
+            Ok(ValueRef::I64(pos))
+        }
+        (Some(ValueRef::Null), _) | (_, Some(ValueRef::Null)) => Ok(ValueRef::Null),
+        (Some(ValueRef::Missing), _) | (_, Some(ValueRef::Missing)) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_overlay<'a>(args: &[ValueRef<'a>], arena: &'a Arena) -> Result<ValueRef<'a>> {
+    fn do_overlay(value: &str, replacement: &str, offset: i64, length: usize) -> String {
+        let mut result = value.to_string();
+        let start = std::cmp::max(offset - 1, 0) as usize;
+        if start > result.len() {
+            result += replacement;
+        } else {
+            let end = std::cmp::min(start + length, result.len());
+            result.replace_range(start..end, replacement);
+        }
+        result
+    }
+
+    match args.len() {
+        3 => match (&args[0], &args[1], &args[2]) {
+            (ValueRef::Str(value), ValueRef::Str(replacement), ValueRef::I64(offset)) => {
+                let length = replacement.len();
+                let result = do_overlay(value, replacement, *offset, length);
+                let bytes = arena.alloc_slice(result.as_bytes());
+                let s = unsafe { std::str::from_utf8_unchecked(bytes) };
+                Ok(ValueRef::Str(s))
+            }
+            _ if args.iter().any(|a| matches!(a, ValueRef::Null)) => Ok(ValueRef::Null),
+            _ if args.iter().any(|a| matches!(a, ValueRef::Missing)) => Ok(ValueRef::Missing),
+            _ => Ok(ValueRef::Missing),
+        },
+        4 => match (&args[0], &args[1], &args[2], &args[3]) {
+            (
+                ValueRef::Str(value),
+                ValueRef::Str(replacement),
+                ValueRef::I64(offset),
+                ValueRef::I64(length),
+            ) => {
+                let length = std::cmp::max(*length, 0) as usize;
+                let result = do_overlay(value, replacement, *offset, length);
+                let bytes = arena.alloc_slice(result.as_bytes());
+                let s = unsafe { std::str::from_utf8_unchecked(bytes) };
+                Ok(ValueRef::Str(s))
+            }
+            _ if args.iter().any(|a| matches!(a, ValueRef::Null)) => Ok(ValueRef::Null),
+            _ if args.iter().any(|a| matches!(a, ValueRef::Missing)) => Ok(ValueRef::Missing),
+            _ => Ok(ValueRef::Missing),
+        },
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_abs<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::I64(n)) => Ok(ValueRef::I64(n.abs())),
+        Some(ValueRef::F64(n)) => Ok(ValueRef::F64(n.abs())),
+        Some(ValueRef::Decimal(d)) => {
+            let abs_val = if d.is_sign_negative() { -d } else { *d };
+            Ok(ValueRef::Decimal(abs_val))
+        }
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_mod<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match (args.first(), args.get(1)) {
+        (Some(ValueRef::I64(a)), Some(ValueRef::I64(b))) => {
+            if *b == 0 {
+                Ok(ValueRef::Missing)
+            } else {
+                Ok(ValueRef::I64(a % b))
+            }
+        }
+        (Some(ValueRef::F64(a)), Some(ValueRef::F64(b))) => Ok(ValueRef::F64(a % b)),
+        (Some(ValueRef::Null), _) | (_, Some(ValueRef::Null)) => Ok(ValueRef::Null),
+        (Some(ValueRef::Missing), _) | (_, Some(ValueRef::Missing)) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_cardinality<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::List(items)) => Ok(ValueRef::I64(items.len() as i64)),
+        Some(ValueRef::Bag(items)) => Ok(ValueRef::I64(items.len() as i64)),
+        Some(ValueRef::Tuple(t)) => Ok(ValueRef::I64(t.fields.len() as i64)),
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}

--- a/partiql-eval/src/engine/expr.rs
+++ b/partiql-eval/src/engine/expr.rs
@@ -1518,7 +1518,8 @@ impl Program {
 }
 
 pub(crate) trait UdfRegistry {
-    fn call(&self, name: &str, args: &[ValueRef<'_>], arena: &Arena) -> Result<ValueRef<'_>>;
+    fn call<'a>(&self, name: &str, args: &[ValueRef<'a>], arena: &'a Arena)
+        -> Result<ValueRef<'a>>;
 }
 
 pub trait SlotResolver {

--- a/partiql-eval/src/engine/mod.rs
+++ b/partiql-eval/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub mod arena;
+pub(crate) mod builtins;
 pub mod catalog;
 pub mod compiler;
 pub mod error;

--- a/partiql-eval/src/engine/plan.rs
+++ b/partiql-eval/src/engine/plan.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::engine::arena::Arena;
+use crate::engine::builtins::BuiltinFunctions;
 use crate::engine::catalog::ExecutionContext;
 use crate::engine::error::{EngineError, Result};
 use crate::engine::expr::{Inst, Program};
@@ -273,6 +274,8 @@ pub struct PartiQLVM {
     halted: bool,
     /// Number of output slots.
     slot_count: usize,
+    /// Built-in function registry.
+    builtins: BuiltinFunctions,
 }
 
 impl PartiQLVM {
@@ -303,6 +306,7 @@ impl PartiQLVM {
             ip: 0,
             halted: false,
             slot_count,
+            builtins: BuiltinFunctions::new(),
         };
 
         // Pre-create data sources from catalog
@@ -544,7 +548,9 @@ impl<'vm> QueryIterator<'vm> {
 
                 // All scalar instructions delegate to eval_inst
                 other => {
-                    if let Err(e) = program.eval_inst(other, &self.vm.arena, regs, None) {
+                    if let Err(e) =
+                        program.eval_inst(other, &self.vm.arena, regs, Some(&self.vm.builtins))
+                    {
                         return Some(Err(e));
                     }
                 }


### PR DESCRIPTION
## Summary
- Wire up a `BuiltinFunctions` registry implementing the `UdfRegistry` trait and pass it into the VM dispatch loop
- Implements `char_length`, `lower`, `upper`, `substring`, `position`, `overlay`, `abs`, `mod`, `cardinality`, `octet_length`, and `bit_length`
- Conformance improves from 16.7% to 38.8% (1,470 additional tests passing)

## Test plan
- [x] `make ci-check` passes (build, test, fmt, clippy, deny)
- [x] VM conformance tests verified: 2,587 / 6,671 passing
- [x] Remaining failures are unrelated (variant literals, unresolved DB objects, unsupported operators)