### PR TITLE
feat: add table function support to the VM engine

### DIFF
--- a/partiql-eval/src/engine/catalog.rs
+++ b/partiql-eval/src/engine/catalog.rs
@@ -34,7 +34,9 @@
 
 use crate::engine::error::Result;
 use crate::engine::plan::ScanId;
-use crate::engine::source::{DataSource, DataSourceHandle, ScanLayout};
+use crate::engine::source::{
+    DataSource, DataSourceHandle, ScanLayout, TableFunction, TableFunctionHandle,
+};
 use partiql_common::catalog::{CatalogId, EntryId};
 use partiql_value::BindingsName;
 use rustc_hash::FxHashMap;
@@ -153,6 +155,18 @@ pub trait CompilationCatalog: Send + Sync {
     /// - `Some(DataSourceHandle)` if the table exists
     /// - `None` if the table is not found
     fn get_table(&self, path: &[BindingsName<'_>]) -> Option<DataSourceHandle>;
+
+    /// Get table function metadata by name.
+    ///
+    /// Returns a `TableFunctionHandle` containing compile-time metadata about
+    /// the function's output schema, enabling field resolution and layout
+    /// construction during compilation.
+    ///
+    /// Default implementation returns `None` (no table functions available).
+    fn get_table_function(&self, name: &str) -> Option<TableFunctionHandle> {
+        let _ = name;
+        None
+    }
 }
 
 /// Execution-time catalog that creates DataSource instances from ScanIds.
@@ -334,6 +348,7 @@ impl Default for CompilationContext {
 /// ```
 pub struct ExecutionContext {
     catalogs: FxHashMap<CatalogId, Box<dyn ExecutionCatalog>>,
+    table_functions: HashMap<String, Arc<dyn TableFunction>>,
 }
 
 impl ExecutionContext {
@@ -341,7 +356,31 @@ impl ExecutionContext {
     pub fn new() -> Self {
         ExecutionContext {
             catalogs: FxHashMap::default(),
+            table_functions: HashMap::new(),
         }
+    }
+
+    /// Register a table function by name.
+    ///
+    /// Table functions are invoked at runtime by `CreateTableFnCursor` instructions.
+    /// The name should match what the query uses in the FROM clause
+    /// (e.g., "scan_ion" for `FROM scan_ion('path')`).
+    pub fn register_table_function(
+        &mut self,
+        name: impl Into<String>,
+        func: Arc<dyn TableFunction>,
+    ) {
+        self.table_functions.insert(name.into(), func);
+    }
+
+    /// Get a registered table function by name.
+    pub fn get_table_function(&self, name: &str) -> Option<&Arc<dyn TableFunction>> {
+        self.table_functions.get(name)
+    }
+
+    /// Get all registered table functions.
+    pub fn table_functions(&self) -> &HashMap<String, Arc<dyn TableFunction>> {
+        &self.table_functions
     }
 
     /// Add an execution catalog with the given CatalogId.

--- a/partiql-eval/src/engine/compiler.rs
+++ b/partiql-eval/src/engine/compiler.rs
@@ -4,13 +4,15 @@ use crate::engine::error::{EngineError, Result};
 use crate::engine::expr::{lit_to_value, Inst, LogicalExprCompiler, ProgramBuilder};
 use crate::engine::field_resolver::{CompileContext, ExprFieldExtractor};
 use crate::engine::plan::{CompiledPlan, CursorInfo, ObjectId, ScanId, ScanMetadata};
-use crate::engine::source::{DataSourceHandle, ScanLayout, ScanProjection, ScanSource};
+use crate::engine::source::{
+    DataSourceHandle, ScanLayout, ScanProjection, ScanSource, TableFunctionHandle,
+};
 use crate::engine::value::{FieldName, FieldShape, PhysicalType, RowShape, Shape, ValueOwned};
 use crate::engine::SlotResolver;
 use crate::plan::EvaluationMode;
 use partiql_logical::{
-    BindingsOp, DBRef, LimitOffset, LogicalPlan, OpId, Project, ProjectAllMode, ProjectValue, Scan,
-    ValueExpr, VarRefType,
+    BindingsOp, CallName, DBRef, LimitOffset, LogicalPlan, OpId, Project, ProjectAllMode,
+    ProjectValue, Scan, ValueExpr, VarRefType,
 };
 use partiql_value::BindingsName;
 use rustc_hash::FxHashMap;
@@ -178,6 +180,15 @@ pub struct PlanCompiler<'a> {
     next_scan_id: u64,
     inline_scans: HashMap<ScanId, Vec<ValueOwned>>,
     expr_scans: HashMap<ScanId, ValueExpr>,
+    table_fn_scans: HashMap<ScanId, TableFnScanInfo>,
+    table_fn_arg_slots: HashMap<ScanId, Vec<SlotId>>,
+}
+
+#[derive(Clone)]
+struct TableFnScanInfo {
+    func_name: String,
+    layout: ScanLayout,
+    arguments: Vec<ValueExpr>,
 }
 
 impl<'a> PlanCompiler<'a> {
@@ -188,6 +199,8 @@ impl<'a> PlanCompiler<'a> {
             next_scan_id: 0,
             inline_scans: HashMap::new(),
             expr_scans: HashMap::new(),
+            table_fn_scans: HashMap::new(),
+            table_fn_arg_slots: HashMap::new(),
         }
     }
 
@@ -218,6 +231,22 @@ impl<'a> PlanCompiler<'a> {
             .shape
             .unwrap_or(Shape::Bag(RowShape::Register(0, PhysicalType::Dynamic)));
 
+        let table_fn_scans = self
+            .table_fn_scans
+            .drain()
+            .map(|(id, info)| {
+                let arg_slots = self.table_fn_arg_slots.remove(&id).unwrap_or_default();
+                (
+                    id,
+                    crate::engine::plan::TableFnScanMetadata {
+                        func_name: info.func_name,
+                        layout: info.layout,
+                        arg_slots,
+                    },
+                )
+            })
+            .collect();
+
         Ok(CompiledPlan {
             program,
             cursors: cursor_infos,
@@ -226,6 +255,7 @@ impl<'a> PlanCompiler<'a> {
             scan_metadata: result.scan_metadata,
             inline_scans: std::mem::take(&mut self.inline_scans),
             expr_scan_ids: self.expr_scans.keys().copied().collect(),
+            table_fn_scans,
         })
     }
 
@@ -393,8 +423,30 @@ impl<'a> PlanCompiler<'a> {
             None
         };
 
-        // For expression-based scans, compile the expression and emit MaterializeCursor
-        if let Some(expr) = self.expr_scans.get(&scan_id).cloned() {
+        // For table function scans, compile arguments and emit CreateTableFnCursor + OpenCursor
+        if let Some(tf_info) = self.table_fn_scans.get(&scan_id).cloned() {
+            // Compile each argument expression into its own register
+            let mut arg_slots: Vec<SlotId> = Vec::new();
+            let expr_compiler = LogicalExprCompiler::new(&result.resolver);
+            for arg_expr in &tf_info.arguments {
+                let target = builder.alloc_reg_pub();
+                let prog = expr_compiler.compile_to_program(arg_expr, target, target + 1)?;
+                self.inline_program(&prog, builder);
+                arg_slots.push(target);
+            }
+
+            // Store resolved arg_slots for the CompiledPlan
+            self.table_fn_arg_slots.insert(scan_id, arg_slots);
+
+            // Emit CreateTableFnCursor + OpenCursor
+            let func_name_idx = builder.push_key_pub(tf_info.func_name.clone());
+            builder.insts.push(Inst::CreateTableFnCursor {
+                cursor_id,
+                func_name_idx,
+            });
+            builder.emit_open_cursor(cursor_id);
+        } else if let Some(expr) = self.expr_scans.get(&scan_id).cloned() {
+            // For expression-based scans, compile the expression and emit MaterializeCursor
             let expr_compiler = LogicalExprCompiler::new(&result.resolver);
             let expr_program =
                 expr_compiler.compile_to_program(&expr, 0, result.slot_count as u16)?;
@@ -405,10 +457,11 @@ impl<'a> PlanCompiler<'a> {
             builder
                 .insts
                 .push(Inst::MaterializeCursor { src: 0, cursor_id });
+            builder.emit_open_cursor(cursor_id);
+        } else {
+            // Regular catalog scan
+            builder.emit_open_cursor(cursor_id);
         }
-
-        // Emit: OpenCursor
-        builder.emit_open_cursor(cursor_id);
 
         // Emit: NextRow (loop head)
         let loop_head = builder.current_offset() as usize;
@@ -766,6 +819,10 @@ impl<'a> PlanCompiler<'a> {
         if let Some(values) = try_expr_to_inline_values(&scan.expr) {
             return self.compile_inline_scan(scan, values);
         }
+        // Try table function resolution (Call expressions)
+        if let Some(result) = self.try_compile_table_fn_scan(scan, ctx)? {
+            return Ok(result);
+        }
         // Try catalog resolution (DBRef / VarRef)
         let catalog_result = self.resolve_reader_factory(scan);
         if catalog_result.is_err() {
@@ -1033,6 +1090,128 @@ impl<'a> PlanCompiler<'a> {
             slot_count: 1,
             shape: None,
         })
+    }
+
+    // -----------------------------------------------------------------------
+    // Table function compilation
+    // -----------------------------------------------------------------------
+
+    /// Try to compile a scan as a table function call.
+    /// Returns `Ok(Some(result))` if the scan expr is a Call to a known table function,
+    /// `Ok(None)` if it's not a Call or the function isn't registered.
+    fn try_compile_table_fn_scan(
+        &mut self,
+        scan: &Scan,
+        ctx: &CompileContext,
+    ) -> Result<Option<SubtreeResult>> {
+        let call_expr = match &scan.expr {
+            ValueExpr::Call(call) => call,
+            _ => return Ok(None),
+        };
+
+        let func_name = match &call_expr.name {
+            CallName::ByName(name) => name.clone(),
+            _ => return Ok(None),
+        };
+
+        let handle = match self.resolve_table_function(&func_name) {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+
+        let scan_id = self.alloc_scan_id();
+
+        // Determine output layout from field requests
+        let table_name = Some(func_name.clone());
+        let my_requests = ctx.requests_for_alias(&scan.as_key, table_name.as_deref());
+
+        let mut projections = Vec::new();
+        let mut column_slots = FxHashMap::default();
+        let mut base_row_slot: Option<SlotId> = None;
+        let mut next_slot: SlotId = 0;
+        let mut needs_whole_value = my_requests.is_empty();
+
+        if !needs_whole_value {
+            for req in &my_requests {
+                if let Some(scan_source) = handle.resolve(&req.field_name) {
+                    let slot = next_slot;
+                    next_slot += 1;
+                    projections.push(ScanProjection {
+                        source: scan_source,
+                        target_slot: slot,
+                    });
+                    column_slots.insert(req.field_name.clone(), slot);
+                } else {
+                    needs_whole_value = true;
+                    break;
+                }
+            }
+        }
+
+        if needs_whole_value {
+            projections.clear();
+            column_slots.clear();
+            base_row_slot = Some(0);
+            projections.push(ScanProjection {
+                source: ScanSource::whole_value(),
+                target_slot: 0,
+            });
+            next_slot = 1;
+        }
+
+        let layout = ScanLayout { projections };
+
+        // Store table function scan info for bytecode emission
+        self.table_fn_scans.insert(
+            scan_id,
+            TableFnScanInfo {
+                func_name,
+                layout: layout.clone(),
+                arguments: call_expr.arguments.clone(),
+            },
+        );
+
+        let resolver = PipelineSlotResolver {
+            base_row_slot,
+            scan_alias: scan.as_key.clone(),
+            table_name,
+            column_slots,
+        };
+
+        // Store scan metadata so find_scan_id_for can locate this scan.
+        let dummy_object_id = ObjectId::from((
+            partiql_common::catalog::CatalogId::from(u64::MAX),
+            partiql_common::catalog::EntryId::from(u64::MAX),
+        ));
+        let mut scan_metadata = HashMap::new();
+        scan_metadata.insert(
+            scan_id,
+            ScanMetadata {
+                layout,
+                object_id: dummy_object_id,
+            },
+        );
+
+        Ok(Some(SubtreeResult {
+            resolver: ResolverKind::Pipeline(resolver),
+            cursor_id: None,
+            scan_metadata,
+            slot_count: next_slot as usize,
+            shape: None,
+        }))
+    }
+
+    /// Search all catalogs for a table function by name.
+    fn resolve_table_function(&self, name: &str) -> Option<TableFunctionHandle> {
+        // Search through all registered catalogs
+        for catalog_name in ["default"] {
+            if let Some((_id, catalog)) = self.compilation_context.get_catalog(catalog_name) {
+                if let Some(handle) = catalog.get_table_function(name) {
+                    return Some(handle);
+                }
+            }
+        }
+        None
     }
 
     // -----------------------------------------------------------------------

--- a/partiql-eval/src/engine/expr.rs
+++ b/partiql-eval/src/engine/expr.rs
@@ -340,6 +340,16 @@ pub enum Inst {
         src: u16,
         cursor_id: u16,
     },
+    /// Create a table function cursor from evaluated arguments in registers.
+    ///
+    /// Looks up the table function by name (from the keys pool at `func_name_idx`),
+    /// reads arguments from the register bank using the slot mapping stored in
+    /// `TableFnScanMetadata`, calls `create()` to produce a `DataSource`, and
+    /// stores it in the cursor slot. The subsequent `OpenCursor` opens it.
+    CreateTableFnCursor {
+        cursor_id: u16,
+        func_name_idx: u16,
+    },
     GetField {
         dst: u16,
         base: u16,
@@ -1631,6 +1641,7 @@ impl Program {
             | Inst::Halt
             | Inst::DecrOrJump { .. }
             | Inst::MaterializeCursor { .. }
+            | Inst::CreateTableFnCursor { .. }
             | Inst::AssertCollection { .. } => {
                 return Err(EngineError::IllegalState(
                     "relational instruction encountered in scalar eval_inst".to_string(),

--- a/partiql-eval/src/engine/plan.rs
+++ b/partiql-eval/src/engine/plan.rs
@@ -41,6 +41,17 @@ pub struct ScanMetadata {
     pub object_id: ObjectId,
 }
 
+/// Metadata for a table function scan, known at compile time.
+///
+/// Associates a table function scan with its function name, output layout,
+/// and the register slots where each argument has been evaluated.
+#[derive(Clone, Debug)]
+pub struct TableFnScanMetadata {
+    pub func_name: String,
+    pub layout: ScanLayout,
+    pub arg_slots: Vec<crate::engine::arena::SlotId>,
+}
+
 /// Metadata for a cursor in bytecode mode.
 ///
 /// Each cursor corresponds to a data source that can be opened/closed/iterated.
@@ -83,6 +94,9 @@ pub struct CompiledPlan {
     pub(crate) inline_scans: HashMap<ScanId, Vec<ValueOwned>>,
     /// Scan IDs that are expression-based (materialized at runtime via MaterializeCursor).
     pub(crate) expr_scan_ids: Vec<ScanId>,
+    /// Table function scans keyed by ScanId. These are bound at runtime by
+    /// the `CreateTableFnCursor` instruction.
+    pub(crate) table_fn_scans: HashMap<ScanId, TableFnScanMetadata>,
 }
 
 // Safety: Program is Send+Sync (verified by its own unsafe impl).
@@ -100,6 +114,7 @@ impl Clone for CompiledPlan {
             scan_metadata: self.scan_metadata.clone(),
             inline_scans: self.inline_scans.clone(),
             expr_scan_ids: self.expr_scan_ids.clone(),
+            table_fn_scans: self.table_fn_scans.clone(),
         }
     }
 }
@@ -111,7 +126,30 @@ impl fmt::Display for CompiledPlan {
         writeln!(f, "  registers: {}", self.program.reg_count)?;
         writeln!(f, "  cursors: {}", self.cursors.len())?;
         for (i, cursor) in self.cursors.iter().enumerate() {
-            if let Some(meta) = self.scan_metadata.get(&cursor.scan_id) {
+            if let Some(tf_meta) = self.table_fn_scans.get(&cursor.scan_id) {
+                write!(
+                    f,
+                    "    {:4}: table_fn \"{}\" args={:?} → ",
+                    i, tf_meta.func_name, tf_meta.arg_slots
+                )?;
+                for (j, proj) in tf_meta.layout.projections.iter().enumerate() {
+                    if j > 0 {
+                        write!(f, ", ")?;
+                    }
+                    match &proj.source.source_type {
+                        crate::engine::source::ScanSourceType::WholeValue => {
+                            write!(f, "slot {} ← WholeValue", proj.target_slot)?;
+                        }
+                        crate::engine::source::ScanSourceType::FieldPath(name) => {
+                            write!(f, "slot {} ← Field(\"{}\")", proj.target_slot, name)?;
+                        }
+                        crate::engine::source::ScanSourceType::ColumnIndex(idx) => {
+                            write!(f, "slot {} ← Column({})", proj.target_slot, idx)?;
+                        }
+                    }
+                }
+                writeln!(f)?;
+            } else if let Some(meta) = self.scan_metadata.get(&cursor.scan_id) {
                 write!(f, "    {:4}: ", i)?;
                 for (j, proj) in meta.layout.projections.iter().enumerate() {
                     if j > 0 {
@@ -203,6 +241,7 @@ impl Default for CompiledPlan {
             scan_metadata: HashMap::new(),
             inline_scans: HashMap::new(),
             expr_scan_ids: Vec::new(),
+            table_fn_scans: HashMap::new(),
         }
     }
 }
@@ -284,6 +323,8 @@ pub struct PartiQLVM {
     slot_count: usize,
     /// Built-in function registry.
     builtins: BuiltinFunctions,
+    /// Registered table functions, keyed by name.
+    table_functions: HashMap<String, Arc<dyn crate::engine::source::TableFunction>>,
 }
 
 impl PartiQLVM {
@@ -315,6 +356,7 @@ impl PartiQLVM {
             halted: false,
             slot_count,
             builtins: BuiltinFunctions::new(),
+            table_functions: exec_context.table_functions().clone(),
         };
 
         // Pre-create data sources from catalog
@@ -336,6 +378,15 @@ impl PartiQLVM {
 
             // Skip expression scans — they are bound at runtime by MaterializeCursor
             if self.compiled.expr_scan_ids.contains(&cursor_info.scan_id) {
+                continue;
+            }
+
+            // Skip table function scans — they are bound at runtime by CreateTableFnCursor
+            if self
+                .compiled
+                .table_fn_scans
+                .contains_key(&cursor_info.scan_id)
+            {
                 continue;
             }
 
@@ -404,6 +455,7 @@ impl PartiQLVM {
             }
             *cursor = None;
         }
+        self.table_functions = exec_context.table_functions().clone();
         self.bind_cursors(exec_context)?;
         self.ip = 0;
         self.halted = false;
@@ -590,6 +642,35 @@ impl<'vm> QueryIterator<'vm> {
                     };
                     self.vm.cursors[*cursor_id as usize] =
                         Some(DataSourceImpl::Inline(InlineDataSource::new(values)));
+                }
+
+                Inst::CreateTableFnCursor {
+                    cursor_id,
+                    func_name_idx,
+                } => {
+                    let func_name = &program.keys[*func_name_idx as usize];
+                    let table_fn = match self.vm.table_functions.get(func_name) {
+                        Some(f) => f.clone(),
+                        None => {
+                            return Some(Err(EngineError::IllegalState(format!(
+                                "table function '{}' not registered",
+                                func_name
+                            ))))
+                        }
+                    };
+
+                    let scan_id = self.vm.compiled.cursors[*cursor_id as usize].scan_id;
+                    let tf_meta = &self.vm.compiled.table_fn_scans[&scan_id];
+
+                    let reader = RegisterReader::new(regs);
+                    let data_source =
+                        match table_fn.create(&reader, &tf_meta.arg_slots, &tf_meta.layout) {
+                            Ok(ds) => ds,
+                            Err(e) => return Some(Err(e)),
+                        };
+
+                    self.vm.cursors[*cursor_id as usize] =
+                        Some(DataSourceImpl::Catalog(data_source));
                 }
 
                 // All scalar instructions delegate to eval_inst

--- a/partiql-eval/src/engine/source/api.rs
+++ b/partiql-eval/src/engine/source/api.rs
@@ -1,5 +1,7 @@
 use crate::engine::arena::SlotId;
 use crate::engine::error::Result;
+use crate::engine::value::RegisterReader;
+use std::sync::Arc;
 
 /// Indicates how long data in a buffer remains valid after a read operation.
 ///
@@ -237,4 +239,67 @@ pub trait DataSourceMetadata: Send + Sync {
     /// Returns `Some(ScanSource)` if the field can be provided, `None` otherwise.
     /// Used by the compiler to determine how to access each required field.
     fn resolve(&self, field_name: &str) -> Option<ScanSource>;
+}
+
+/// Factory for creating a streaming DataSource from evaluated arguments.
+///
+/// Table functions are registered by name and invoked at runtime when the
+/// VM encounters a `CreateTableFnCursor` instruction. The function receives
+/// the full register bank (as a `RegisterReader`) plus a slice of slot indices
+/// indicating where each argument lives. This allows reading arguments of any
+/// type, including complex values (tuples, lists) via `reader.get_value_view()`.
+///
+/// # Contract
+///
+/// String/bytes data read from the `RegisterReader` is only guaranteed valid
+/// for the duration of `create()`. Implementations must `.to_string()` or copy
+/// any data they need to retain.
+///
+/// # Example
+/// ```ignore
+/// struct ScanIonFn;
+///
+/// impl TableFunction for ScanIonFn {
+///     fn create(
+///         &self,
+///         reader: &RegisterReader<'_>,
+///         arg_slots: &[SlotId],
+///         layout: &ScanLayout,
+///     ) -> Result<Box<dyn DataSource>> {
+///         let path = reader.get_str(arg_slots[0] as usize)
+///             .ok_or(EngineError::ReaderError("scan_ion requires a path".into()))?
+///             .to_string();
+///         Ok(Box::new(IonDataSource::new(path, layout.clone())))
+///     }
+/// }
+/// ```
+pub trait TableFunction: Send + Sync {
+    fn create(
+        &self,
+        reader: &RegisterReader<'_>,
+        arg_slots: &[SlotId],
+        layout: &ScanLayout,
+    ) -> Result<Box<dyn DataSource>>;
+}
+
+/// Compile-time handle returned by `CompilationCatalog::get_table_function()`.
+///
+/// Provides metadata about the function's output schema so the compiler can
+/// build a `ScanLayout` (resolve field names to column indices/types).
+pub struct TableFunctionHandle {
+    pub metadata: Arc<dyn DataSourceMetadata>,
+}
+
+impl TableFunctionHandle {
+    pub fn new(metadata: Arc<dyn DataSourceMetadata>) -> Self {
+        TableFunctionHandle { metadata }
+    }
+
+    pub fn buffer_stability(&self) -> BufferStability {
+        self.metadata.buffer_stability()
+    }
+
+    pub fn resolve(&self, field_name: &str) -> Option<ScanSource> {
+        self.metadata.resolve(field_name)
+    }
 }

--- a/partiql-eval/src/engine/source/mod.rs
+++ b/partiql-eval/src/engine/source/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod api;
 // Re-export public API types from api.rs
 pub use api::{
     BufferStability, DataSource, DataSourceMetadata, PhysicalType, ScanLayout, ScanProjection,
-    ScanSource, ScanSourceType,
+    ScanSource, ScanSourceType, TableFunction, TableFunctionHandle,
 };
 
 // Re-export ScanId and CatalogScans for catalog implementations

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,12 +1,9 @@
 use partiql_tools::common;
 
-use common::{
-    count_rows_from_file, create_catalog, lower, parse, random_catalog, simple_catalog,
-    CompiledSourceFactory,
-};
+use common::{create_table_fn_catalog, lower, parse};
 use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
-use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanCompiler};
+use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -17,9 +14,6 @@ use reedline::{
     ValidationResult, Validator,
 };
 
-const BATCH_SIZE: usize = 1;
-const NUM_BATCHES: usize = 10_000;
-
 /// Maximum number of lines retained in the REPL history file.
 const HISTORY_CAPACITY: usize = 1000;
 
@@ -29,18 +23,12 @@ const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "@", env!("PQLITE_GIT_S
 
 /// Pqlite: An interactive PartiQL database engine and REPL.
 ///
-/// Note: `~input~` in the query is replaced with `data`.
+/// Use table functions in queries to access data:
+///   SELECT t.a FROM mem(100, 2) t;
+///   SELECT t.name FROM scan_ion('data.ion') t;
 #[derive(Parser)]
 #[command(name = "pqlite", version = VERSION)]
 struct Cli {
-    /// Data source: mem | rand | ion | ionb.
-    #[arg(long, default_value = "mem", global = true)]
-    data_source: String,
-
-    /// Path to the data file (required for file-based data sources).
-    #[arg(long, global = true)]
-    data_path: Option<String>,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -57,15 +45,6 @@ enum Commands {
 fn main() {
     let cli = Cli::parse();
 
-    // File-based data sources require an explicit --data-path.
-    if cli.data_source != "mem" && cli.data_source != "rand" && cli.data_path.is_none() {
-        eprintln!(
-            "Error: --data-path is required for file-based data source '{}'",
-            cli.data_source
-        );
-        std::process::exit(1);
-    }
-
     match &cli.command {
         Some(Commands::Exec { query }) => {
             let query = normalize_query(query);
@@ -73,13 +52,13 @@ fn main() {
                 eprintln!("Error: empty query");
                 std::process::exit(1);
             }
-            if let Err(e) = execute_query(query, &cli.data_source, cli.data_path.as_ref()) {
+            if let Err(e) = execute_query(query) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
         }
         None => {
-            run_repl(&cli.data_source, cli.data_path.as_ref());
+            run_repl();
         }
     }
 }
@@ -192,13 +171,16 @@ fn home_dir() -> Option<std::path::PathBuf> {
 fn print_help() {
     println!("PartiQL REPL — available commands:");
     println!("  .help     Show this help message");
-    println!("  .tables   List tables in the current catalog");
     println!("  .quit     Exit the REPL (alias: .exit)");
     println!("  .exit     Exit the REPL (alias: .quit)");
     println!();
-    println!("To run a query, type any PartiQL statement and press Enter,");
-    println!("e.g.  SELECT a FROM ~input~ LIMIT 5");
-    println!("(`~input~` is replaced with the `data` table.)");
+    println!("To run a query, type any PartiQL statement and press Enter.");
+    println!("Available table functions:");
+    println!("  mem(rows, cols)       — sequential integer data");
+    println!("  rand(rows, cols)      — random integer data");
+    println!("  scan_ion(path)        — read Ion file");
+    println!();
+    println!("Example: SELECT t.a, t.b FROM mem(100, 2) t LIMIT 5;");
 }
 
 /// Outcome of handling a REPL meta-command (a line starting with `.`).
@@ -215,10 +197,6 @@ fn handle_meta_command(input: &str) -> MetaOutcome {
         ".quit" | ".exit" => MetaOutcome::Quit,
         ".help" => {
             print_help();
-            MetaOutcome::Handled
-        }
-        ".tables" => {
-            println!("Mock: Current tables in catalog: [data]");
             MetaOutcome::Handled
         }
         _ => {
@@ -240,7 +218,7 @@ fn print_startup_banner() {
 /// Run the interactive REPL: read a line, execute it as a query, and loop.
 ///
 /// Errors from `execute_query` are reported but never terminate the session.
-fn run_repl(data_source: &str, data_path: Option<&String>) {
+fn run_repl() {
     print_startup_banner();
 
     let mut line_editor = Reedline::create()
@@ -276,7 +254,7 @@ fn run_repl(data_source: &str, data_path: Option<&String>) {
                     continue;
                 }
 
-                if let Err(e) = execute_query(query, data_source, data_path) {
+                if let Err(e) = execute_query(query) {
                     eprintln!("{}", e);
                 }
             }
@@ -298,50 +276,13 @@ fn run_repl(data_source: &str, data_path: Option<&String>) {
     }
 }
 
-fn execute_query(
-    query_str: &str,
-    data_source: &str,
-    data_path: Option<&String>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Replace !input with data (no parentheses for hybrid)
-    let query = query_str.replace("~input~", "data");
+fn execute_query(query_str: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let query = query_str.to_string();
 
-    println!("Query:       {}", query);
-    println!("Data Source: {}", data_source);
-    if let Some(path) = data_path {
-        println!("Data Path:   {}", path);
-    }
-
-    let total_rows = if data_source == "mem" || data_source == "rand" {
-        let batch_size = BATCH_SIZE;
-        let num_batches = NUM_BATCHES;
-        let total = batch_size * num_batches;
-        println!(
-            "Reader Config: batch_size={}, num_batches={}, total_rows={}",
-            batch_size,
-            num_batches,
-            common::format_with_commas(total)
-        );
-        total
-    } else if let Some(path) = data_path {
-        let total = count_rows_from_file(data_source, path);
-        println!(
-            "Reader Config: total_rows={} (from file)",
-            common::format_with_commas(total)
-        );
-        total
-    } else {
-        0
-    };
-
-    std::env::set_var("TOTAL_ROWS", total_rows.to_string());
-
+    println!("Query: {}", query);
     println!();
 
-    let catalog = create_catalog(data_source.to_string(), data_path.cloned());
-
-    // Default column names for in-memory reader
-    let column_names = vec!["a".to_string(), "b".to_string()];
+    let catalog = create_table_fn_catalog();
 
     // Phase 1: Parse
     let parse_start = Instant::now();
@@ -368,42 +309,14 @@ fn execute_query(
     // Phase 3: Compile (Logical → CompiledPlan)
     let compile_start = Instant::now();
 
-    // Set up compilation context - use two-phase catalog pattern for ALL data sources
+    // Set up compilation context with table function support
     let mut context = CompilationContext::new();
 
-    // Create appropriate catalog based on data source - all use two-phase pattern
-    // The execution catalog is wrapped in an enum to handle different concrete types
-    enum ExecCatalog {
-        Random(common::RandomExecutionCatalog),
-        Simple(common::SimpleExecutionCatalog),
-    }
-
-    let (comp_catalog, mut exec_catalog_inner) = match data_source {
-        "rand" => {
-            // Random catalog for custom reader demonstration
-            let (comp, exec) =
-                random_catalog(vec![("data".to_string(), total_rows, column_names.clone())]);
-            (comp, ExecCatalog::Random(exec))
-        }
-        "mem" | "ion" | "ionb" => {
-            // Simple catalog for mem/ion data sources - use CompiledSourceFactory
-            let factory = match data_source {
-                "mem" => CompiledSourceFactory::mem(total_rows, column_names.clone()),
-                "ion" | "ionb" => {
-                    CompiledSourceFactory::ion(data_path.cloned().unwrap_or_default())
-                }
-                _ => unreachable!(),
-            };
-            let (comp, exec) = simple_catalog(vec![("data".to_string(), factory)]);
-            (comp, ExecCatalog::Simple(exec))
-        }
-        _ => {
-            return Err(format!("Unsupported data source: {}", data_source).into());
-        }
-    };
-
-    // Add catalog and CAPTURE the returned catalog_id - this is the ONLY place catalog_id is assigned
-    let catalog_id = context.add_catalog("default", comp_catalog);
+    // Use TableFnCompilationCatalog which supports both table lookups and table functions
+    let column_names = vec!["a".to_string(), "b".to_string()];
+    let comp_catalog: std::sync::Arc<dyn partiql_eval::CompilationCatalog> =
+        std::sync::Arc::new(common::TableFnCompilationCatalog::new(column_names));
+    let _catalog_id = context.add_catalog("default", comp_catalog);
 
     let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
     let compiled = compiler
@@ -419,19 +332,14 @@ fn execute_query(
     // Phase 4: Execute
     let exec_start = Instant::now();
 
-    // Prepare execution catalog with catalog-specific scans (ScanId-based pattern)
-    let catalog_scans = compiled.scans_for_catalog(catalog_id);
-    match &mut exec_catalog_inner {
-        ExecCatalog::Random(exec) => exec.prepare(&catalog_scans),
-        ExecCatalog::Simple(exec) => exec.prepare(&catalog_scans),
-    }
-
-    // Create ExecutionContext and ALWAYS populate it with execution catalog
+    // Create ExecutionContext with table functions registered
     let mut exec_context = ExecutionContext::new();
-    match exec_catalog_inner {
-        ExecCatalog::Random(exec) => exec_context.add_catalog(catalog_id, Box::new(exec)),
-        ExecCatalog::Simple(exec) => exec_context.add_catalog(catalog_id, Box::new(exec)),
-    }
+    exec_context.register_table_function("rand", std::sync::Arc::new(common::RandTableFunction));
+    exec_context.register_table_function("mem", std::sync::Arc::new(common::MemTableFunction));
+    exec_context.register_table_function(
+        "scan_ion",
+        std::sync::Arc::new(common::ScanIonTableFunction),
+    );
 
     let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
         .map_err(|e| format!("Execution setup error: {:?}", e))?;

--- a/partiql-tools/src/common.rs
+++ b/partiql-tools/src/common.rs
@@ -12,6 +12,9 @@ use partiql_eval::error::PlanErr;
 use partiql_eval::eval::EvalPlan;
 use partiql_eval::plan::{EvaluationMode, EvaluatorPlanner};
 use partiql_eval::source::DataSourceHandle;
+use partiql_eval::source::{
+    TableFunction as VmTableFunction, TableFunctionHandle as VmTableFunctionHandle,
+};
 use partiql_eval::CompilationCatalog;
 use partiql_extension_ion::decode::{IonDecoderBuilder, IonDecoderConfig};
 use partiql_extension_ion::Encoding;
@@ -311,11 +314,14 @@ impl BaseTableExpr for DataTableExpr {
 pub fn create_catalog(data_source: String, data_path: Option<String>) -> Box<dyn SharedCatalog> {
     let mut catalog = PartiqlCatalog::default();
 
-    // Add the data table function
+    // Add the data table function (legacy: used by other binaries)
     let data_fn = TableFunction::new(Box::new(DataTableFunction::new(data_source, data_path)));
     catalog
         .add_table_function(data_fn)
         .expect("Failed to add table function");
+
+    // Register table functions for the VM path (rand, mem, scan_ion)
+    register_table_fn_stubs(&mut catalog);
 
     // Add type entry for "data" table so it can be referenced without parentheses
     let mut bld = PartiqlShapeBuilder::default();
@@ -336,6 +342,91 @@ pub fn create_catalog(data_source: String, data_path: Option<String>) -> Box<dyn
     Box::new(catalog.to_shared_catalog())
 }
 
+/// Create a frontend catalog with only table function stubs (no legacy data table).
+/// Used by pqlite when table functions are the sole data source mechanism.
+pub fn create_table_fn_catalog() -> Box<dyn SharedCatalog> {
+    let mut catalog = PartiqlCatalog::default();
+    register_table_fn_stubs(&mut catalog);
+    Box::new(catalog.to_shared_catalog())
+}
+
+fn register_table_fn_stubs(catalog: &mut PartiqlCatalog) {
+    catalog
+        .add_table_function(TableFunction::new(Box::new(StubTableFn::new(
+            "rand",
+            vec![
+                partiql_catalog::call_defs::CallSpecArg::Positional,
+                partiql_catalog::call_defs::CallSpecArg::Positional,
+            ],
+        ))))
+        .expect("Failed to add rand table function");
+    catalog
+        .add_table_function(TableFunction::new(Box::new(StubTableFn::new(
+            "mem",
+            vec![
+                partiql_catalog::call_defs::CallSpecArg::Positional,
+                partiql_catalog::call_defs::CallSpecArg::Positional,
+            ],
+        ))))
+        .expect("Failed to add mem table function");
+    catalog
+        .add_table_function(TableFunction::new(Box::new(StubTableFn::new(
+            "scan_ion",
+            vec![partiql_catalog::call_defs::CallSpecArg::Positional],
+        ))))
+        .expect("Failed to add scan_ion table function");
+}
+
+/// Stub table function for the frontend planner. Only provides `call_def()` so
+/// the planner can validate the call and produce a `CallExpr` in the logical plan.
+/// The actual execution is handled by the VM's `TableFunction` implementations.
+#[derive(Debug)]
+struct StubTableFn {
+    call_def: CallDef,
+}
+
+impl StubTableFn {
+    fn new(name: &'static str, input: Vec<partiql_catalog::call_defs::CallSpecArg>) -> Self {
+        StubTableFn {
+            call_def: CallDef {
+                names: vec![name],
+                overloads: vec![CallSpec {
+                    input,
+                    output: Box::new(move |args| {
+                        partiql_logical::ValueExpr::Call(partiql_logical::CallExpr {
+                            name: partiql_logical::CallName::ByName(name.to_string()),
+                            arguments: args,
+                        })
+                    }),
+                }],
+            },
+        }
+    }
+}
+
+impl BaseTableFunctionInfo for StubTableFn {
+    fn call_def(&self) -> &CallDef {
+        &self.call_def
+    }
+
+    fn plan_eval(&self) -> Box<dyn BaseTableExpr> {
+        Box::new(StubTableExpr)
+    }
+}
+
+#[derive(Debug)]
+struct StubTableExpr;
+
+impl BaseTableExpr for StubTableExpr {
+    fn evaluate<'c>(
+        &self,
+        _args: &[Cow<'_, Value>],
+        _ctx: &'c dyn SessionContext,
+    ) -> BaseTableExprResult<'c> {
+        unreachable!("StubTableExpr should never be evaluated — VM handles execution")
+    }
+}
+
 // =============================================================================
 // Random Data Source - Customer-Provided Reader Example
 // =============================================================================
@@ -354,7 +445,10 @@ use partiql_eval::source::{
     BufferStability, CatalogScans, DataSource, DataSourceMetadata, PhysicalType, RegisterWriter,
     ScanId, ScanLayout, ScanSource, ScanSourceType,
 };
+use partiql_eval::value::RegisterReader;
 use partiql_eval::{ExecutionCatalog, Result as EvalResult};
+
+type SlotId = u16;
 use rand::Rng;
 
 /// Custom DataSource that generates random integer data
@@ -1213,4 +1307,147 @@ pub fn simple_catalog(
     let comp_catalog = Arc::new(SimpleCompilationCatalog::new(tables.clone()));
     let exec_catalog = SimpleExecutionCatalog::new(tables);
     (comp_catalog, exec_catalog)
+}
+
+// =============================================================================
+// Table Function implementations for the VM engine
+// =============================================================================
+
+/// Compile-time metadata for table functions that produce columnar integer data.
+/// Used by `rand()` and `mem()` table functions.
+pub struct ColumnarIntMetadata {
+    column_names: Vec<String>,
+}
+
+impl ColumnarIntMetadata {
+    pub fn new(column_names: Vec<String>) -> Self {
+        ColumnarIntMetadata { column_names }
+    }
+}
+
+impl DataSourceMetadata for ColumnarIntMetadata {
+    fn buffer_stability(&self) -> BufferStability {
+        BufferStability::UntilNext
+    }
+
+    fn resolve(&self, field_name: &str) -> Option<ScanSource> {
+        self.column_names
+            .iter()
+            .position(|name| name.eq_ignore_ascii_case(field_name))
+            .map(|index| ScanSource::column(index, PhysicalType::I64))
+    }
+}
+
+/// Compile-time metadata for Ion table functions (dynamic schema).
+pub struct DynamicSchemaMetadata;
+
+impl DataSourceMetadata for DynamicSchemaMetadata {
+    fn buffer_stability(&self) -> BufferStability {
+        BufferStability::UntilNext
+    }
+
+    fn resolve(&self, field_name: &str) -> Option<ScanSource> {
+        Some(ScanSource::field(field_name, PhysicalType::Dynamic))
+    }
+}
+
+/// Table function: `rand(total_rows, num_columns)`
+///
+/// Generates random integer data. Each column gets a random i64 value per row.
+pub struct RandTableFunction;
+
+impl VmTableFunction for RandTableFunction {
+    fn create(
+        &self,
+        reader: &RegisterReader<'_>,
+        arg_slots: &[SlotId],
+        layout: &ScanLayout,
+    ) -> EvalResult<Box<dyn DataSource>> {
+        let total_rows = reader.get_i64(arg_slots[0] as usize).ok_or_else(|| {
+            partiql_eval::EngineError::ReaderError("rand: arg 0 must be integer".into())
+        })? as usize;
+        let num_columns = reader.get_i64(arg_slots[1] as usize).ok_or_else(|| {
+            partiql_eval::EngineError::ReaderError("rand: arg 1 must be integer".into())
+        })? as usize;
+        Ok(Box::new(RandomDataSource::new(
+            total_rows,
+            num_columns,
+            layout.clone(),
+        )))
+    }
+}
+
+/// Table function: `mem(total_rows, num_columns)`
+///
+/// Generates sequential integer data. Row N has value N in all columns.
+pub struct MemTableFunction;
+
+impl VmTableFunction for MemTableFunction {
+    fn create(
+        &self,
+        reader: &RegisterReader<'_>,
+        arg_slots: &[SlotId],
+        layout: &ScanLayout,
+    ) -> EvalResult<Box<dyn DataSource>> {
+        let total_rows = reader.get_i64(arg_slots[0] as usize).ok_or_else(|| {
+            partiql_eval::EngineError::ReaderError("mem: arg 0 must be integer".into())
+        })? as usize;
+        let num_columns = reader.get_i64(arg_slots[1] as usize).ok_or_else(|| {
+            partiql_eval::EngineError::ReaderError("mem: arg 1 must be integer".into())
+        })? as usize;
+        Ok(Box::new(InMemGeneratedReader::new(
+            total_rows,
+            num_columns,
+            layout.clone(),
+        )))
+    }
+}
+
+/// Table function: `scan_ion(path)`
+///
+/// Reads Ion data from a file path, streaming rows lazily.
+pub struct ScanIonTableFunction;
+
+impl VmTableFunction for ScanIonTableFunction {
+    fn create(
+        &self,
+        reader: &RegisterReader<'_>,
+        arg_slots: &[SlotId],
+        layout: &ScanLayout,
+    ) -> EvalResult<Box<dyn DataSource>> {
+        let path = reader
+            .get_str(arg_slots[0] as usize)
+            .ok_or_else(|| {
+                partiql_eval::EngineError::ReaderError("scan_ion: arg 0 must be string".into())
+            })?
+            .to_string();
+        Ok(Box::new(IonDataSource::new(path, layout.clone())))
+    }
+}
+
+/// CompilationCatalog that provides table function metadata for pqlite.
+pub struct TableFnCompilationCatalog {
+    column_names: Vec<String>,
+}
+
+impl TableFnCompilationCatalog {
+    pub fn new(column_names: Vec<String>) -> Self {
+        TableFnCompilationCatalog { column_names }
+    }
+}
+
+impl CompilationCatalog for TableFnCompilationCatalog {
+    fn get_table(&self, _path: &[BindingsName<'_>]) -> Option<DataSourceHandle> {
+        None
+    }
+
+    fn get_table_function(&self, name: &str) -> Option<VmTableFunctionHandle> {
+        match name {
+            "rand" | "mem" => Some(VmTableFunctionHandle::new(Arc::new(
+                ColumnarIntMetadata::new(self.column_names.clone()),
+            ))),
+            "scan_ion" => Some(VmTableFunctionHandle::new(Arc::new(DynamicSchemaMetadata))),
+            _ => None,
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Introduces a `TableFunction` trait in `partiql-eval` that receives `RegisterReader` + arg slot mapping + `ScanLayout` and returns a streaming `DataSource`. This enables zero-copy reading of table function arguments and zero-copy writing of data into the vm. It reuses `OpenCursor`, `NextRow`, and `CloseCursor`.
- Adds `CreateTableFnCursor` bytecode instruction that binds a table function cursor at runtime, then reuses existing `OpenCursor`/`NextRow`/`CloseCursor` for iteration
  - I would prefer to not carry over the function name as an execution-time load, but the planner today doesn't give unique ids to each table function. For now, this will suffice.
- Extends `CompilationCatalog` with `get_table_function()` for compile-time resolution and `ExecutionContext` with `register_table_function()` for runtime registration
- Implements `rand(rows, cols)`, `mem(rows, cols)`, and `scan_ion(path)` table functions for pqlite

## Usage

Queries use explicit alias syntax for field access:
```sql
SELECT t.a, t.b FROM mem(10000, 2) t LIMIT 5;
SELECT t.name, t.age FROM scan_ion('/path/to/data.ion') t;
SELECT r.a FROM rand(100, 2) r LIMIT 10;
```

## Test plan

- [x] `cargo build -p partiql-eval -p partiql-tools` — clean build
- [x] `cargo test -p partiql-eval` — no regressions
- [x] `pqlite exec "SELECT m.a, m.b FROM mem(5, 2) m"` — sequential integers
- [x] `pqlite exec "SELECT r.a, r.b FROM rand(3, 2) r"` — random i64 values
- [x] `pqlite exec "SELECT t.name, t.age FROM scan_ion('/tmp/test.ion') t"` — Ion file streaming

## Known limitation

Unqualified field references (`SELECT a FROM mem(5, 2)`) don't resolve because the frontend planner produces `VarRef("a", Global)` instead of `Path(VarRef(alias), Key("a"))`. This is a planner-level fix tracked separately. Use explicit alias syntax (`SELECT m.a FROM mem(5, 2) m`) as a workaround.