### PR TITLE
feat: parse CREATE TABLE ... AS (query) (CTAS) in pqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- *BREAKING* partiql-parser: `Parsed`'s `ast` field type changed from `ast::AstNode<ast::TopLevelQuery>` to `ast::AstNode<ast::Item>` to support DDL statements alongside queries. Code that accesses `parsed.ast` must now match on `ast::Item` (e.g. `Item::Query`) to reach the query node.
 
 ### Added
+- partiql-parser: Parsing support for `CREATE TABLE <name>` and `CREATE TABLE <name> AS (<query>)` (CTAS). DDL lowering/evaluation is not yet implemented and surfaces a `NotYetImplemented` error.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- *BREAKING* partiql-parser: `Parsed`'s `ast` field type changed from `ast::AstNode<ast::TopLevelQuery>` to `ast::AstNode<ast::Item>` to support DDL statements alongside queries. Code that accesses `parsed.ast` must now match on `ast::Item` (e.g. `Item::Query`) to reach the query node.
+- *BREAKING* partiql-parser: `Parsed`'s `ast` field replaced by `statements: Vec<AstNode<Statement>>`. The `Item` enum is renamed to `Statement` with bare variants (`Statement::Query(TopLevelQuery)`, `Statement::Ddl(DdlOp)`, `Statement::Dml(Dml)`). The single-field `Ddl` wrapper struct is removed; `DdlOp` is held directly. Code that accessed `parsed.ast` must now use `parsed.statements[0]` and match on `Statement` variants.
 
 ### Added
 - partiql-parser: Parsing support for `CREATE TABLE <name>` and `CREATE TABLE <name> AS (<query>)` (CTAS). DDL lowering/evaluation is not yet implemented and surfaces a `NotYetImplemented` error.

