### PR TITLE
feat: lower CREATE TABLE AS into a top-level LogicalStatement

### DIFF
--- a/partiql-ast/src/ast/mod.rs
+++ b/partiql-ast/src/ast/mod.rs
@@ -76,8 +76,9 @@ pub struct CreateTable {
     #[visit(skip)]
     pub table_name: SymbolPrimitive,
     /// Optional source query for `CREATE TABLE <name> AS (<query>)` (CTAS).
-    /// `None` for a plain `CREATE TABLE <name>`.
-    pub as_query: Option<Box<AstNode<Query>>>,
+    /// `None` for a plain `CREATE TABLE <name>`. Holds a `TopLevelQuery` so the
+    /// CTAS source may carry a `WITH` (CTE) clause, per the SQL specification.
+    pub as_query: Option<Box<AstNode<TopLevelQuery>>>,
 }
 
 #[derive(Visit, Clone, Debug, PartialEq, Eq)]

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -6,6 +6,7 @@ use crate::lower::AstToLogical;
 use partiql_ast::ast;
 use partiql_ast_passes::error::{AstTransformError, AstTransformationError};
 use partiql_ast_passes::name_resolver::NameResolver;
+use partiql_common::node::NodeId;
 use partiql_logical as logical;
 use partiql_parser::Parsed;
 
@@ -21,16 +22,30 @@ pub struct LogicalPlanner<'c> {
     catalog: &'c dyn SharedCatalog,
 }
 
