### PR TITLE
feat: implement EvaluationMode support for VM compiler

### DIFF
--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -48,6 +48,16 @@ impl From<EvaluationMode> for eval::plan::EvaluationMode {
     }
 }
 
+#[cfg(feature = "eval_vm")]
+impl From<EvaluationMode> for partiql_eval::plan::EvaluationMode {
+    fn from(value: EvaluationMode) -> Self {
+        match value {
+            EvaluationMode::Coerce => partiql_eval::plan::EvaluationMode::Permissive,
+            EvaluationMode::Error => partiql_eval::plan::EvaluationMode::Strict,
+        }
+    }
+}
+
 #[track_caller]
 #[inline]
 pub(crate) fn parse(statement: &str) -> ParserResult {

--- a/partiql-conformance-tests/tests/support/eval_vm.rs
+++ b/partiql-conformance-tests/tests/support/eval_vm.rs
@@ -410,12 +410,9 @@ fn engine_error_to_eval_err(e: EngineError) -> EvalErr {
 // Main Evaluation Entry Point
 // =============================================================================
 
-// TODO: PlanCompiler should eventually accept an EvaluationMode parameter.
-// For now the VM runs in its default mode regardless of the mode passed here.
-// Mode-dependent behavior differences will appear in the conformance gap report.
 pub(crate) fn eval_via_vm<'a>(
     statement: &'a str,
-    _mode: EvaluationMode,
+    mode: EvaluationMode,
     env: &Option<TestValue>,
 ) -> Result<Value, TestError<'a>> {
     let mut catalog = PartiqlCatalog::default();
@@ -455,7 +452,8 @@ pub(crate) fn eval_via_vm<'a>(
 
     let mut context = CompilationContext::new();
     let catalog_id = context.add_catalog("default", comp_catalog);
-    let mut compiler = PlanCompiler::new(&context);
+    let eval_mode: partiql_eval::plan::EvaluationMode = mode.into();
+    let mut compiler = PlanCompiler::new(&context, eval_mode);
     let compiled = compiler
         .compile(&logical)
         .map_err(|e| TestError::Plan(engine_error_to_plan_err(e)))?;

--- a/partiql-eval/src/engine/compiler.rs
+++ b/partiql-eval/src/engine/compiler.rs
@@ -7,6 +7,7 @@ use crate::engine::plan::{CompiledPlan, CursorInfo, ObjectId, ScanId, ScanMetada
 use crate::engine::source::{DataSourceHandle, ScanLayout, ScanProjection, ScanSource};
 use crate::engine::value::{FieldName, FieldShape, PhysicalType, RowShape, Shape, ValueOwned};
 use crate::engine::SlotResolver;
+use crate::plan::EvaluationMode;
 use partiql_logical::{
     BindingsOp, DBRef, LimitOffset, LogicalPlan, OpId, Project, ProjectAllMode, ProjectValue, Scan,
     ValueExpr, VarRefType,
@@ -173,15 +174,17 @@ impl SlotResolver for GlobalSlotResolver {
 
 pub struct PlanCompiler<'a> {
     compilation_context: &'a CompilationContext,
+    mode: EvaluationMode,
     next_scan_id: u64,
     inline_scans: HashMap<ScanId, Vec<ValueOwned>>,
     expr_scans: HashMap<ScanId, ValueExpr>,
 }
 
 impl<'a> PlanCompiler<'a> {
-    pub fn new(compilation_context: &'a CompilationContext) -> Self {
+    pub fn new(compilation_context: &'a CompilationContext, mode: EvaluationMode) -> Self {
         PlanCompiler {
             compilation_context,
+            mode,
             next_scan_id: 0,
             inline_scans: HashMap::new(),
             expr_scans: HashMap::new(),
@@ -396,6 +399,9 @@ impl<'a> PlanCompiler<'a> {
             let expr_program =
                 expr_compiler.compile_to_program(&expr, 0, result.slot_count as u16)?;
             self.inline_program(&expr_program, builder);
+            if self.mode == EvaluationMode::Strict {
+                builder.insts.push(Inst::AssertCollection { src: 0 });
+            }
             builder
                 .insts
                 .push(Inst::MaterializeCursor { src: 0, cursor_id });
@@ -603,6 +609,20 @@ impl<'a> PlanCompiler<'a> {
         let expr_compiler = LogicalExprCompiler::new(&result.resolver);
         let program = expr_compiler.compile_to_program(&copy_expr, output_slot, output_slot + 1)?;
         self.inline_program(&program, builder);
+
+        match self.mode {
+            EvaluationMode::Permissive => {
+                let const_idx = builder.push_const_pub(ValueOwned::String("_1".to_string()));
+                builder.insts.push(Inst::CoerceToTuple {
+                    dst: output_slot,
+                    src: output_slot,
+                    const_idx,
+                });
+            }
+            EvaluationMode::Strict => {
+                builder.insts.push(Inst::AssertTuple { src: output_slot });
+            }
+        }
         Ok(())
     }
 
@@ -1297,6 +1317,15 @@ fn remap_inst(inst: &Inst, const_offset: u16, key_offset: u16) -> Inst {
             dst: *dst,
             func_idx: *func_idx + key_offset,
             args: args.clone(),
+        },
+        Inst::CoerceToTuple {
+            dst,
+            src,
+            const_idx,
+        } => Inst::CoerceToTuple {
+            dst: *dst,
+            src: *src,
+            const_idx: *const_idx + const_offset,
         },
         // All other instructions don't reference const/key pools
         other => other.clone(),

--- a/partiql-eval/src/engine/error.rs
+++ b/partiql-eval/src/engine/error.rs
@@ -20,6 +20,8 @@ pub enum EngineError {
     ReaderError(String),
     #[error("slot index out of bounds: {0}")]
     SlotOutOfBounds(u16),
+    #[error("strict mode violation: {0}")]
+    StrictModeViolation(String),
 }
 
 pub type Result<T> = std::result::Result<T, EngineError>;

--- a/partiql-eval/src/engine/expr.rs
+++ b/partiql-eval/src/engine/expr.rs
@@ -368,6 +368,25 @@ pub enum Inst {
         element_regs: Vec<u16>,
     },
 
+    /// If src is already a Tuple, copy to dst. Otherwise wrap as {'key': value}.
+    /// const_idx indexes into the Program's const pool for the field name string.
+    CoerceToTuple {
+        dst: u16,
+        src: u16,
+        const_idx: u16,
+    },
+
+    /// Strict mode: assert src is a Tuple. If not, runtime error.
+    AssertTuple {
+        src: u16,
+    },
+
+    /// Strict mode: assert src is a List or Bag. If not, runtime error.
+    /// Handled in the VM dispatch loop (relational instruction).
+    AssertCollection {
+        src: u16,
+    },
+
     // === Relational Instructions (SFW bytecode) ===
     /// Open a data source cursor. cursor_id indexes into the VM's cursor array.
     /// The cursor's ScanLayout is determined at compile time from CursorMetadata.
@@ -1568,6 +1587,39 @@ impl Program {
                 regs[*dst as usize] = ValueRef::Bag(bag_slice);
             }
 
+            Inst::CoerceToTuple {
+                dst,
+                src,
+                const_idx,
+            } => {
+                let value = regs[*src as usize];
+                match value {
+                    ValueRef::Tuple(_) => {
+                        regs[*dst as usize] = value;
+                    }
+                    _ => {
+                        let name_ref = self
+                            .const_refs
+                            .get(*const_idx as usize)
+                            .copied()
+                            .ok_or_else(|| {
+                                EngineError::IllegalState("invalid const index".to_string())
+                            })?;
+                        let fields = std::iter::once((name_ref, value));
+                        let tuple_ref = arena.alloc_tuple(fields);
+                        regs[*dst as usize] = ValueRef::Tuple(tuple_ref);
+                    }
+                }
+            }
+            Inst::AssertTuple { src } => {
+                let value = regs[*src as usize];
+                if !matches!(value, ValueRef::Tuple(_)) {
+                    return Err(EngineError::StrictModeViolation(
+                        "SELECT * requires tuple value".to_string(),
+                    ));
+                }
+            }
+
             // Relational instructions are handled by the VM dispatch loop,
             // not by eval_inst. If we reach them here, it's a bug.
             Inst::OpenCursor { .. }
@@ -1578,7 +1630,8 @@ impl Program {
             | Inst::EmitRow
             | Inst::Halt
             | Inst::DecrOrJump { .. }
-            | Inst::MaterializeCursor { .. } => {
+            | Inst::MaterializeCursor { .. }
+            | Inst::AssertCollection { .. } => {
                 return Err(EngineError::IllegalState(
                     "relational instruction encountered in scalar eval_inst".to_string(),
                 ));

--- a/partiql-eval/src/engine/plan.rs
+++ b/partiql-eval/src/engine/plan.rs
@@ -571,6 +571,15 @@ impl<'vm> QueryIterator<'vm> {
                     }
                 }
 
+                Inst::AssertCollection { src } => {
+                    let value = regs[*src as usize];
+                    if !matches!(value, ValueRef::Bag(_) | ValueRef::List(_)) {
+                        return Some(Err(EngineError::StrictModeViolation(
+                            "FROM clause requires collection value".to_string(),
+                        )));
+                    }
+                }
+
                 Inst::MaterializeCursor { src, cursor_id } => {
                     let collection = regs[*src as usize];
                     let values = match collection {

--- a/partiql-eval/tests/vm_tests.rs
+++ b/partiql-eval/tests/vm_tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use partiql_catalog::catalog::{MutableCatalog, PartiqlCatalog, TypeEnvEntry};
 use partiql_common::catalog::EntryId;
+use partiql_eval::plan::EvaluationMode;
 use partiql_eval::source::{
     BufferStability, CatalogScans, DataSource, DataSourceHandle, DataSourceMetadata, PhysicalType,
     RegisterWriter, ScanLayout, ScanSource, ScanSourceType, ValueWriter,
@@ -397,7 +398,7 @@ fn eval_vm(query: &str, tables: &[(&str, &str)]) -> Value {
     // Compile
     let mut context = CompilationContext::new();
     let catalog_id = context.add_catalog("default", comp_catalog);
-    let mut compiler = PlanCompiler::new(&context);
+    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
     let compiled = compiler.compile(&logical).expect("compile failed");
 
     // Prepare execution catalog

--- a/partiql-tools/src/bin/engine_profiler.rs
+++ b/partiql-tools/src/bin/engine_profiler.rs
@@ -181,7 +181,7 @@ impl HybridPlan {
         let logical = lower(&*catalog, &parsed).expect("Lower failed");
 
         let compilation_ctx = partiql_eval::CompilationContext::new();
-        let mut compiler = PlanCompiler::new(&compilation_ctx);
+        let mut compiler = PlanCompiler::new(&compilation_ctx, EvaluationMode::Permissive);
         let compiled = compiler.compile(&logical).expect("Compile failed");
 
         Self {

--- a/partiql-tools/src/bin/partiql_benchmarks.rs
+++ b/partiql-tools/src/bin/partiql_benchmarks.rs
@@ -619,7 +619,7 @@ fn compile_hybrid(
     _total_rows: usize,
 ) -> partiql_eval::Result<partiql_eval::PartiQLVM> {
     let compilation_context = partiql_eval::CompilationContext::new();
-    let mut compiler = PlanCompiler::new(&compilation_context);
+    let mut compiler = PlanCompiler::new(&compilation_context, EvaluationMode::Permissive);
     let compiled = compiler.compile(logical)?;
     let exec_context = partiql_eval::ExecutionContext::new();
     partiql_eval::PartiQLVM::new(compiled, &exec_context)

--- a/partiql-tools/src/bin/partiql_hybrid.rs
+++ b/partiql-tools/src/bin/partiql_hybrid.rs
@@ -4,6 +4,7 @@ use common::{
     count_rows_from_file, create_catalog, lower, parse, random_catalog, simple_catalog,
     CompiledSourceFactory,
 };
+use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
 use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanCompiler};
 use partiql_value::{Tuple, Value};
@@ -187,7 +188,7 @@ fn main() {
     // Add catalog and CAPTURE the returned catalog_id - this is the ONLY place catalog_id is assigned
     let catalog_id = context.add_catalog("default", comp_catalog);
 
-    let mut compiler = PlanCompiler::new(&context);
+    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
     let compiled = match compiler.compile(&logical) {
         Ok(p) => p,
         Err(e) => {

--- a/partiql-tools/src/bin/partiql_profile.rs
+++ b/partiql-tools/src/bin/partiql_profile.rs
@@ -271,7 +271,7 @@ fn compile_hybrid(
     _total_rows: usize,
 ) -> partiql_eval::Result<partiql_eval::PartiQLVM> {
     let compilation_context = partiql_eval::CompilationContext::new();
-    let mut compiler = PlanCompiler::new(&compilation_context);
+    let mut compiler = PlanCompiler::new(&compilation_context, EvaluationMode::Permissive);
     let compiled = compiler.compile(logical)?;
     let exec_context = partiql_eval::ExecutionContext::new();
     partiql_eval::PartiQLVM::new(compiled, &exec_context)


### PR DESCRIPTION
## Summary

- Thread `EvaluationMode` (Permissive/Strict) into `PlanCompiler` so mode-dependent behavior is resolved at compile time via different bytecode, not runtime branching per row
- Add `CoerceToTuple` instruction: wraps non-tuple values as `{'_1': value}` for permissive `SELECT *`
- Add `AssertTuple` / `AssertCollection` instructions for strict mode error reporting
- Fix 66 conformance tests (3911→3977 passing) by correctly handling `SELECT *` from non-tuple values

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — all existing tests pass, zero regressions
- [x] `cargo clippy --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Conformance tests with `eval_vm` feature: +66 tests now passing