--- a/partiql-ast-passes/src/name_resolver.rs
+++ b/partiql-ast-passes/src/name_resolver.rs
@@ -129,9 +129,12 @@ impl<'c> NameResolver<'c> {
 
     pub fn resolve(
         &mut self,
-        query: &ast::AstNode<ast::TopLevelQuery>,
+        query: &ast::TopLevelQuery,
+        stmt_id: NodeId,
     ) -> Result<KeyRegistry, AstTransformationError> {
+        self.id_path_to_root.push(stmt_id);
         query.visit(self);
+        self.id_path_to_root.pop();
         if !self.errors.is_empty() {
             return Err(AstTransformationError {
                 errors: std::mem::take(&mut self.errors),

--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -50,7 +50,7 @@ pub enum Item {
     // Data Modification Language statements
     Dml(Dml),
     // Data retrieval statements
-    Query(Query),
+    Query(AstNode<TopLevelQuery>),
 }
 
 impl fmt::Display for Item {
@@ -69,7 +69,7 @@ pub struct Ddl {
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DdlOp {
-    /// `CREATE TABLE <symbol>`
+    /// `CREATE TABLE <symbol>` or `CREATE TABLE <symbol> AS (<query>)`
     CreateTable(CreateTable),
     /// `DROP TABLE <Ident>`
     DropTable(DropTable),
@@ -80,11 +80,14 @@ pub enum DdlOp {
     DropIndex(DropIndex),
 }
 
-#[derive(Visit, Clone, Debug, PartialEq, Eq)]
+#[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CreateTable {
     #[visit(skip)]
     pub table_name: SymbolPrimitive,
+    /// Optional source query for `CREATE TABLE <name> AS (<query>)` (CTAS).
+    /// `None` for a plain `CREATE TABLE <name>`.
+    pub as_query: Option<Box<AstNode<Query>>>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq, Eq)]

--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -1,8 +1,8 @@
 //! A `PartiQL` abstract syntax tree (AST).
 //!
 //! This module contains the structures for the language AST.
-//! Two main entities in the module are [`Item`] and [`AstNode`]. `AstNode` represents an AST node
-//! and `Item` represents a `PartiQL` statement type, e.g. query, data definition language (DDL)
+//! Two main entities in the module are [`Statement`] and [`AstNode`]. `AstNode` represents an AST node
+//! and `Statement` represents a `PartiQL` statement type, e.g. query, data definition language (DDL)
 //! data manipulation language (DML).
 
 // As more changes to this AST are expected, unless explicitly advised, using the structures exposed
@@ -44,26 +44,16 @@ impl<T> IdAnnotated<NodeId> for AstNode<T> {
 
 #[derive(Visit, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Item {
-    // Data Definition Language statements
-    Ddl(Ddl),
-    // Data Modification Language statements
+pub enum Statement {
+    Query(TopLevelQuery),
+    Ddl(DdlOp),
     Dml(Dml),
-    // Data retrieval statements
-    Query(AstNode<TopLevelQuery>),
 }
 
-impl fmt::Display for Item {
+impl fmt::Display for Statement {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Use Debug formatting for now
         write!(f, "{self:?}")
     }
-}
-
-#[derive(Visit, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Ddl {
-    pub op: DdlOp,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq)]

--- a/partiql-ast/src/pretty/mod.rs
+++ b/partiql-ast/src/pretty/mod.rs
@@ -22,6 +22,71 @@ where
     }
 }
 
+impl PrettyDoc for Item {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        match self {
+            Item::Query(q) => q.pretty_doc(arena),
+            Item::Ddl(ddl) => ddl.op.pretty_doc(arena),
+            // DML pretty-printing is not yet implemented; emit an empty document
+            // rather than panicking so round-trip/snapshot harnesses degrade gracefully.
+            Item::Dml(_) => arena.nil(),
+        }
+    }
+}
+
+impl PrettyDoc for DdlOp {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        match self {
+            DdlOp::CreateTable(create_table) => create_table.pretty_doc(arena),
+            // The remaining DDL operations are not yet produced by the grammar; emit
+            // an empty document rather than panicking until they are implemented.
+            DdlOp::DropTable(_) | DdlOp::CreateIndex(_) | DdlOp::DropIndex(_) => arena.nil(),
+        }
+    }
+}
+
+impl PrettyDoc for CreateTable {
+    fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
+    where
+        D: DocAllocator<'b, A>,
+        D::Doc: Clone,
+        A: Clone,
+    {
+        let CreateTable {
+            table_name,
+            as_query,
+        } = self;
+        // `CREATE TABLE <name>`
+        let create = arena
+            .text("CREATE")
+            .append(arena.space())
+            .append(arena.text("TABLE"))
+            .append(arena.space())
+            .append(table_name.pretty_doc(arena));
+        match as_query {
+            // `CREATE TABLE <name> AS ( <query> )` (CTAS). The grammar accepts exactly
+            // this form, so the emitted text re-parses cleanly on round-trip.
+            Some(query) => create
+                .append(arena.space())
+                .append(arena.text("AS"))
+                .append(arena.space())
+                .append(pretty_parenthesized_doc(query.pretty_doc(arena), arena))
+                .group(),
+            None => create.group(),
+        }
+    }
+}
+
 impl PrettyDoc for TopLevelQuery {
     fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
     where

--- a/partiql-ast/src/pretty/mod.rs
+++ b/partiql-ast/src/pretty/mod.rs
@@ -22,7 +22,7 @@ where
     }
 }
 