+/// The uniform "DDL not yet lowerable" error, shared by every DDL-rejection site.
+#[inline]
+fn ddl_not_yet_implemented() -> AstTransformationError {
+    AstTransformationError {
+        errors: vec![AstTransformError::NotYetImplemented(
+            "DDL statement lowering".to_string(),
+        )],
+    }
+}
+
 impl<'c> LogicalPlanner<'c> {
     pub fn new(catalog: &'c dyn SharedCatalog) -> Self {
         LogicalPlanner { catalog }
     }
 
+    /// Lower a parsed statement into a top-level [`logical::LogicalStatement`].
+    ///
+    /// This is the full-fidelity entry point: it preserves the statement
+    /// category (query vs. DDL). [`Self::lower`] is a back-compat shim over this.
     #[inline]
-    pub fn lower(
+    pub fn lower_statement(
         &self,
         parsed: &Parsed<'_>,
-    ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
+    ) -> Result<logical::LogicalStatement, AstTransformationError> {
         if parsed.statements.len() != 1 {
             return Err(AstTransformationError {
                 errors: vec![AstTransformError::NotYetImplemented(
@@ -41,21 +56,79 @@ impl<'c> LogicalPlanner<'c> {
         let stmt = &parsed.statements[0];
         match &stmt.node {
             ast::Statement::Query(q) => {
-                let mut resolver = NameResolver::new(self.catalog);
-                let registry = resolver.resolve(q, stmt.id)?;
-                let planner = AstToLogical::new(self.catalog, registry);
-                planner.lower_query(q, stmt.id)
+                let plan = self.lower_query(q, stmt.id)?;
+                Ok(logical::LogicalStatement::Query(plan))
             }
-            ast::Statement::Ddl(_) => Err(AstTransformationError {
-                errors: vec![AstTransformError::NotYetImplemented(
-                    "DDL statement lowering".to_string(),
-                )],
-            }),
+            ast::Statement::Ddl(ast::DdlOp::CreateTable(ct)) => {
+                let table_name = AstToLogical::symprim_to_binding(&ct.table_name);
+                match &ct.as_query {
+                    None => Ok(logical::LogicalStatement::CreateTable { table_name }),
+                    Some(inner) => {
+                        // Wrap the inner AstNode<Query> in a TopLevelQuery to feed the
+                        // existing pipeline. Lossless: Query has no `with` field, so
+                        // `with: None` drops nothing. Id-safe: we clone the original
+                        // node, so its parse-time NodeId is preserved verbatim;
+                        // both NameResolver and AstToLogical key on that id. Never
+                        // reconstruct the node with a fresh id or search_locals breaks.
+                        let wrapped = ast::TopLevelQuery {
+                            with: None,
+                            query: inner.as_ref().clone(),
+                        };
+                        let plan = self.lower_query(&wrapped, stmt.id)?;
+                        Ok(logical::LogicalStatement::CreateTableAs {
+                            table_name,
+                            query: plan,
+                        })
+                    }
+                }
+            }
+            ast::Statement::Ddl(_) => Err(ddl_not_yet_implemented()),
             ast::Statement::Dml(_) => Err(AstTransformationError {
                 errors: vec![AstTransformError::NotYetImplemented(
                     "DML statement lowering".to_string(),
                 )],
             }),
         }
+    }
+
+    /// Lower a parsed statement into a relational plan.
+    ///
+    /// Back-compat shim over [`Self::lower_statement`]: returns the inner
+    /// [`logical::LogicalPlan`] for a query, and rejects DDL/DML so existing
+    /// callers (which only handle queries) keep their current contract.
+    #[inline]
+    pub fn lower(
+        &self,
+        parsed: &Parsed<'_>,
+    ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
+        // Reject DDL at the front door, before any inner-query lowering, so this
+        // shim returns a uniform `NotYetImplemented("DDL statement lowering")`
+        // rather than leaking an inner-query error (e.g. an unresolved table in a
+        // CTAS source). CTAS is surfaced as a plan via `lower_statement`.
+        if let [stmt] = parsed.statements.as_slice() {
+            if matches!(stmt.node, ast::Statement::Ddl(_)) {
+                return Err(ddl_not_yet_implemented());
+            }
+        }
+        match self.lower_statement(parsed)? {
+            logical::LogicalStatement::Query(plan) => Ok(plan),
+            // Exhaustive on purpose: a new LogicalStatement variant must be triaged
+            // here. DDL is short-circuited above, so these arms are belt-and-suspenders.
+            logical::LogicalStatement::CreateTableAs { .. }
+            | logical::LogicalStatement::CreateTable { .. } => Err(ddl_not_yet_implemented()),
+        }
+    }
+
+    /// Shared two-pass lowering of a `TopLevelQuery` (name resolution + visitor).
+    #[inline]
+    fn lower_query(
+        &self,
+        query: &ast::TopLevelQuery,
+        stmt_id: NodeId,
+    ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
+        let mut resolver = NameResolver::new(self.catalog);
+        let registry = resolver.resolve(query, stmt_id)?;
+        let planner = AstToLogical::new(self.catalog, registry);
+        planner.lower_query(query, stmt_id)
     }
 }

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -37,23 +37,20 @@ impl<'c> LogicalPlanner<'c> {
         LogicalPlanner { catalog }
     }
 
-    /// Lower a parsed statement into a top-level [`logical::LogicalStatement`].
+    /// Lower a single parsed statement into a top-level [`logical::LogicalStatement`].
     ///
     /// This is the full-fidelity entry point: it preserves the statement
-    /// category (query vs. DDL). [`Self::lower`] is a back-compat shim over this.
+    /// category (query vs. DDL). It takes a single `AstNode<Statement>` rather
+    /// than a bare `Statement` because query-bearing statements (a top-level
+    /// query, or a CTAS source) are lowered through the two-pass pipeline, which
+    /// keys name resolution and lowering on the node's parse-time `NodeId`.
+    /// Iterating a multi-statement parse is the caller's concern. [`Self::lower`]
+    /// is a back-compat shim over this.
     #[inline]
     pub fn lower_statement(
         &self,
-        parsed: &Parsed<'_>,
+        stmt: &ast::AstNode<ast::Statement>,
     ) -> Result<logical::LogicalStatement, AstTransformationError> {
-        if parsed.statements.len() != 1 {
-            return Err(AstTransformationError {
-                errors: vec![AstTransformError::NotYetImplemented(
-                    "multi-statement input".to_string(),
-                )],
-            });
-        }
-        let stmt = &parsed.statements[0];
         match &stmt.node {
             ast::Statement::Query(q) => {
                 let plan = self.lower_query(q, stmt.id)?;
@@ -93,16 +90,23 @@ impl<'c> LogicalPlanner<'c> {
         &self,
         parsed: &Parsed<'_>,
     ) -> Result<logical::LogicalPlan<logical::BindingsOp>, AstTransformationError> {
+        // This shim only handles a single statement; multi-statement iteration is
+        // not its job (the relational-plan return type can carry just one query).
+        let [stmt] = parsed.statements.as_slice() else {
+            return Err(AstTransformationError {
+                errors: vec![AstTransformError::NotYetImplemented(
+                    "multi-statement input".to_string(),
+                )],
+            });
+        };
         // Reject DDL at the front door, before any inner-query lowering, so this
         // shim returns a uniform `NotYetImplemented("DDL statement lowering")`
         // rather than leaking an inner-query error (e.g. an unresolved table in a
         // CTAS source). CTAS is surfaced as a plan via `lower_statement`.
-        if let [stmt] = parsed.statements.as_slice() {
-            if matches!(stmt.node, ast::Statement::Ddl(_)) {
-                return Err(ddl_not_yet_implemented());
-            }
+        if matches!(stmt.node, ast::Statement::Ddl(_)) {
+            return Err(ddl_not_yet_implemented());
         }
-        match self.lower_statement(parsed)? {
+        match self.lower_statement(stmt)? {
             logical::LogicalStatement::Query(plan) => Ok(plan),
             // DDL is already rejected at the front door above, so only a query plan
             // reaches here. This arm is a defensive fallback for any non-query result.

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -112,10 +112,9 @@ impl<'c> LogicalPlanner<'c> {
         }
         match self.lower_statement(parsed)? {
             logical::LogicalStatement::Query(plan) => Ok(plan),
-            // Exhaustive on purpose: a new LogicalStatement variant must be triaged
-            // here. DDL is short-circuited above, so these arms are belt-and-suspenders.
-            logical::LogicalStatement::CreateTableAs { .. }
-            | logical::LogicalStatement::CreateTable { .. } => Err(ddl_not_yet_implemented()),
+            // DDL is already rejected at the front door above, so only a query plan
+            // reaches here. This arm is a defensive fallback for any non-query result.
+            _ => Err(ddl_not_yet_implemented()),
         }
     }
 

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -64,17 +64,9 @@ impl<'c> LogicalPlanner<'c> {
                 match &ct.as_query {
                     None => Ok(logical::LogicalStatement::CreateTable { table_name }),
                     Some(inner) => {
-                        // Wrap the inner AstNode<Query> in a TopLevelQuery to feed the
-                        // existing pipeline. Lossless: Query has no `with` field, so
-                        // `with: None` drops nothing. Id-safe: we clone the original
-                        // node, so its parse-time NodeId is preserved verbatim;
-                        // both NameResolver and AstToLogical key on that id. Never
-                        // reconstruct the node with a fresh id or search_locals breaks.
-                        let wrapped = ast::TopLevelQuery {
-                            with: None,
-                            query: inner.as_ref().clone(),
-                        };
-                        let plan = self.lower_query(&wrapped, stmt.id)?;
+                        // `as_query` is a `TopLevelQuery` (it may carry a `WITH` clause),
+                        // so it feeds the existing pipeline directly — no wrapping needed.
+                        let plan = self.lower_query(&inner.node, stmt.id)?;
                         Ok(logical::LogicalStatement::CreateTableAs {
                             table_name,
                             query: plan,

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -2269,4 +2269,24 @@ mod tests {
             [AstTransformError::NotYetImplemented(msg)] if msg == "DDL statement lowering"
         );
     }
+
+    #[test]
+    fn test_legacy_lower_rejects_plain_create_table() {
+        // The no-AS form (`CreateTable`, as_query: None) must also be rejected by the
+        // legacy `lower` shim with the same uniform DDL error — covering the
+        // CreateTable branch of the shim, not just CTAS.
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE t")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let errs = planner
+            .lower(&parsed)
+            .expect_err("legacy lower() must reject plain CREATE TABLE")
+            .errors;
+        assert_matches!(
+            errs.as_slice(),
+            [AstTransformError::NotYetImplemented(msg)] if msg == "DDL statement lowering"
+        );
+    }
 }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -2120,7 +2120,7 @@ mod tests {
             .expect("Expect successful parse");
         let planner = LogicalPlanner::new(&catalog);
         let stmt = planner
-            .lower_statement(&parsed)
+            .lower_statement(&parsed.statements[0])
             .expect("Expect successful lowering");
 
         let (table_name, query) = assert_matches!(
@@ -2154,7 +2154,7 @@ mod tests {
             .expect("Expect successful parse");
         let planner = LogicalPlanner::new(&catalog);
         let stmt = planner
-            .lower_statement(&parsed)
+            .lower_statement(&parsed.statements[0])
             .expect("Expect successful lowering");
 
         let table_name = assert_matches!(
@@ -2175,7 +2175,7 @@ mod tests {
             .expect("Expect successful parse");
         let planner = LogicalPlanner::new(&catalog);
         let stmt = planner
-            .lower_statement(&parsed)
+            .lower_statement(&parsed.statements[0])
             .expect("Expect successful lowering");
 
         let table_name = assert_matches!(
@@ -2201,7 +2201,7 @@ mod tests {
             .expect("Expect successful parse");
         let planner = LogicalPlanner::new(&catalog);
         let stmt = planner
-            .lower_statement(&parsed)
+            .lower_statement(&parsed.statements[0])
             .expect("Expect successful lowering");
 
         let query = assert_matches!(

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -308,7 +308,7 @@ impl<'a> AstToLogical<'a> {
     }
 
     /// Convert a `SymbolPrimitive` into a `BindingsName`
-    fn symprim_to_binding(sym: &SymbolPrimitive) -> BindingsName<'static> {
+    pub(crate) fn symprim_to_binding(sym: &SymbolPrimitive) -> BindingsName<'static> {
         match sym.case {
             CaseSensitivity::CaseSensitive => {
                 BindingsName::CaseSensitive(Cow::Owned(sym.value.clone()))
@@ -2106,5 +2106,167 @@ mod tests {
         assert_eq!(expected_logical, logical);
 
         println!("logical: {:?}", &logical);
+    }
+
+    #[test]
+    fn test_ctas_lowers_to_create_table_as() {
+        use partiql_logical::{BindingsOp, LogicalStatement};
+        use partiql_value::BindingsName;
+
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let statement = "CREATE TABLE t AS (SELECT a FROM foo WHERE a > 1)";
+        let parsed = partiql_parser::Parser::default()
+            .parse(statement)
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed)
+            .expect("Expect successful lowering");
+
+        let (table_name, query) = assert_matches!(
+            stmt,
+            LogicalStatement::CreateTableAs { table_name, query } => (table_name, query)
+        );
+
+        // Target carried verbatim, case-insensitive (bare identifier).
+        assert_eq!(table_name, BindingsName::CaseInsensitive("t".into()));
+
+        // Inner plan is the ordinary relational DAG, terminating in Sink.
+        assert!(
+            query.operator_count() >= 2,
+            "expected a non-trivial inner plan"
+        );
+        assert_matches!(
+            query.operators().last(),
+            Some(BindingsOp::Sink),
+            "inner plan must terminate in Sink"
+        );
+    }
+
+    #[test]
+    fn test_plain_create_table_lowers_to_create_table() {
+        use partiql_logical::LogicalStatement;
+        use partiql_value::BindingsName;
+
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE t")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed)
+            .expect("Expect successful lowering");
+
+        let table_name = assert_matches!(
+            stmt,
+            LogicalStatement::CreateTable { table_name } => table_name
+        );
+        assert_eq!(table_name, BindingsName::CaseInsensitive("t".into()));
+    }
+
+    #[test]
+    fn test_ctas_preserves_quoted_target_casing() {
+        use partiql_logical::LogicalStatement;
+        use partiql_value::BindingsName;
+
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE \"T\" AS (SELECT a FROM foo)")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed)
+            .expect("Expect successful lowering");
+
+        let table_name = assert_matches!(
+            stmt,
+            LogicalStatement::CreateTableAs { table_name, .. } => table_name
+        );
+        // Quoted identifier -> CaseSensitive, value preserved verbatim.
+        assert_eq!(table_name, BindingsName::CaseSensitive("T".into()));
+    }
+
+    #[test]
+    fn test_ctas_inner_source_resolves_through_existing_path() {
+        use partiql_logical::{self as logical, LogicalStatement};
+        use partiql_value::BindingsName;
+
+        let mut catalog = PartiqlCatalog::default();
+        let _oid =
+            catalog.add_type_entry(TypeEnvEntry::new("customers", &[], PartiqlShape::Dynamic));
+        let catalog = catalog.to_shared_catalog();
+
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE t AS (SELECT customers.name FROM customers AS c)")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed)
+            .expect("Expect successful lowering");
+
+        let query = assert_matches!(
+            stmt,
+            LogicalStatement::CreateTableAs { query, .. } => query
+        );
+
+        // The catalog-registered source lowered to a Scan over a DBRef (not a fallback
+        // Global VarRef), proving the inner query used the normal resolution path.
+        let has_dbref_scan = query.operators().iter().any(|op| {
+            matches!(
+                op,
+                BindingsOp::Scan(logical::Scan { expr: ValueExpr::DBRef(db), .. })
+                    if db.catalog == "default"
+                        && db.path == vec![BindingsName::CaseInsensitive("customers".into())]
+            )
+        });
+        assert!(
+            has_dbref_scan,
+            "inner source `customers` must resolve to a DBRef Scan"
+        );
+    }
+
+    #[test]
+    fn test_legacy_lower_rejects_ctas() {
+        // Back-compat contract: the legacy `lower` entry point (used by ~16 callers
+        // that only handle relational plans) must still reject DDL rather than
+        // silently changing its return type. CTAS is surfaced via `lower_statement`.
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE t AS (SELECT a FROM foo)")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let errs = planner
+            .lower(&parsed)
+            .expect_err("legacy lower() must reject CTAS")
+            .errors;
+        // Assert the specific rejection error, not merely that *some* error occurred,
+        // so a future change that swapped this for a different error (a parse error,
+        // the inner query's error, etc.) would fail rather than silently pass.
+        assert_matches!(
+            errs.as_slice(),
+            [AstTransformError::NotYetImplemented(msg)] if msg == "DDL statement lowering"
+        );
+    }
+
+    #[test]
+    fn test_legacy_lower_short_circuits_ddl_before_inner_query() {
+        // The legacy `lower` shim must reject DDL at the front door, BEFORE lowering
+        // the inner query. Here the CTAS source references an undefined function, which
+        // would itself produce a lowering error — but `lower()` must still return the
+        // uniform DDL rejection, never leak the inner-query error.
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("CREATE TABLE t AS (SELECT undefined_fn(a) FROM foo)")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let errs = planner
+            .lower(&parsed)
+            .expect_err("legacy lower() must reject CTAS")
+            .errors;
+        // Uniform DDL error — NOT the inner UnsupportedFunction("undefined_fn") error.
+        assert_matches!(
+            errs.as_slice(),
+            [AstTransformError::NotYetImplemented(msg)] if msg == "DDL statement lowering"
+        );
     }
 }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -465,6 +465,30 @@ pub struct DBRef {
     pub path: Vec<BindingsName<'static>>,
 }
 
+/// A top-level `PartiQL` statement produced by the planner.
+///
+/// DDL is a statement *category* that contains a query, not a relational
+/// operator — so it lives here, above [`LogicalPlan`], rather than inside
+/// [`BindingsOp`]. The relational operator graph is left untouched.
+///
+/// The target `table_name` is a name being *defined*, carried verbatim as a
+/// case-preserving [`BindingsName`] (single identifier, no catalog/path). The
+/// library never resolves the destination catalog or performs writes; a
+/// consumer orchestrates storage/transactions around query execution.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum LogicalStatement {
+    /// An ordinary data-retrieval query.
+    Query(LogicalPlan<BindingsOp>),
+    /// `CREATE TABLE <name> AS (<query>)` — the target plus the lowered source query.
+    CreateTableAs {
+        table_name: BindingsName<'static>,
+        query: LogicalPlan<BindingsOp>,
+    },
+    /// `CREATE TABLE <name>` — the target only, no source query.
+    CreateTable { table_name: BindingsName<'static> },
+}
+
 /// Represents a `PartiQL` value expression. Evaluation of a [`ValueExpr`] leads to a `PartiQL` value as
 /// specified by [PartiQL Specification 2019](https://partiql.org/assets/PartiQL-Specification.pdf).
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -986,12 +986,21 @@ mod tests {
             parse!(r"CREATE TABLE new_table AS (SELECT m.a FROM mem(5, 2) m)");
         }
 
-        // The parenthesized query is the full top-level `Query` rule, so WHERE,
+        // The parenthesized query is the full `TopLevelQuery` rule, so WHERE,
         // ORDER BY, and LIMIT are all accepted inside `AS (...)`.
         #[test]
         fn create_table_as_complex() {
             parse!(
                 r"CREATE TABLE summary AS (SELECT m.a FROM mem(5, 2) m WHERE m.a > 1 ORDER BY m.a DESC LIMIT 10)"
+            );
+        }
+
+        // CTAS source is a `TopLevelQuery`, so it may carry a `WITH` (CTE) clause,
+        // per the SQL specification.
+        #[test]
+        fn create_table_as_with_cte() {
+            parse!(
+                r"CREATE TABLE t AS (WITH q AS (SELECT m.a FROM mem(2, 1) m) SELECT q.a FROM q)"
             );
         }
 

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -56,8 +56,8 @@ CreateTable: ast::CreateTable = {
 }
 
 #[inline]
-CtasClause: Box<ast::AstNode<ast::Query>> = {
-    "AS" "(" <query:Query> ")" => Box::new(query),
+CtasClause: Box<ast::AstNode<ast::TopLevelQuery>> = {
+    "AS" "(" <query:TopLevelQuery> ")" => Box::new(query),
 }
 
 Query: ast::AstNode<ast::Query> = {

--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -52,6 +52,7 @@ ion-rs = "0.18.1"
 bytes = "1.9"
 rand = "0.8"
 partiql-logical = { path = "../partiql-logical" }
+partiql-ast = { path = "../partiql-ast" }
 partiql-ast-passes = { path = "../partiql-ast-passes" }
 partiql-catalog = { path = "../partiql-catalog" }
 partiql-common = { path = "../partiql-common" }

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,9 +1,10 @@
 use partiql_tools::common;
 
-use common::{create_table_fn_catalog, lower, parse};
+use common::{create_table_fn_catalog, lower_statement, parse};
 use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
 use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
+use partiql_logical::LogicalStatement;
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -312,10 +313,35 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
         eprintln!("[AST] {:?}", parsed);
     }
 
-    // Phase 2: Lower (AST → Logical Plan)
+    // Phase 2: Lower (AST → Logical Statement)
     let lower_start = Instant::now();
-    let logical = lower(&*catalog, &parsed).map_err(|e| format!("Lower error: {:?}", e))?;
+    let statement =
+        lower_statement(&*catalog, &parsed).map_err(|e| format!("Lower error: {:?}", e))?;
     let lower_time = lower_start.elapsed();
+
+    // DDL statements are planning-only for now: print the lowered plan and stop.
+    // (Compile/execute and storage are a later slice; the consumer would
+    // orchestrate writes around the inner query's execution.)
+    let logical = match statement {
+        LogicalStatement::Query(plan) => plan,
+        LogicalStatement::CreateTableAs { table_name, query } => {
+            println!("Planned CREATE TABLE {:?} AS:", table_name);
+            println!("{:?}", query);
+            eprintln!(
+                "(planned in {:.1}ms — execution not yet implemented)",
+                (parse_time + lower_time).as_secs_f64() * 1000.0
+            );
+            return Ok(());
+        }
+        LogicalStatement::CreateTable { table_name } => {
+            println!("Planned CREATE TABLE {:?} (no source query)", table_name);
+            eprintln!(
+                "(planned in {:.1}ms — execution not yet implemented)",
+                (parse_time + lower_time).as_secs_f64() * 1000.0
+            );
+            return Ok(());
+        }
+    };
 
     if debug.plan {
         eprintln!("[Plan] {:?}", logical);

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -334,9 +334,17 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
     }
 
     // Phase 2: Lower (AST → Logical Statement)
+    // pqlite runs exactly one statement per submission; reject anything else here,
+    // since lowering operates on a single statement.
+    let stmt = match parsed.statements.as_slice() {
+        [stmt] => stmt,
+        // Match the planner's wording for this condition so the failure reads the
+        // same whether it surfaces here or via `LogicalPlanner::lower`.
+        _ => return Err("Lower error: multi-statement input".into()),
+    };
     let lower_start = Instant::now();
     let statement =
-        lower_statement(&*catalog, &parsed).map_err(|e| format!("Lower error: {:?}", e))?;
+        lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;
     let lower_time = lower_start.elapsed();
 
     // DDL statements are planning-only for now: print the lowered plan and stop.

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -299,6 +299,23 @@ fn run_repl(debug: &DebugFlags) {
     }
 }
 
+/// Render a `BindingsName` as its bare identifier (`t`), not the Debug wrapper
+/// (`CaseInsensitive("t")`). `BindingsName` has no Display impl, so match it out.
+fn binding_name_str<'a>(name: &'a partiql_value::BindingsName<'_>) -> &'a str {
+    match name {
+        partiql_value::BindingsName::CaseSensitive(s) => s.as_ref(),
+        partiql_value::BindingsName::CaseInsensitive(s) => s.as_ref(),
+    }
+}
+
+/// Shared stderr footer for a planning-only DDL statement.
+fn print_ddl_planned_footer(elapsed: std::time::Duration) {
+    eprintln!(
+        "(planned in {:.1}ms — execution not yet implemented)",
+        elapsed.as_secs_f64() * 1000.0
+    );
+}
+
 fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std::error::Error>> {
     let query = query_str.to_string();
 
@@ -325,20 +342,19 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
     let logical = match statement {
         LogicalStatement::Query(plan) => plan,
         LogicalStatement::CreateTableAs { table_name, query } => {
-            println!("Planned CREATE TABLE {:?} AS:", table_name);
-            println!("{:?}", query);
-            eprintln!(
-                "(planned in {:.1}ms — execution not yet implemented)",
-                (parse_time + lower_time).as_secs_f64() * 1000.0
-            );
+            // `{}` (Display) on the plan, not `{:?}`: LogicalPlan has a readable
+            // Display impl; Debug would dump the raw nodes/edges struct.
+            println!("Planned CREATE TABLE {} AS:", binding_name_str(&table_name));
+            println!("{}", query);
+            print_ddl_planned_footer(parse_time + lower_time);
             return Ok(());
         }
         LogicalStatement::CreateTable { table_name } => {
-            println!("Planned CREATE TABLE {:?} (no source query)", table_name);
-            eprintln!(
-                "(planned in {:.1}ms — execution not yet implemented)",
-                (parse_time + lower_time).as_secs_f64() * 1000.0
+            println!(
+                "Planned CREATE TABLE {} (no source query)",
+                binding_name_str(&table_name)
             );
+            print_ddl_planned_footer(parse_time + lower_time);
             return Ok(());
         }
     };

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -299,12 +299,15 @@ fn run_repl(debug: &DebugFlags) {
     }
 }
 
-/// Render a `BindingsName` as its bare identifier (`t`), not the Debug wrapper
-/// (`CaseInsensitive("t")`). `BindingsName` has no Display impl, so match it out.
-fn binding_name_str<'a>(name: &'a partiql_value::BindingsName<'_>) -> &'a str {
+/// Render a `BindingsName` the SQL-idiomatic way, so the printed form round-trips
+/// the case-sensitivity the user typed (instead of the `CaseInsensitive("t")` Debug
+/// wrapper, which both leaks internals and reads identically for quoted vs bare):
+///   - case-sensitive (originally quoted) -> re-quoted, e.g. `"My_Table"`
+///   - case-insensitive (originally bare) -> bare, e.g. `my_table`
+fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
     match name {
-        partiql_value::BindingsName::CaseSensitive(s) => s.as_ref(),
-        partiql_value::BindingsName::CaseInsensitive(s) => s.as_ref(),
+        partiql_value::BindingsName::CaseSensitive(s) => format!("\"{}\"", s),
+        partiql_value::BindingsName::CaseInsensitive(s) => s.as_ref().to_string(),
     }
 }
 
@@ -344,7 +347,10 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
         LogicalStatement::CreateTableAs { table_name, query } => {
             // `{}` (Display) on the plan, not `{:?}`: LogicalPlan has a readable
             // Display impl; Debug would dump the raw nodes/edges struct.
-            println!("Planned CREATE TABLE {} AS:", binding_name_str(&table_name));
+            println!(
+                "Planned CREATE TABLE {} AS:",
+                format_table_name(&table_name)
+            );
             println!("{}", query);
             print_ddl_planned_footer(parse_time + lower_time);
             return Ok(());
@@ -352,7 +358,7 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
         LogicalStatement::CreateTable { table_name } => {
             println!(
                 "Planned CREATE TABLE {} (no source query)",
-                binding_name_str(&table_name)
+                format_table_name(&table_name)
             );
             print_ddl_planned_footer(parse_time + lower_time);
             return Ok(());

--- a/partiql-tools/src/common.rs
+++ b/partiql-tools/src/common.rs
@@ -59,16 +59,16 @@ pub fn lower(
     planner.lower(parsed)
 }
 
-/// Lower AST to a top-level logical statement (query or DDL).
+/// Lower a single statement to a top-level logical statement (query or DDL).
 ///
 /// Unlike [`lower`], this preserves the statement category, so callers can
 /// distinguish a `Query` plan from a `CreateTableAs` / `CreateTable` DDL node.
 pub fn lower_statement(
     catalog: &dyn SharedCatalog,
-    parsed: &Parsed<'_>,
+    stmt: &partiql_ast::ast::AstNode<partiql_ast::ast::Statement>,
 ) -> Result<partiql_logical::LogicalStatement, AstTransformationError> {
     let planner = LogicalPlanner::new(catalog);
-    planner.lower_statement(parsed)
+    planner.lower_statement(stmt)
 }
 
 /// Compile logical plan to evaluation plan

--- a/partiql-tools/src/common.rs
+++ b/partiql-tools/src/common.rs
@@ -59,6 +59,18 @@ pub fn lower(
     planner.lower(parsed)
 }
 
+/// Lower AST to a top-level logical statement (query or DDL).
+///
+/// Unlike [`lower`], this preserves the statement category, so callers can
+/// distinguish a `Query` plan from a `CreateTableAs` / `CreateTable` DDL node.
+pub fn lower_statement(
+    catalog: &dyn SharedCatalog,
+    parsed: &Parsed<'_>,
+) -> Result<partiql_logical::LogicalStatement, AstTransformationError> {
+    let planner = LogicalPlanner::new(catalog);
+    planner.lower_statement(parsed)
+}
+
 /// Compile logical plan to evaluation plan
 pub fn compile(
     mode: EvaluationMode,


### PR DESCRIPTION
Add CTAS logical planning: CREATE TABLE <name> and CREATE TABLE <name> AS (<query>) now lower into a new top-level LogicalStatement enum that wraps the relational  plan, rather than living inside the BindingsOp graph. DDL is a statement category containing a query, not a relational operator. Planning only for now.

- partiql-logical: Add LogicalStatement enum (Query / CreateTableAs / CreateTable) and target table identity is carried as a case-preserving BindingsName.

- partiql-logical-planner: Add LogicalPlanner::lower_statement, safely reusing
    the existing two-pass pipeline on the inner query. Retained lower() as a back-compatible version and it now rejects DDL at the front door so inner-query errors don't leak.

- pqlite: Wire REPL tool execution flow to lower_statement. Ordinary queries execute on the register VM as before, while CreateTableAs and CreateTable statements intercept execution printing out the planned logical plan graph.


