### PR TITLE
feat: add clap support in partiql_hybrid

### DIFF
--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -55,6 +55,8 @@ partiql-logical-planner = { path = "../partiql-logical-planner" }
 partiql-parser = { path = "../partiql-parser" }
 partiql-types = { path = "../partiql-types" }
 partiql-value = { path = "../partiql-value" }
+clap = { version = "4.6.1", features = ["derive"] }
+reedline = "0.48.0"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/partiql-tools/src/bin/partiql_hybrid.rs
+++ b/partiql-tools/src/bin/partiql_hybrid.rs
@@ -10,7 +10,7 @@ use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanC
 use partiql_value::{Tuple, Value};
 use std::time::Instant;
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 const BATCH_SIZE: usize = 1;
 const NUM_BATCHES: usize = 10_000;
@@ -21,16 +21,25 @@ const NUM_BATCHES: usize = 10_000;
 #[derive(Parser)]
 #[command(name = "partiql-hybrid")]
 struct Cli {
-    /// Query to execute. If omitted, enter REPL mode.
-    query: Option<String>,
-
     /// Data source: mem | rand | ion | ionb.
-    #[arg(long, default_value = "mem")]
+    #[arg(long, default_value = "mem", global = true)]
     data_source: String,
 
     /// Path to the data file (required for file-based data sources).
-    #[arg(long)]
+    #[arg(long, global = true)]
     data_path: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Execute a single query immediately
+    Exec {
+        /// The mandatory PartiQL query string to run
+        query: String,
+    },
 }
 
 fn main() {
@@ -45,8 +54,8 @@ fn main() {
         std::process::exit(1);
     }
 
-    match &cli.query {
-        Some(query) => {
+    match &cli.command {
+        Some(Commands::Exec { query }) => {
             if let Err(e) = execute_query(query, &cli.data_source, cli.data_path.as_ref()) {
                 eprintln!("{}", e);
                 std::process::exit(1);

--- a/partiql-tools/src/bin/partiql_hybrid.rs
+++ b/partiql-tools/src/bin/partiql_hybrid.rs
@@ -184,7 +184,9 @@ fn execute_query(
             // Simple catalog for mem/ion data sources - use CompiledSourceFactory
             let factory = match data_source {
                 "mem" => CompiledSourceFactory::mem(total_rows, column_names.clone()),
-                "ion" | "ionb" => CompiledSourceFactory::ion(data_path.cloned().unwrap_or_default()),
+                "ion" | "ionb" => {
+                    CompiledSourceFactory::ion(data_path.cloned().unwrap_or_default())
+                }
                 _ => unreachable!(),
             };
             let (comp, exec) = simple_catalog(vec![("data".to_string(), factory)]);

--- a/partiql-tools/src/bin/partiql_hybrid.rs
+++ b/partiql-tools/src/bin/partiql_hybrid.rs
@@ -10,86 +10,51 @@ use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanC
 use partiql_value::{Tuple, Value};
 use std::time::Instant;
 
+use clap::Parser;
+
 const BATCH_SIZE: usize = 1;
 const NUM_BATCHES: usize = 10_000;
 
+/// PartiQL hybrid engine CLI: run a single query or drop into a REPL.
+///
+/// Note: `~input~` in the query is replaced with `data`.
+#[derive(Parser)]
+#[command(name = "partiql-hybrid")]
+struct Cli {
+    /// Query to execute. If omitted, enter REPL mode.
+    query: Option<String>,
+
+    /// Data source: mem | rand | ion | ionb.
+    #[arg(long, default_value = "mem")]
+    data_source: String,
+
+    /// Path to the data file (required for file-based data sources).
+    #[arg(long)]
+    data_path: Option<String>,
+}
+
 fn main() {
-    // Parse command line arguments
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 2 {
+    let cli = Cli::parse();
+
+    // File-based data sources require an explicit --data-path.
+    if cli.data_source != "mem" && cli.data_source != "rand" && cli.data_path.is_none() {
         eprintln!(
-            "Usage: {} <query> --data-source <mem|ion|rand> [--data-path <path>]",
-            args[0]
+            "Error: --data-path is required for file-based data source '{}'",
+            cli.data_source
         );
-        eprintln!("\nExamples:");
-        eprintln!("  {} \"SELECT a, b FROM !input WHERE a % 1000 = 0\" --data-source ion --data-path test_data/data_b1024_n10000.ion", args[0]);
-        eprintln!("  {} \"SELECT * FROM !input\" --data-source mem", args[0]);
-        eprintln!(
-            "  {} \"SELECT * FROM data WHERE a > 0 LIMIT 10\" --data-source rand",
-            args[0]
-        );
-        eprintln!("\nNote: !input will be replaced with 'data' in the query");
         std::process::exit(1);
     }
 
-    let mut query_arg = None;
-    let mut data_source = "mem".to_string();
-    let mut data_path = None;
-
-    // Parse arguments
-    let mut i = 1;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--data-source" => {
-                if i + 1 < args.len() {
-                    data_source = args[i + 1].clone();
-                    i += 2;
-                } else {
-                    eprintln!("Error: --data-source requires a value");
-                    std::process::exit(1);
-                }
-            }
-            "--data-path" => {
-                if i + 1 < args.len() {
-                    data_path = Some(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    eprintln!("Error: --data-path requires a value");
-                    std::process::exit(1);
-                }
-            }
-            arg if !arg.starts_with("--") => {
-                if query_arg.is_none() {
-                    query_arg = Some(arg.to_string());
-                } else {
-                    eprintln!("Error: Only one query is allowed");
-                    std::process::exit(1);
-                }
-                i += 1;
-            }
-            _ => {
-                eprintln!("Unknown argument: {}", args[i]);
+    match &cli.query {
+        Some(query) => {
+            if let Err(e) = execute_query(query, &cli.data_source, cli.data_path.as_ref()) {
+                eprintln!("{}", e);
                 std::process::exit(1);
             }
         }
-    }
-
-    let query_arg = query_arg.unwrap_or_else(|| {
-        eprintln!("Error: Query is required");
-        std::process::exit(1);
-    });
-
-    if data_source != "mem" && data_source != "rand" && data_path.is_none() {
-        eprintln!(
-            "Error: --data-path is required for file-based data source '{}'",
-            data_source
-        );
-        std::process::exit(1);
-    }
-
-    if let Err(e) = execute_query(&query_arg, &data_source, data_path.as_ref()) {
-        eprintln!("{}", e);
-        std::process::exit(1);
+        None => {
+            println!("REPL mode triggered!");
+        }
     }
 }
 

--- a/partiql-tools/src/bin/partiql_hybrid.rs
+++ b/partiql-tools/src/bin/partiql_hybrid.rs
@@ -87,12 +87,23 @@ fn main() {
         std::process::exit(1);
     }
 
+    if let Err(e) = execute_query(&query_arg, &data_source, data_path.as_ref()) {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+}
+
+fn execute_query(
+    query_str: &str,
+    data_source: &str,
+    data_path: Option<&String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Replace !input with data (no parentheses for hybrid)
-    let query = query_arg.replace("~input~", "data");
+    let query = query_str.replace("~input~", "data");
 
     println!("Query:       {}", query);
     println!("Data Source: {}", data_source);
-    if let Some(ref path) = data_path {
+    if let Some(path) = data_path {
         println!("Data Path:   {}", path);
     }
 
@@ -107,8 +118,8 @@ fn main() {
             common::format_with_commas(total)
         );
         total
-    } else if let Some(ref path) = data_path {
-        let total = count_rows_from_file(&data_source, path);
+    } else if let Some(path) = data_path {
+        let total = count_rows_from_file(data_source, path);
         println!(
             "Reader Config: total_rows={} (from file)",
             common::format_with_commas(total)
@@ -122,32 +133,32 @@ fn main() {
 
     println!();
 
-    let catalog = create_catalog(data_source.clone(), data_path.clone());
+    let catalog = create_catalog(data_source.to_string(), data_path.cloned());
 
     // Default column names for in-memory reader
     let column_names = vec!["a".to_string(), "b".to_string()];
 
     // Phase 1: Parse
     let parse_start = Instant::now();
-    let parsed = match parse(&query) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("Parse error: {:?}", e);
-            std::process::exit(1);
-        }
-    };
+    let parsed = parse(&query).map_err(|e| format!("Parse error: {:?}", e))?;
     let parse_time = parse_start.elapsed();
+
+    // === PIPELINE TRACE: AST ===
+    println!("\n{}", "=".repeat(60));
+    println!("PHASE 1: PARSED AST");
+    println!("{}", "=".repeat(60));
+    println!("{:#?}", parsed);
 
     // Phase 2: Lower (AST → Logical Plan)
     let lower_start = Instant::now();
-    let logical = match lower(&*catalog, &parsed) {
-        Ok(l) => l,
-        Err(e) => {
-            eprintln!("Lower error: {:?}", e);
-            std::process::exit(1);
-        }
-    };
+    let logical = lower(&*catalog, &parsed).map_err(|e| format!("Lower error: {:?}", e))?;
     let lower_time = lower_start.elapsed();
+
+    // === PIPELINE TRACE: LOGICAL PLAN ===
+    println!("\n{}", "=".repeat(60));
+    println!("PHASE 2: LOGICAL PLAN");
+    println!("{}", "=".repeat(60));
+    println!("{:#?}", logical);
 
     // Phase 3: Compile (Logical → CompiledPlan)
     let compile_start = Instant::now();
@@ -162,7 +173,7 @@ fn main() {
         Simple(common::SimpleExecutionCatalog),
     }
 
-    let (comp_catalog, mut exec_catalog_inner) = match data_source.as_str() {
+    let (comp_catalog, mut exec_catalog_inner) = match data_source {
         "rand" => {
             // Random catalog for custom reader demonstration
             let (comp, exec) =
@@ -171,17 +182,16 @@ fn main() {
         }
         "mem" | "ion" | "ionb" => {
             // Simple catalog for mem/ion data sources - use CompiledSourceFactory
-            let factory = match data_source.as_str() {
+            let factory = match data_source {
                 "mem" => CompiledSourceFactory::mem(total_rows, column_names.clone()),
-                "ion" | "ionb" => CompiledSourceFactory::ion(data_path.clone().unwrap_or_default()),
+                "ion" | "ionb" => CompiledSourceFactory::ion(data_path.cloned().unwrap_or_default()),
                 _ => unreachable!(),
             };
             let (comp, exec) = simple_catalog(vec![("data".to_string(), factory)]);
             (comp, ExecCatalog::Simple(exec))
         }
         _ => {
-            eprintln!("Unsupported data source: {}", data_source);
-            std::process::exit(1);
+            return Err(format!("Unsupported data source: {}", data_source).into());
         }
     };
 
@@ -189,13 +199,9 @@ fn main() {
     let catalog_id = context.add_catalog("default", comp_catalog);
 
     let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
-    let compiled = match compiler.compile(&logical) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("Compile error: {:?}", e);
-            std::process::exit(1);
-        }
-    };
+    let compiled = compiler
+        .compile(&logical)
+        .map_err(|e| format!("Compile error: {:?}", e))?;
     let compile_time = compile_start.elapsed();
 
     // Dump compiled plan for debugging
@@ -220,13 +226,8 @@ fn main() {
         ExecCatalog::Simple(exec) => exec_context.add_catalog(catalog_id, Box::new(exec)),
     }
 
-    let mut vm = match partiql_eval::PartiQLVM::new(compiled, &exec_context) {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("Execution setup error: {:?}", e);
-            std::process::exit(1);
-        }
-    };
+    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+        .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
     let shape = vm.shape().clone();
     let mut row_count = 0usize;
@@ -260,8 +261,7 @@ fn main() {
                         print!("{:?}", value);
                     }
                     Err(e) => {
-                        eprintln!("Execution error: {:?}", e);
-                        std::process::exit(1);
+                        return Err(format!("Execution error: {:?}", e).into());
                     }
                 }
             }
@@ -271,8 +271,7 @@ fn main() {
             }
         }
         Err(e) => {
-            eprintln!("Execution setup error: {:?}", e);
-            std::process::exit(1);
+            return Err(format!("Execution setup error: {:?}", e).into());
         }
     }
     let exec_time = exec_start.elapsed();
@@ -297,6 +296,8 @@ fn main() {
         exec_time.as_secs_f64() * 1000.0
     );
     println!("Rows returned:     {}", row_count);
+
+    Ok(())
 }
 
 fn row_to_value(


### PR DESCRIPTION
Replaced the std::env::args() loop in main with a clap
  CLI struct. clap now handles the usage/error messages, and main keeps the
  data-path-required exception check for file sources.

  When a query is given it is sent to execute_query as before but when none is
  given, prints a "REPL mode triggered!" placeholder for the upcoming
  pqlite REPL.