-impl PrettyDoc for Item {
+impl PrettyDoc for Statement {
     fn pretty_doc<'b, D, A>(&'b self, arena: &'b D) -> DocBuilder<'b, D, A>
     where
         D: DocAllocator<'b, A>,
@@ -30,11 +30,9 @@ impl PrettyDoc for Item {
         A: Clone,
     {
         match self {
-            Item::Query(q) => q.pretty_doc(arena),
-            Item::Ddl(ddl) => ddl.op.pretty_doc(arena),
-            // DML pretty-printing is not yet implemented; emit an empty document
-            // rather than panicking so round-trip/snapshot harnesses degrade gracefully.
-            Item::Dml(_) => arena.nil(),
+            Statement::Query(q) => q.pretty_doc(arena),
+            Statement::Ddl(ddl_op) => ddl_op.pretty_doc(arena),
+            Statement::Dml(_) => arena.nil(),
         }
     }
 }

--- a/partiql-ast/src/visit.rs
+++ b/partiql-ast/src/visit.rs
@@ -99,16 +99,10 @@ pub trait Visitor<'ast> {
     fn exit_ast_node(&mut self, _id: NodeId) -> Traverse {
         Traverse::Continue
     }
-    fn enter_item(&mut self, _item: &'ast ast::Item) -> Traverse {
+    fn enter_statement(&mut self, _statement: &'ast ast::Statement) -> Traverse {
         Traverse::Continue
     }
-    fn exit_item(&mut self, _item: &'ast ast::Item) -> Traverse {
-        Traverse::Continue
-    }
-    fn enter_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Traverse {
-        Traverse::Continue
-    }
-    fn exit_ddl(&mut self, _ddl: &'ast ast::Ddl) -> Traverse {
+    fn exit_statement(&mut self, _statement: &'ast ast::Statement) -> Traverse {
         Traverse::Continue
     }
     fn enter_ddl_op(&mut self, _ddl_op: &'ast ast::DdlOp) -> Traverse {

--- a/partiql-conformance-tests/tests/mod.rs
+++ b/partiql-conformance-tests/tests/mod.rs
@@ -66,7 +66,7 @@ pub(crate) fn parse(statement: &str) -> ParserResult {
     #[cfg(feature = "test_pretty_print")]
     if let Ok(result) = &result {
         use partiql_common::pretty::ToPretty;
-        let pretty = result.ast.to_pretty_string(80);
+        let pretty = result.statements[0].to_pretty_string(80);
         if let Ok(pretty) = pretty {
             println!("{pretty}");
         } else {

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -31,22 +31,27 @@ impl<'c> LogicalPlanner<'c> {
         &self,
         parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
-        match &parsed.ast.node {
-            // Data-retrieval queries flow through the existing lowering pipeline unchanged.
-            ast::Item::Query(q) => {
+        if parsed.statements.len() != 1 {
+            return Err(AstTransformationError {
+                errors: vec![AstTransformError::NotYetImplemented(
+                    "multi-statement input".to_string(),
+                )],
+            });
+        }
+        let stmt = &parsed.statements[0];
+        match &stmt.node {
+            ast::Statement::Query(q) => {
                 let mut resolver = NameResolver::new(self.catalog);
-                let registry = resolver.resolve(q)?;
+                let registry = resolver.resolve(q, stmt.id)?;
                 let planner = AstToLogical::new(self.catalog, registry);
-                planner.lower_query(q)
+                planner.lower_query(q, stmt.id)
             }
-            // DDL/DML lowering is not yet implemented; surface a clear error rather
-            // than silently producing an empty plan.
-            ast::Item::Ddl(_) => Err(AstTransformationError {
+            ast::Statement::Ddl(_) => Err(AstTransformationError {
                 errors: vec![AstTransformError::NotYetImplemented(
                     "DDL statement lowering".to_string(),
                 )],
             }),
-            ast::Item::Dml(_) => Err(AstTransformationError {
+            ast::Statement::Dml(_) => Err(AstTransformationError {
                 errors: vec![AstTransformError::NotYetImplemented(
                     "DML statement lowering".to_string(),
                 )],

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -3,7 +3,8 @@
 
 use crate::lower::AstToLogical;
 
-use partiql_ast_passes::error::AstTransformationError;
+use partiql_ast::ast;
+use partiql_ast_passes::error::{AstTransformError, AstTransformationError};
 use partiql_ast_passes::name_resolver::NameResolver;
 use partiql_logical as logical;
 use partiql_parser::Parsed;
@@ -30,10 +31,26 @@ impl<'c> LogicalPlanner<'c> {
         &self,
         parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
-        let q = &parsed.ast;
-        let mut resolver = NameResolver::new(self.catalog);
-        let registry = resolver.resolve(q)?;
-        let planner = AstToLogical::new(self.catalog, registry);
-        planner.lower_query(q)
+        match &parsed.ast.node {
+            // Data-retrieval queries flow through the existing lowering pipeline unchanged.
+            ast::Item::Query(q) => {
+                let mut resolver = NameResolver::new(self.catalog);
+                let registry = resolver.resolve(q)?;
+                let planner = AstToLogical::new(self.catalog, registry);
+                planner.lower_query(q)
+            }
+            // DDL/DML lowering is not yet implemented; surface a clear error rather
+            // than silently producing an empty plan.
+            ast::Item::Ddl(_) => Err(AstTransformationError {
+                errors: vec![AstTransformError::NotYetImplemented(
+                    "DDL statement lowering".to_string(),
+                )],
+            }),
+            ast::Item::Dml(_) => Err(AstTransformationError {
+                errors: vec![AstTransformError::NotYetImplemented(
+                    "DML statement lowering".to_string(),
+                )],
+            }),
+        }
     }
 }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -5,12 +5,12 @@ use ordered_float::OrderedFloat;
 use partiql_ast::ast;
 use partiql_ast::ast::{
     Assignment, Bag, BagOpExpr, BagOperator, Between, BinOp, BinOpKind, Call, CallAgg, CallArg,
-    CallArgNamed, CaseSensitivity, CreateIndex, CreateTable, Ddl, DdlOp, Delete, Dml, DmlOp,
-    DropIndex, DropTable, Exclusion, Expr, FromClause, FromLet, FromLetKind, GroupByExpr, GroupKey,
-    GroupingStrategy, Insert, InsertValue, Item, Join, JoinKind, JoinSpec, Like, List, Lit,
+    CallArgNamed, CaseSensitivity, CreateIndex, CreateTable, DdlOp, Delete, Dml, DmlOp, DropIndex,
+    DropTable, Exclusion, Expr, FromClause, FromLet, FromLetKind, GroupByExpr, GroupKey,
+    GroupingStrategy, Insert, InsertValue, Join, JoinKind, JoinSpec, Like, List, Lit,
     NullOrderingSpec, OnConflict, OrderByExpr, OrderingSpec, Path, PathStep, ProjectExpr,
     Projection, ProjectionKind, Query, QuerySet, Remove, SearchedCase, Select, Set, SetQuantifier,
-    SimpleCase, SortSpec, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
+    SimpleCase, SortSpec, Statement, Struct, SymbolPrimitive, UniOp, UniOpKind, VarRef,
 };
 use partiql_ast::visit::{Traverse, Visit, Visitor};
 use partiql_logical as logical;
@@ -265,10 +265,13 @@ impl<'a> AstToLogical<'a> {
 
     pub fn lower_query(
         mut self,
-        query: &ast::AstNode<ast::TopLevelQuery>,
+        query: &ast::TopLevelQuery,
+        stmt_id: NodeId,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
         self.enter_plan();
+        self.id_stack.push(stmt_id);
         query.visit(&mut self);
+        self.id_stack.pop();
         true_or_fault_err!(
             self,
             self.plan_stack.len() == 1,
@@ -580,12 +583,8 @@ impl<'ast> Visitor<'ast> for AstToLogical<'_> {
         Traverse::Continue
     }
 
-    fn enter_item(&mut self, _item: &'ast Item) -> Traverse {
-        not_yet_implemented_fault!(self, "Item");
-    }
-
-    fn enter_ddl(&mut self, _ddl: &'ast Ddl) -> Traverse {
-        not_yet_implemented_fault!(self, "Ddl".to_string());
+    fn enter_statement(&mut self, _statement: &'ast Statement) -> Traverse {
+        not_yet_implemented_fault!(self, "Statement");
     }
 
     fn enter_ddl_op(&mut self, _ddl_op: &'ast DdlOp) -> Traverse {

--- a/partiql-parser/src/lexer/partiql.rs
+++ b/partiql-parser/src/lexer/partiql.rs
@@ -331,6 +331,8 @@ pub enum Token<'input> {
     Case,
     #[regex("(?i:Columns)")]
     Columns,
+    #[regex("(?i:Create)")]
+    Create,
     #[regex("(?i:Cross)")]
     Cross,
     #[regex("(?i:Cycle)")]
@@ -632,6 +634,7 @@ impl Token<'_> {
                 | Token::Between
                 | Token::By
                 | Token::Case
+                | Token::Create
                 | Token::Cross
                 | Token::Cycle
                 | Token::Date

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -111,7 +111,7 @@ impl Parser {
 pub struct Parsed<'input> {
     pub text: &'input str,
     pub offsets: LineOffsetTracker,
-    pub ast: ast::AstNode<ast::TopLevelQuery>,
+    pub ast: ast::AstNode<ast::Item>,
     pub locations: LocationMap,
 }
 

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -85,13 +85,13 @@ impl Parser {
     pub fn parse<'input>(&self, text: &'input str) -> ParserResult<'input> {
         match parse_partiql(text) {
             Ok(AstData {
-                ast,
+                statements,
                 locations,
                 offsets,
             }) => Ok(Parsed {
                 text,
                 offsets,
-                ast,
+                statements,
                 locations,
             }),
             Err(ErrorData { errors, offsets }) => Err(ParserError {
@@ -111,7 +111,7 @@ impl Parser {
 pub struct Parsed<'input> {
     pub text: &'input str,
     pub offsets: LineOffsetTracker,
-    pub ast: ast::AstNode<ast::Item>,
+    pub statements: Vec<ast::AstNode<ast::Statement>>,
     pub locations: LocationMap,
 }
 

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -30,13 +30,13 @@ mod grammar {
 
 type LalrpopError<'input> =
     lpop::ParseError<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
-type LalrpopResult<'input> = Result<ast::AstNode<ast::Item>, LalrpopError<'input>>;
+type LalrpopResult<'input> = Result<ast::AstNode<ast::Statement>, LalrpopError<'input>>;
 type LalrpopErrorRecovery<'input> =
     lpop::ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AstData {
-    pub ast: ast::AstNode<ast::Item>,
+    pub statements: Vec<ast::AstNode<ast::Statement>>,
     pub locations: LocationMap,
     pub offsets: LineOffsetTracker,
 }
@@ -84,8 +84,8 @@ fn parse_partiql_with_state<'input, Id: NodeIdGenerator>(
             errors.push(ParseError::from(e));
             Err(ErrorData { errors, offsets })
         }
-        (Ok(ast), true) => Ok(AstData {
-            ast,
+        (Ok(stmt), true) => Ok(AstData {
+            statements: vec![stmt],
             locations,
             offsets,
         }),
@@ -150,7 +150,7 @@ mod tests {
             let res = parse_partiql($q);
             println!("{:#?}", res);
             match res {
-                Ok(data) => data.ast,
+                Ok(data) => data.statements.into_iter().next().unwrap(),
                 _ => panic!("{:?}", res),
             }
         }};
@@ -361,18 +361,14 @@ mod tests {
 
             if let ast::AstNode {
                 node:
-                    ast::Item::Query(ast::AstNode {
-                        node:
-                            ast::TopLevelQuery {
-                                query:
-                                    ast::AstNode {
-                                        node:
-                                            ast::Query {
-                                                set:
-                                                    ast::AstNode {
-                                                        node: ast::QuerySet::Expr(ref e),
-                                                        ..
-                                                    },
+                    ast::Statement::Query(ast::TopLevelQuery {
+                        query:
+                            ast::AstNode {
+                                node:
+                                    ast::Query {
+                                        set:
+                                            ast::AstNode {
+                                                node: ast::QuerySet::Expr(ref e),
                                                 ..
                                             },
                                         ..
@@ -563,7 +559,7 @@ mod tests {
                 let res = parse_partiql_null_id($q);
                 println!("{:#?}", res);
                 match res {
-                    Ok(data) => data.ast,
+                    Ok(data) => data.statements.into_iter().next().unwrap(),
                     _ => panic!("{:?}", res),
                 }
             }};

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -30,13 +30,13 @@ mod grammar {
 
 type LalrpopError<'input> =
     lpop::ParseError<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
-type LalrpopResult<'input> = Result<ast::AstNode<ast::TopLevelQuery>, LalrpopError<'input>>;
+type LalrpopResult<'input> = Result<ast::AstNode<ast::Item>, LalrpopError<'input>>;
 type LalrpopErrorRecovery<'input> =
     lpop::ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AstData {
-    pub ast: ast::AstNode<ast::TopLevelQuery>,
+    pub ast: ast::AstNode<ast::Item>,
     pub locations: LocationMap,
     pub offsets: LineOffsetTracker,
 }
@@ -62,7 +62,7 @@ fn parse_partiql_with_state<'input, Id: NodeIdGenerator>(
     let lexer = PreprocessingPartiqlLexer::new(s, &mut offsets, &BUILT_INS);
     let lexer = CommentSkippingLexer::new(lexer);
 
-    let result: LalrpopResult<'_> = grammar::TopLevelQueryParser::new().parse(s, &mut state, lexer);
+    let result: LalrpopResult<'_> = grammar::StatementParser::new().parse(s, &mut state, lexer);
 
     let ParserState {
         locations, errors, ..
@@ -361,14 +361,18 @@ mod tests {
 
             if let ast::AstNode {
                 node:
-                    ast::TopLevelQuery {
-                        query:
-                            ast::AstNode {
-                                node:
-                                    ast::Query {
-                                        set:
-                                            ast::AstNode {
-                                                node: ast::QuerySet::Expr(ref e),
+                    ast::Item::Query(ast::AstNode {
+                        node:
+                            ast::TopLevelQuery {
+                                query:
+                                    ast::AstNode {
+                                        node:
+                                            ast::Query {
+                                                set:
+                                                    ast::AstNode {
+                                                        node: ast::QuerySet::Expr(ref e),
+                                                        ..
+                                                    },
                                                 ..
                                             },
                                         ..
@@ -376,7 +380,7 @@ mod tests {
                                 ..
                             },
                         ..
-                    },
+                    }),
                 ..
             } = res
             {
@@ -966,6 +970,47 @@ mod tests {
                     },
                 })
             );
+        }
+    }
+
+    mod ddl {
+        use super::*;
+
+        // `CREATE TABLE <name>` with no `AS (...)` clause is valid; the CtasClause
+        // is optional (`<as_query:CtasClause?>`) and leaves `as_query` as `None`.
+        #[test]
+        fn create_table_plain() {
+            parse!(r"CREATE TABLE my_table");
+        }
+
+        // CTAS over the upstream table-function layout: a function-call FROM source
+        // (`mem(5, 2)`) with alias `m` and a qualified projection `m.a`.
+        #[test]
+        fn create_table_as_select() {
+            parse!(r"CREATE TABLE new_table AS (SELECT m.a FROM mem(5, 2) m)");
+        }
+
+        // The parenthesized query is the full top-level `Query` rule, so WHERE,
+        // ORDER BY, and LIMIT are all accepted inside `AS (...)`.
+        #[test]
+        fn create_table_as_complex() {
+            parse!(
+                r"CREATE TABLE summary AS (SELECT m.a FROM mem(5, 2) m WHERE m.a > 1 ORDER BY m.a DESC LIMIT 10)"
+            );
+        }
+
+        // Negative: a missing closing parenthesis must fail gracefully (Err), not panic.
+        #[test]
+        fn create_table_as_missing_close_paren() {
+            let res = parse_partiql(r"CREATE TABLE foo AS (SELECT 1");
+            assert!(res.is_err());
+        }
+
+        // Negative: a missing table identifier must fail gracefully (Err), not panic.
+        #[test]
+        fn create_table_missing_identifier() {
+            let res = parse_partiql(r"CREATE TABLE");
+            assert!(res.is_err());
         }
     }
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -28,27 +28,18 @@ grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'
 
 // Top-level entry point: a single `PartiQL` statement, which is either a
 // data-retrieval query or a DDL operation (currently `CREATE TABLE` / CTAS).
-pub(crate) Statement: ast::AstNode<ast::Item> = {
-    <lo:@L> <query:TopLevelQuery> <hi:@R> => state.node(ast::Item::Query(query), lo..hi),
-    <lo:@L> <ddl:Ddl> <hi:@R> => state.node(ast::Item::Ddl(ddl), lo..hi),
+pub(crate) Statement: ast::AstNode<ast::Statement> = {
+    <lo:@L> <query:TopLevelQuery> <hi:@R> => state.node(ast::Statement::Query(query.node), lo..hi),
+    <lo:@L> <ddl_op:DdlOp> <hi:@R> => state.node(ast::Statement::Ddl(ddl_op), lo..hi),
 }
 
-pub(crate) TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
+TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
     <lo:@L>
     <with:WithClause?>
     <query:Query>
     <hi:@R> => {
         state.node(ast::TopLevelQuery { with, query }, lo..hi)
     }
-}
-
-// ------------------------------------------------------------------------------ //
-//                                                                                //
-//                          Data Definition Language                             //
-//                                                                                //
-// ------------------------------------------------------------------------------ //
-Ddl: ast::Ddl = {
-    <op:DdlOp> => ast::Ddl { op },
 }
 
 DdlOp: ast::DdlOp = {

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -26,6 +26,13 @@ use partiql_common::node::NodeIdGenerator;
 grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'input, Id>) where Id: NodeIdGenerator;
 
 
+// Top-level entry point: a single `PartiQL` statement, which is either a
+// data-retrieval query or a DDL operation (currently `CREATE TABLE` / CTAS).
+pub(crate) Statement: ast::AstNode<ast::Item> = {
+    <lo:@L> <query:TopLevelQuery> <hi:@R> => state.node(ast::Item::Query(query), lo..hi),
+    <lo:@L> <ddl:Ddl> <hi:@R> => state.node(ast::Item::Ddl(ddl), lo..hi),
+}
+
 pub(crate) TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
     <lo:@L>
     <with:WithClause?>
@@ -33,6 +40,33 @@ pub(crate) TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
     <hi:@R> => {
         state.node(ast::TopLevelQuery { with, query }, lo..hi)
     }
+}
+
+// ------------------------------------------------------------------------------ //
+//                                                                                //
+//                          Data Definition Language                             //
+//                                                                                //
+// ------------------------------------------------------------------------------ //
+Ddl: ast::Ddl = {
+    <op:DdlOp> => ast::Ddl { op },
+}
+
+DdlOp: ast::DdlOp = {
+    <c:CreateTable> => ast::DdlOp::CreateTable(c),
+}
+
+// `CREATE TABLE <name>` and `CREATE TABLE <name> AS (<query>)` (CTAS).
+// The optional `AS (...)` clause distinguishes the two forms; a plain
+// `CREATE TABLE <name>` leaves `as_query` as `None`.
+CreateTable: ast::CreateTable = {
+    "CREATE" "TABLE" <table_name:SymbolPrimitive> <as_query:CtasClause?> => {
+        ast::CreateTable { table_name, as_query }
+    }
+}
+
+#[inline]
+CtasClause: Box<ast::AstNode<ast::Query>> = {
+    "AS" "(" <query:Query> ")" => Box::new(query),
 }
 
 Query: ast::AstNode<ast::Query> = {
@@ -2163,6 +2197,7 @@ extern {
         "BY" => lexer::Token::By,
         "CASE" => lexer::Token::Case,
         "COLUMNS" => lexer::Token::Columns,
+        "CREATE" => lexer::Token::Create,
         "CROSS" => lexer::Token::Cross,
         "CYCLE" => lexer::Token::Cycle,
         "DATE" => lexer::Token::Date,

--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "partiql-tools"
-version = "0.15.0-alpha.2"
+version = "0.15.0-alpha.1"
 edition = "2021"
 publish = false
 autobins = false

--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "partiql-tools"
-version = "0.15.0-alpha.1"
+version = "0.15.0-alpha.2"
 edition = "2021"
 publish = false
 autobins = false

--- a/partiql/tests/pretty.rs
+++ b/partiql/tests/pretty.rs
@@ -1,6 +1,6 @@
 use crate::common::parse;
 use itertools::Itertools;
-use partiql_ast::ast::{AstNode, TopLevelQuery};
+use partiql_ast::ast::{AstNode, Item};
 use partiql_common::pretty::ToPretty;
 use partiql_value::{bag, list, tuple, DateTime, Value};
 use rust_decimal::prelude::FromPrimitive;
@@ -23,7 +23,7 @@ fn pretty_print_test(name: &str, statement: &str) {
 }
 
 #[track_caller]
-fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode<TopLevelQuery>) {
+fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode<Item>) {
     // TODO https://github.com/partiql/partiql-lang-rust/issues/473
     let doc = [180, 120, 80, 40, 30, 20, 10]
         .into_iter()
@@ -42,7 +42,7 @@ fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode
 }
 
 #[track_caller]
-fn pretty_print_roundtrip_test(statement_ast: &AstNode<TopLevelQuery>) {
+fn pretty_print_roundtrip_test(statement_ast: &AstNode<Item>) {
     let pretty = statement_ast.to_pretty_string(40).unwrap();
     let reparsed = parse(pretty.as_str());
     assert!(reparsed.is_ok());

--- a/partiql/tests/pretty.rs
+++ b/partiql/tests/pretty.rs
@@ -1,6 +1,6 @@
 use crate::common::parse;
 use itertools::Itertools;
-use partiql_ast::ast::{AstNode, Item};
+use partiql_ast::ast::{AstNode, Statement};
 use partiql_common::pretty::ToPretty;
 use partiql_value::{bag, list, tuple, DateTime, Value};
 use rust_decimal::prelude::FromPrimitive;
@@ -16,14 +16,14 @@ fn pretty_print_test(name: &str, statement: &str) {
     let res = res.unwrap();
 
     // First test that the pretty printed version is parseable
-    pretty_print_roundtrip_test(&res.ast);
+    pretty_print_roundtrip_test(&res.statements[0]);
 
     // Then snapshot the pretty printed version
-    pretty_print_output_test(name, statement, &res.ast);
+    pretty_print_output_test(name, statement, &res.statements[0]);
 }
 
 #[track_caller]
-fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode<Item>) {
+fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode<Statement>) {
     // TODO https://github.com/partiql/partiql-lang-rust/issues/473
     let doc = [180, 120, 80, 40, 30, 20, 10]
         .into_iter()
@@ -42,12 +42,12 @@ fn pretty_print_output_test(name: &str, statement: &str, statement_ast: &AstNode
 }
 
 #[track_caller]
-fn pretty_print_roundtrip_test(statement_ast: &AstNode<Item>) {
+fn pretty_print_roundtrip_test(statement_ast: &AstNode<Statement>) {
     let pretty = statement_ast.to_pretty_string(40).unwrap();
     let reparsed = parse(pretty.as_str());
     assert!(reparsed.is_ok());
 
-    let pretty2 = reparsed.unwrap().ast.to_pretty_string(40).unwrap();
+    let pretty2 = reparsed.unwrap().statements[0].to_pretty_string(40).unwrap();
 
     assert_eq!(pretty, pretty2);
 }
@@ -84,7 +84,7 @@ fn pretty_print_value_roundtrip_test(value: &Value) {
     let reparsed = parse(pretty.as_str());
     assert!(reparsed.is_ok());
 
-    let pretty2 = reparsed.unwrap().ast.to_pretty_string(40).unwrap();
+    let pretty2 = reparsed.unwrap().statements[0].to_pretty_string(40).unwrap();
 
     assert_eq!(pretty, pretty2);
 }

--- a/partiql/tests/pretty.rs
+++ b/partiql/tests/pretty.rs
@@ -47,7 +47,9 @@ fn pretty_print_roundtrip_test(statement_ast: &AstNode<Statement>) {
     let reparsed = parse(pretty.as_str());
     assert!(reparsed.is_ok());
 
-    let pretty2 = reparsed.unwrap().statements[0].to_pretty_string(40).unwrap();
+    let pretty2 = reparsed.unwrap().statements[0]
+        .to_pretty_string(40)
+        .unwrap();
 
     assert_eq!(pretty, pretty2);
 }
@@ -84,7 +86,9 @@ fn pretty_print_value_roundtrip_test(value: &Value) {
     let reparsed = parse(pretty.as_str());
     assert!(reparsed.is_ok());
 
-    let pretty2 = reparsed.unwrap().statements[0].to_pretty_string(40).unwrap();
+    let pretty2 = reparsed.unwrap().statements[0]
+        .to_pretty_string(40)
+        .unwrap();
 
     assert_eq!(pretty, pretty2);
 }


### PR DESCRIPTION
  Adds grammar, AST, and pretty-printing support for CREATE TABLE
  statements, including the optional CTAS clause backed by a full
  subquery.

  Key additions:
  - Add Create lexer token and register it as a keyword
  - Add Ddl/DdlOp/CreateTable/CtasClause grammar rules; AS (query) is optional, so plain CREATE TABLE <name> parses with as_query = None
  - Add CreateTable AST node (table_name + optional boxed query)
  - Re-type the top-level parse result as an Item enum (Ddl/Dml/Query)
  - Implement PrettyDoc for Item/DdlOp/CreateTable, replacing a panicking todo! in the pretty-printer
  - Route DDL through the logical planner as NotYetImplemented (parses cleanly; lowering/eval is future work)
  - Add parser unit tests: plain CREATE TABLE, simple CTAS, complex CTAS with WHERE/ORDER BY/LIMIT, and graceful failure on malformed input
  - Bump pqlite (partiql-tools) to 0.15.0-alpha.2

