### PR TITLE
feat(eval): add trim and exists built-in functions to VM engine

### DIFF
--- a/docs/VM_CONFORMANCE_PLAN.md
+++ b/docs/VM_CONFORMANCE_PLAN.md
@@ -42,9 +42,10 @@ The `stdout` field of failed tests contains the error classification:
 | 13 | GroupBy | Not supported |
 | 14 | Having | Not supported |
 
-## Current State (2026-06-03)
+## Current State (2026-06-11)
 
-- **3,911 passing / 2,760 failing / 6,671 total (58.6% conformant)**
+- **4,115 passing / 2,556 failing / 6,671 total (61.7% conformant)**
+- Previously 3,911 (58.6%) before trim/exists support
 - Previously 3,775 (56.6%) before LIKE support
 - Previously 2,587 (38.8%) before DBRef/global resolution was implemented
 - Previously 1,117 (16.7%) before built-in functions were implemented
@@ -55,7 +56,7 @@ The `stdout` field of failed tests contains the error classification:
 
 | # | Root Cause | Tests Blocked | Cumulative | Key Files |
 |--:|:--|--:|--:|:--|
-| 1 | Missing built-in functions | ~338 remaining | — | `engine/builtins.rs` (DONE for top functions) |
+| 1 | Missing built-in functions | ~170 remaining | — | `engine/builtins.rs` (trim/exists DONE; extract blocked on DateTime in ValueRef) |
 | 2 | Unresolved DB objects / globals | ~126 remaining | — | `engine/compiler.rs` (DONE: implicit scans for ExprQuery) |
 | 3 | GROUP BY operator | 688 (12.4%) | 64.7% | `engine/compiler.rs` |
 | 4 | Scan expression types | ~57 remaining | — | `engine/compiler.rs` (DONE: inline scans for literals) |
@@ -79,7 +80,7 @@ The `stdout` field of failed tests contains the error classification:
 
 ## Task Breakdown
 
-### Task 1: Built-in Functions (~338 tests remaining)
+### Task 1: Built-in Functions (~170 tests remaining)
 
 The VM dispatches function calls via `UdfRegistry` trait in `engine/builtins.rs`. The `BuiltinFunctions` struct implements this and is wired into `PartiQLVM` (passed to `eval_inst` in the dispatch loop at `plan.rs`).
 
@@ -89,19 +90,19 @@ The VM dispatches function calls via `UdfRegistry` trait in `engine/builtins.rs`
 - [x] `lower` — 274 tests
 - [x] `upper` — 274 tests
 - [x] `substring` — 188 tests
+- [x] `trim` (LTrim/BTrim/RTrim) — 140 tests (5 remaining are static analysis tests)
 - [x] `overlay` — 44 tests
 - [x] `cardinality` — 35 tests
 - [x] `mod` — 30 tests
 - [x] `position` — 28 tests
+- [x] `exists` — 20 tests (remaining failures blocked by unresolved vars / variant literals)
 - [x] `abs` — 11 tests
 - [x] `bit_length` — 11 tests
 - [x] `octet_length` — 11 tests
 
 **Remaining (not yet implemented in `builtins.rs`):**
 
-- [ ] `trim` (LTrim/BTrim/RTrim) — 120 tests
-- [ ] `extract` (ExtractYear/Month/Day/etc.) — 32 tests
-- [ ] `exists` — 18 tests
+- [ ] `extract` (ExtractYear/Month/Day/etc.) — 32 tests (blocked: no DateTime variant in ValueRef)
 
 **Aggregate functions (require GROUP BY first):**
 

--- a/partiql-eval/src/engine/builtins.rs
+++ b/partiql-eval/src/engine/builtins.rs
@@ -30,6 +30,10 @@ impl UdfRegistry for BuiltinFunctions {
             "Abs" => builtin_abs(args),
             "Mod" => builtin_mod(args),
             "Cardinality" => builtin_cardinality(args),
+            "LTrim" => builtin_ltrim(args),
+            "BTrim" => builtin_btrim(args),
+            "RTrim" => builtin_rtrim(args),
+            "Exists" => builtin_exists(args),
             _ => Err(EngineError::UdfNotFound(name.to_string())),
         }
     }
@@ -224,5 +228,52 @@ fn builtin_cardinality<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
         Some(ValueRef::Null) => Ok(ValueRef::Null),
         Some(ValueRef::Missing) => Ok(ValueRef::Missing),
         _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_ltrim<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match (args.first(), args.get(1)) {
+        (Some(ValueRef::Str(trim_chars)), Some(ValueRef::Str(source))) => {
+            let chars: Vec<char> = trim_chars.chars().collect();
+            Ok(ValueRef::Str(source.trim_start_matches(&chars[..])))
+        }
+        (Some(ValueRef::Null), _) | (_, Some(ValueRef::Null)) => Ok(ValueRef::Null),
+        (Some(ValueRef::Missing), _) | (_, Some(ValueRef::Missing)) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_btrim<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match (args.first(), args.get(1)) {
+        (Some(ValueRef::Str(trim_chars)), Some(ValueRef::Str(source))) => {
+            let chars: Vec<char> = trim_chars.chars().collect();
+            Ok(ValueRef::Str(source.trim_matches(&chars[..])))
+        }
+        (Some(ValueRef::Null), _) | (_, Some(ValueRef::Null)) => Ok(ValueRef::Null),
+        (Some(ValueRef::Missing), _) | (_, Some(ValueRef::Missing)) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_rtrim<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match (args.first(), args.get(1)) {
+        (Some(ValueRef::Str(trim_chars)), Some(ValueRef::Str(source))) => {
+            let chars: Vec<char> = trim_chars.chars().collect();
+            Ok(ValueRef::Str(source.trim_end_matches(&chars[..])))
+        }
+        (Some(ValueRef::Null), _) | (_, Some(ValueRef::Null)) => Ok(ValueRef::Null),
+        (Some(ValueRef::Missing), _) | (_, Some(ValueRef::Missing)) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Missing),
+    }
+}
+
+fn builtin_exists<'a>(args: &[ValueRef<'a>]) -> Result<ValueRef<'a>> {
+    match args.first() {
+        Some(ValueRef::Tuple(t)) => Ok(ValueRef::Bool(!t.fields.is_empty())),
+        Some(ValueRef::List(items)) => Ok(ValueRef::Bool(!items.is_empty())),
+        Some(ValueRef::Bag(items)) => Ok(ValueRef::Bool(!items.is_empty())),
+        Some(ValueRef::Null) => Ok(ValueRef::Null),
+        Some(ValueRef::Missing) => Ok(ValueRef::Missing),
+        _ => Ok(ValueRef::Bool(false)),
     }
 }


### PR DESCRIPTION
## Summary
- Implement `LTrim`, `BTrim`, `RTrim`, and `Exists` in the VM bytecode engine's builtin function registry (`partiql-eval/src/engine/builtins.rs`)
- Update `docs/VM_CONFORMANCE_PLAN.md` to reflect new conformance numbers

## Impact
- Conformance: 58.6% → 61.7% (204 newly passing tests)
- 140/145 trim tests now pass (5 remaining are static analysis tests expecting compile-time errors)
- 20/48 exists tests now pass (remaining blocked by unresolved vars / variant literal gaps)

## Test plan
- [x] `make ci-check` passes
- [x] `cargo test --package partiql-conformance-tests --features "conformance_test, eval_vm, experimental" --release -- "trim"` → 140 passed
- [x] `cargo test --package partiql-conformance-tests --features "conformance_test, eval_vm, experimental" --release -- "exists"` → 20 passed