### PR TITLE
feat: add LMDB storage env, --db flag, and _tables catalog to pqlite

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,7 @@ allow = [
     "ISC",
     "Zlib",
     "ICU",
+    "Unicode-3.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses

--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -63,6 +63,9 @@ partiql-parser = { path = "../partiql-parser" }
 partiql-types = { path = "../partiql-types" }
 partiql-value = { path = "../partiql-value" }
 clap = { version = "4.6.1", features = ["derive"] }
+# default-features disabled drops the serde / serde-json / serde-bincode codecs
+# we don't use; the LMDB backend and the Str/Bytes codecs are unaffected.
+heed = { version = "0.20", default-features = false }
 reedline = "0.48.0"
 
 [dev-dependencies]

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -5,7 +5,7 @@ use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
 use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
 use partiql_logical::LogicalStatement;
-use partiql_tools::storage::{default_db_path, HeedDB};
+use partiql_tools::storage::HeedDB;
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -35,7 +35,8 @@ struct Cli {
     #[arg(long, global = true, value_delimiter = ',')]
     debug: Vec<String>,
 
-    /// Path to the database file. Defaults to ~/.pqlite/default.pal.
+    /// Path to the database file (required for the interactive REPL). The
+    /// parent directory must already exist; it is not created for you.
     #[arg(long, global = true)]
     db: Option<std::path::PathBuf>,
 
@@ -86,24 +87,19 @@ fn main() {
             }
         }
         None => {
-            // Open the database lazily — only the interactive REPL needs it.
-            // A one-shot `exec` query is read-only today, so it must not
-            // manifest a database file on disk as a side effect (e.g. silently
-            // creating ~/.pqlite/default.pal). When the write path lands, exec
-            // will open the db explicitly where it needs to.
-
-            // Resolve the database path: explicit --db wins, else the default.
-            let db_path = cli.db.clone().or_else(default_db_path).unwrap_or_else(|| {
-                eprintln!(
-                    "Error: could not resolve a database path (home directory not found); pass --db <PATH>"
-                );
+            // The REPL needs a database. We require an explicit --db rather
+            // than inventing a default path: like standard UNIX tools, we don't
+            // create files or directories on the user's behalf.
+            let db_path = cli.db.clone().unwrap_or_else(|| {
+                eprintln!("Error: The `--db <PATH>` option is required to open the database.");
                 std::process::exit(1);
             });
 
-            // Open (or create) the database up front. A database that silently
-            // stops persisting is worse than one that refuses to start, so this
+            // Open the database up front. A database that silently stops
+            // persisting is worse than one that refuses to start, so this
             // hard-fails (unlike the REPL history file, which falls back to
-            // in-memory by design).
+            // in-memory by design). The parent directory must already exist;
+            // the filesystem error bubbles up naturally if it does not.
             let db = match HeedDB::open(&db_path) {
                 Ok(db) => db,
                 Err(e) => {

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -5,6 +5,7 @@ use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
 use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
 use partiql_logical::LogicalStatement;
+use partiql_tools::storage::{default_db_path, HeedDB};
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -33,6 +34,10 @@ struct Cli {
     /// Print debug info for pipeline stages. Accepts: ast, plan, program, or * for all.
     #[arg(long, global = true, value_delimiter = ',')]
     debug: Vec<String>,
+
+    /// Path to the database file. Defaults to ~/.pqlite/default.pal.
+    #[arg(long, global = true)]
+    db: Option<std::path::PathBuf>,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -81,7 +86,37 @@ fn main() {
             }
         }
         None => {
-            run_repl(&debug);
+            // Open the database lazily — only the interactive REPL needs it.
+            // A one-shot `exec` query is read-only today, so it must not
+            // manifest a database file on disk as a side effect (e.g. silently
+            // creating ~/.pqlite/default.pal). When the write path lands, exec
+            // will open the db explicitly where it needs to.
+
+            // Resolve the database path: explicit --db wins, else the default.
+            let db_path = cli.db.clone().or_else(default_db_path).unwrap_or_else(|| {
+                eprintln!(
+                    "Error: could not resolve a database path (home directory not found); pass --db <PATH>"
+                );
+                std::process::exit(1);
+            });
+
+            // Open (or create) the database up front. A database that silently
+            // stops persisting is worse than one that refuses to start, so this
+            // hard-fails (unlike the REPL history file, which falls back to
+            // in-memory by design).
+            let db = match HeedDB::open(&db_path) {
+                Ok(db) => db,
+                Err(e) => {
+                    eprintln!(
+                        "Error: could not open database at {}: {}",
+                        db_path.display(),
+                        e
+                    );
+                    std::process::exit(1);
+                }
+            };
+
+            run_repl(&debug, &db);
         }
     }
 }
@@ -230,19 +265,23 @@ fn handle_meta_command(input: &str) -> MetaOutcome {
 }
 
 /// Print the REPL startup banner: the crate version, the git commit it was
-/// built from, and a pointer to the help command.
-fn print_startup_banner() {
+/// built from, the active database path, and a pointer to the help command.
+///
+/// Written to stderr, not stdout: the banner is startup chrome, and stdout is
+/// reserved for the query result stream so it can be piped/redirected cleanly.
+fn print_startup_banner(db_path: &std::path::Path) {
     // Reuse the same VERSION string that backs the `--version` flag so the two
     // can never drift (crate version + git SHA captured in build.rs).
-    println!("pqlite version {VERSION}");
-    println!("For usage information, enter \".help\".");
+    eprintln!("pqlite version {VERSION}");
+    eprintln!("database: {}", db_path.display());
+    eprintln!("For usage information, enter \".help\".");
 }
 
 /// Run the interactive REPL: read a line, execute it as a query, and loop.
 ///
 /// Errors from `execute_query` are reported but never terminate the session.
-fn run_repl(debug: &DebugFlags) {
-    print_startup_banner();
+fn run_repl(debug: &DebugFlags, db: &HeedDB) {
+    print_startup_banner(db.path());
 
     let mut line_editor = Reedline::create()
         .with_history(build_history())

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,2 +1,3 @@
 // Public modules for use in benchmarks and binaries
 pub mod common;
+pub mod storage;

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -1,0 +1,284 @@
+//! LMDB-backed storage for pqlite.
+//!
+//! All heed/LMDB contact lives here so the binary stays thin and this logic is
+//! unit-testable in isolation. PR 1 opens the environment and creates the
+//! `_tables` system catalog; it writes nothing into the catalog.
+
+use std::path::{Path, PathBuf};
+
+/// Virtual address space reserved for the LMDB map. Sparse (not pre-allocated
+/// on disk); LMDB grows actual usage up to this ceiling.
+const DEFAULT_MAP_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
+
+/// Upper bound on named databases in the environment. One catalog db now, with
+/// headroom for one named db per user table in later PRs.
+const MAX_DBS: u32 = 128;
+
+/// Name of the system catalog database inside the environment.
+const TABLES_DB: &str = "_tables";
+
+/// The `_tables` catalog database: table-name keys to opaque byte values. The
+/// value format is deliberately left opaque until the table-registration PR.
+type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
+
+/// Errors from opening or initializing the storage environment.
+#[derive(Debug)]
+pub enum StorageError {
+    /// Filesystem error (e.g. the parent directory could not be created).
+    Io(std::io::Error),
+    /// Error from the heed/LMDB layer.
+    Heed(heed::Error),
+}
+
+impl std::fmt::Display for StorageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StorageError::Io(e) => write!(f, "storage I/O error: {e}"),
+            StorageError::Heed(e) => write!(f, "storage engine error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for StorageError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            StorageError::Io(e) => Some(e),
+            StorageError::Heed(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for StorageError {
+    fn from(e: std::io::Error) -> Self {
+        StorageError::Io(e)
+    }
+}
+
+impl From<heed::Error> for StorageError {
+    fn from(e: heed::Error) -> Self {
+        StorageError::Heed(e)
+    }
+}
+
+/// Create the parent directory of `path` if needed.
+///
+/// In single-file (`NO_SUB_DIR`) mode LMDB does not create the containing
+/// directory, so we must. A bare filename like `local.pal` has a parent of
+/// `Some("")`; `create_dir_all("")` errors with `NotFound`, so we skip
+/// creation when the parent is absent or empty.
+fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    Ok(())
+}
+
+/// The default database path: `~/.pqlite/default.pal`.
+///
+/// Returns `None` if the home directory cannot be resolved; the binary treats
+/// that as a startup error and asks the user to pass `--db`.
+pub fn default_db_path() -> Option<PathBuf> {
+    // `std::env::home_dir` was un-deprecated in Rust 1.85 and is correct on all
+    // supported platforms, matching how the pqlite binary resolves home.
+    #[allow(deprecated)]
+    let mut home = std::env::home_dir()?;
+    home.push(".pqlite");
+    home.push("default.pal");
+    Some(home)
+}
+
+/// Owns the LMDB environment and the `_tables` system catalog handle.
+///
+/// The `Env` and the `Database` handle share a lifecycle: the catalog handle is
+/// valid only while the `Env` is alive, so both live on this struct together.
+/// Later PRs reuse `env()` to begin transactions and `tables()` across them
+/// without re-resolving the catalog by name.
+#[derive(Debug)]
+pub struct HeedDB {
+    env: heed::Env,
+    tables: TablesDb,
+    path: PathBuf,
+}
+
+impl HeedDB {
+    /// Open (or create) the LMDB environment at `path` as a single file, and
+    /// open/create the `_tables` system catalog inside it.
+    pub fn open(path: &Path) -> Result<HeedDB, StorageError> {
+        // 1. Single-file mode does not create the containing directory.
+        ensure_parent_dir(path)?;
+
+        // 2. Open the environment. `flags` and `open` are both unsafe in heed
+        //    0.20, so the whole builder chain is in one unsafe block.
+        // SAFETY: NO_SUB_DIR only changes the on-disk layout (single file vs.
+        // directory) and carries none of the corruption-prone semantics of the
+        // dangerous flags (NO_SYNC / NO_META_SYNC / NO_LOCK). open() memory-maps
+        // the file; inter-process coordination is handled by LMDB's sibling
+        // lock file, and pqlite opens each env path at most once per process.
+        let env = unsafe {
+            heed::EnvOpenOptions::new()
+                .map_size(DEFAULT_MAP_SIZE)
+                .max_dbs(MAX_DBS)
+                .flags(heed::EnvFlags::NO_SUB_DIR)
+                .open(path)?
+        };
+
+        // 3. Open/create the `_tables` catalog in a write transaction.
+        //    `create_database` borrows the RwTxn mutably and opens the db if it
+        //    already exists, so reopening is not an error.
+        let mut wtxn = env.write_txn()?;
+        let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
+        wtxn.commit()?;
+
+        Ok(HeedDB {
+            env,
+            tables,
+            path: path.to_path_buf(),
+        })
+    }
+
+    // TODO: these accessors expose heed types (`Env`, `Database`) directly,
+    // which leaks the storage engine across the module boundary. If a later
+    // milestone abstracts storage away from heed (e.g. custom index
+    // structures), wrap these behind an engine-agnostic interface instead.
+
+    /// The live environment. Used by later PRs to begin transactions.
+    pub fn env(&self) -> &heed::Env {
+        &self.env
+    }
+
+    /// The `_tables` system catalog handle (opaque byte values for now).
+    pub fn tables(&self) -> &TablesDb {
+        &self.tables
+    }
+
+    /// The resolved on-disk path this environment was opened at.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_error_displays_and_converts_from_io() {
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "boom");
+        let err: StorageError = io.into();
+        assert!(matches!(err, StorageError::Io(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("storage I/O error"), "got: {msg}");
+        assert!(msg.contains("boom"), "got: {msg}");
+    }
+
+    #[test]
+    fn ensure_parent_dir_skips_bare_filename() {
+        // Precondition: a bare filename's parent is Some(""), the case the
+        // guard exists for. Assert it explicitly so this test fails loudly
+        // (rather than passing vacuously) if `Path::parent`'s contract shifts.
+        assert_eq!(
+            Path::new("local.pal")
+                .parent()
+                .map(|p| p.as_os_str().is_empty()),
+            Some(true),
+            "test precondition: bare-filename parent must be Some(\"\")"
+        );
+        // `create_dir_all("")` would error with NotFound, so the guard must
+        // skip it and return Ok without touching the filesystem.
+        let result = ensure_parent_dir(Path::new("local.pal"));
+        assert!(result.is_ok(), "bare filename should not error: {result:?}");
+    }
+
+    #[test]
+    fn ensure_parent_dir_skips_root_path() {
+        // `Path::new("/").parent()` is None; the guard must not error.
+        assert!(ensure_parent_dir(Path::new("/")).is_ok());
+    }
+
+    #[test]
+    fn ensure_parent_dir_creates_missing_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b").join("c.pal");
+        ensure_parent_dir(&nested).unwrap();
+        assert!(
+            nested.parent().unwrap().is_dir(),
+            "parent chain should exist"
+        );
+    }
+
+    #[test]
+    fn default_db_path_ends_with_pqlite_default_pal() {
+        // If home isn't resolvable (e.g. a hermetic CI sandbox with no HOME),
+        // skip rather than fail — the binary handles that case at startup.
+        if let Some(path) = default_db_path() {
+            // Build the expected suffix with the OS-native separator so the
+            // component-wise `ends_with` matches on every platform (a literal
+            // ".pqlite/default.pal" string is a single component on Windows).
+            let suffix = Path::new(".pqlite").join("default.pal");
+            assert!(
+                path.ends_with(&suffix),
+                "unexpected default path: {}",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn open_creates_file_and_missing_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        // Parent chain `nested/sub` does not exist yet.
+        let path = dir.path().join("nested").join("sub").join("test.pal");
+        let db = HeedDB::open(&path).expect("open should succeed");
+        assert!(path.is_file(), "db should be a single file (NO_SUB_DIR)");
+        assert_eq!(db.path(), path.as_path());
+    }
+
+    #[test]
+    fn open_creates_empty_tables_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cat.pal");
+        let db = HeedDB::open(&path).unwrap();
+        let rtxn = db.env().read_txn().unwrap();
+
+        // Assert the named `_tables` database specifically exists: look it up by
+        // the literal on-disk name (not the TABLES_DB constant, so renaming the
+        // constant can't make this pass spuriously). `open_database` returns
+        // `None` when no database of that name exists.
+        let named = db
+            .env()
+            .open_database::<heed::types::Str, heed::types::Bytes>(&rtxn, Some("_tables"))
+            .unwrap();
+        assert!(
+            named.is_some(),
+            "the `_tables` catalog should exist by name"
+        );
+
+        // And it starts empty.
+        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
+    }
+
+    #[test]
+    fn open_is_idempotent_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reopen.pal");
+        {
+            let _db = HeedDB::open(&path).unwrap();
+        } // first handle dropped, env closed
+        let reopened = HeedDB::open(&path);
+        assert!(reopened.is_ok(), "reopening an existing db must succeed");
+    }
+
+    #[test]
+    fn open_errors_when_parent_cannot_be_created() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create a regular FILE, then try to open a db "underneath" it, so the
+        // parent-dir creation must fail.
+        let blocker = dir.path().join("afile");
+        std::fs::write(&blocker, b"x").unwrap();
+        let bad = blocker.join("test.pal");
+        let res = HeedDB::open(&bad);
+        assert!(matches!(res, Err(StorageError::Io(_))), "got: {res:?}");
+    }
+}

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -24,7 +24,7 @@ type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 /// Errors from opening or initializing the storage environment.
 #[derive(Debug)]
 pub enum StorageError {
-    /// Filesystem error (e.g. the parent directory could not be created).
+    /// Filesystem-level error surfaced while working with the database file.
     Io(std::io::Error),
     /// Error from the heed/LMDB layer.
     Heed(heed::Error),
@@ -60,35 +60,6 @@ impl From<heed::Error> for StorageError {
     }
 }
 
-/// Create the parent directory of `path` if needed.
-///
-/// In single-file (`NO_SUB_DIR`) mode LMDB does not create the containing
-/// directory, so we must. A bare filename like `local.pal` has a parent of
-/// `Some("")`; `create_dir_all("")` errors with `NotFound`, so we skip
-/// creation when the parent is absent or empty.
-fn ensure_parent_dir(path: &Path) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent)?;
-        }
-    }
-    Ok(())
-}
-
-/// The default database path: `~/.pqlite/default.pal`.
-///
-/// Returns `None` if the home directory cannot be resolved; the binary treats
-/// that as a startup error and asks the user to pass `--db`.
-pub fn default_db_path() -> Option<PathBuf> {
-    // `std::env::home_dir` was un-deprecated in Rust 1.85 and is correct on all
-    // supported platforms, matching how the pqlite binary resolves home.
-    #[allow(deprecated)]
-    let mut home = std::env::home_dir()?;
-    home.push(".pqlite");
-    home.push("default.pal");
-    Some(home)
-}
-
 /// Owns the LMDB environment and the `_tables` system catalog handle.
 ///
 /// The `Env` and the `Database` handle share a lifecycle: the catalog handle is
@@ -106,11 +77,13 @@ impl HeedDB {
     /// Open (or create) the LMDB environment at `path` as a single file, and
     /// open/create the `_tables` system catalog inside it.
     pub fn open(path: &Path) -> Result<HeedDB, StorageError> {
-        // 1. Single-file mode does not create the containing directory.
-        ensure_parent_dir(path)?;
+        // We do not create the parent directory on the user's behalf. In
+        // single-file (`NO_SUB_DIR`) mode LMDB opens the file directly, so if
+        // the parent directory is missing the filesystem error bubbles up
+        // naturally — matching how standard UNIX tools behave.
 
-        // 2. Open the environment. `flags` and `open` are both unsafe in heed
-        //    0.20, so the whole builder chain is in one unsafe block.
+        // Open the environment. `flags` and `open` are both unsafe in heed
+        // 0.20, so the whole builder chain is in one unsafe block.
         // SAFETY: NO_SUB_DIR only changes the on-disk layout (single file vs.
         // directory) and carries none of the corruption-prone semantics of the
         // dangerous flags (NO_SYNC / NO_META_SYNC / NO_LOCK). open() memory-maps
@@ -124,9 +97,9 @@ impl HeedDB {
                 .open(path)?
         };
 
-        // 3. Open/create the `_tables` catalog in a write transaction.
-        //    `create_database` borrows the RwTxn mutably and opens the db if it
-        //    already exists, so reopening is not an error.
+        // Open/create the `_tables` catalog in a write transaction.
+        // `create_database` borrows the RwTxn mutably and opens the db if it
+        // already exists, so reopening is not an error.
         let mut wtxn = env.write_txn()?;
         let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
         wtxn.commit()?;
@@ -174,72 +147,14 @@ mod tests {
     }
 
     #[test]
-    fn ensure_parent_dir_skips_bare_filename() {
-        // Precondition: a bare filename's parent is Some(""), the case the
-        // guard exists for. Assert it explicitly so this test fails loudly
-        // (rather than passing vacuously) if `Path::parent`'s contract shifts.
-        assert_eq!(
-            Path::new("local.pal")
-                .parent()
-                .map(|p| p.as_os_str().is_empty()),
-            Some(true),
-            "test precondition: bare-filename parent must be Some(\"\")"
-        );
-        // `create_dir_all("")` would error with NotFound, so the guard must
-        // skip it and return Ok without touching the filesystem.
-        let result = ensure_parent_dir(Path::new("local.pal"));
-        assert!(result.is_ok(), "bare filename should not error: {result:?}");
-    }
-
-    #[test]
-    fn ensure_parent_dir_skips_root_path() {
-        // `Path::new("/").parent()` is None; the guard must not error.
-        assert!(ensure_parent_dir(Path::new("/")).is_ok());
-    }
-
-    #[test]
-    fn ensure_parent_dir_creates_missing_parents() {
-        let dir = tempfile::tempdir().unwrap();
-        let nested = dir.path().join("a").join("b").join("c.pal");
-        ensure_parent_dir(&nested).unwrap();
-        assert!(
-            nested.parent().unwrap().is_dir(),
-            "parent chain should exist"
-        );
-    }
-
-    #[test]
-    fn default_db_path_ends_with_pqlite_default_pal() {
-        // If home isn't resolvable (e.g. a hermetic CI sandbox with no HOME),
-        // skip rather than fail — the binary handles that case at startup.
-        if let Some(path) = default_db_path() {
-            // Build the expected suffix with the OS-native separator so the
-            // component-wise `ends_with` matches on every platform (a literal
-            // ".pqlite/default.pal" string is a single component on Windows).
-            let suffix = Path::new(".pqlite").join("default.pal");
-            assert!(
-                path.ends_with(&suffix),
-                "unexpected default path: {}",
-                path.display()
-            );
-        }
-    }
-
-    #[test]
-    fn open_creates_file_and_missing_parent() {
-        let dir = tempfile::tempdir().unwrap();
-        // Parent chain `nested/sub` does not exist yet.
-        let path = dir.path().join("nested").join("sub").join("test.pal");
-        let db = HeedDB::open(&path).expect("open should succeed");
-        assert!(path.is_file(), "db should be a single file (NO_SUB_DIR)");
-        assert_eq!(db.path(), path.as_path());
-    }
-
-    #[test]
     fn open_creates_empty_tables_catalog() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("cat.pal");
         let db = HeedDB::open(&path).unwrap();
+
+        // NO_SUB_DIR mode stores the environment as a single file, not a dir.
+        assert!(path.is_file(), "db should be a single file (NO_SUB_DIR)");
+
         let rtxn = db.env().read_txn().unwrap();
 
         // Assert the named `_tables` database specifically exists: look it up by
@@ -268,17 +183,5 @@ mod tests {
         } // first handle dropped, env closed
         let reopened = HeedDB::open(&path);
         assert!(reopened.is_ok(), "reopening an existing db must succeed");
-    }
-
-    #[test]
-    fn open_errors_when_parent_cannot_be_created() {
-        let dir = tempfile::tempdir().unwrap();
-        // Create a regular FILE, then try to open a db "underneath" it, so the
-        // parent-dir creation must fail.
-        let blocker = dir.path().join("afile");
-        std::fs::write(&blocker, b"x").unwrap();
-        let bad = blocker.join("test.pal");
-        let res = HeedDB::open(&bad);
-        assert!(matches!(res, Err(StorageError::Io(_))), "got: {res:?}");
     }
 }


### PR DESCRIPTION
  Add a storage module to partiql-tools backed by heed 0.20 (LMDB). HeedDB
  opens a single-file environment and creates the _tables system catalog,
  exposing the env, catalog, and path. The pqlite REPL gains a global --db
  flag that selects the database file (defaulting to ~/.pqlite/default.pal),
  opens it on startup, and hard-fails with a clear message if it cannot be
  opened. The startup banner reports the active path on stderr so stdout
  stays reserved for query results.

  The database is opened lazily, only for the interactive REPL: a one-shot
  exec query is read-only today and must not create a database file as a
  side effect. heed is pulled with default-features disabled since the serde
  codecs are unused.

  Storage stays on the consumer side: the catalog is created but not written
  to, and the handle is not threaded into query execution. Those are
  follow-up PRs.

