### PR TITLE
feat: implement CREATE TABLE AS write path on LMDB

### DIFF
--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -5,7 +5,7 @@ use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
 use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
 use partiql_logical::LogicalStatement;
-use partiql_tools::storage::HeedDB;
+use partiql_tools::storage::{HeedDB, StorageError};
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
 use std::time::Instant;
@@ -70,6 +70,26 @@ enum Commands {
     },
 }
 
+/// How `execute_query` obtains a database when a statement needs one.
+///
+/// Only `CREATE TABLE AS` needs storage. The REPL opens one handle for the
+/// whole session and passes it as `Open`; `exec` passes `Lazy` so the database
+/// is opened only if a write statement actually requires it — a plain query via
+/// `exec` never opens or creates a file.
+///
+/// This is CLI dispatch plumbing, not a storage abstraction: it encodes the
+/// three valid call states (live handle / lazy path / no path) as two variants
+/// so an illegal "both a handle and a path" state is unrepresentable. It is
+/// unrelated to any future engine-agnostic storage trait.
+#[derive(Clone, Copy)]
+enum DbSource<'a> {
+    /// An already-open handle (the REPL session database).
+    Open(&'a HeedDB),
+    /// A `--db` path to open on demand (the `exec` subcommand); `None` if no
+    /// `--db` was given.
+    Lazy(Option<&'a std::path::Path>),
+}
+
 fn main() {
     let cli = Cli::parse();
     let debug = DebugFlags::from_args(&cli.debug);
@@ -81,7 +101,7 @@ fn main() {
                 eprintln!("Error: empty query");
                 std::process::exit(1);
             }
-            if let Err(e) = execute_query(query, &debug) {
+            if let Err(e) = execute_query(query, &debug, DbSource::Lazy(cli.db.as_deref())) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
@@ -312,7 +332,7 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
                     continue;
                 }
 
-                if let Err(e) = execute_query(query, debug) {
+                if let Err(e) = execute_query(query, debug, DbSource::Open(db)) {
                     eprintln!("{}", e);
                 }
             }
@@ -346,6 +366,25 @@ fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
     }
 }
 
+/// Derive the canonical catalog key for a table name. Bare (case-insensitive)
+/// identifiers fold to lowercase so `foo`, `FOO`, and `Foo` collide as one
+/// table; quoted (case-sensitive) identifiers are kept verbatim. This is
+/// ASCII-equivalent to the engine's `UniCase` fold; full Unicode-consistent
+/// folding is a later-PR refinement.
+///
+/// NOTE: `name` may contain arbitrary bytes from a quoted identifier. The
+/// downstream `HeedDB::create_table_from_rows` passes this key to heed's
+/// `create_database`, which calls `CString::new(name).unwrap()` internally —
+/// an interior NUL byte would panic there (rolling back the txn, so no
+/// corruption, but an ugly panic). A future hardening can reject interior-NUL
+/// names here; PR 2 does not, as it is not a corruption risk.
+fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
+    match name {
+        partiql_value::BindingsName::CaseInsensitive(s) => s.to_lowercase(),
+        partiql_value::BindingsName::CaseSensitive(s) => s.to_string(),
+    }
+}
+
 /// Shared stderr footer for a planning-only DDL statement.
 fn print_ddl_planned_footer(elapsed: std::time::Duration) {
     eprintln!(
@@ -354,7 +393,58 @@ fn print_ddl_planned_footer(elapsed: std::time::Duration) {
     );
 }
 
-fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std::error::Error>> {
+/// Compile a lowered query plan into an executable program, applying the
+/// `plan`/`program` debug dumps. Shared by the `Query` and `CreateTableAs`
+/// paths so their compilation setup cannot drift.
+///
+/// Note: when a debug flag is set, the `[Plan]`/`[Program]` dumps are written
+/// inside this call, so the caller's reported `compile:` time includes their
+/// cost. That only affects the diagnostic timing line under `--debug`; normal
+/// output is unaffected.
+fn build_compiled(
+    logical: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+    debug: &DebugFlags,
+) -> Result<partiql_eval::CompiledPlan, Box<dyn std::error::Error>> {
+    if debug.plan {
+        eprintln!("[Plan] {:?}", logical);
+    }
+
+    let mut context = CompilationContext::new();
+    let column_names = vec!["a".to_string(), "b".to_string()];
+    let comp_catalog: std::sync::Arc<dyn partiql_eval::CompilationCatalog> =
+        std::sync::Arc::new(common::TableFnCompilationCatalog::new(column_names));
+    let _catalog_id = context.add_catalog("default", comp_catalog);
+
+    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
+    let compiled = compiler
+        .compile(logical)
+        .map_err(|e| format!("Compile error: {:?}", e))?;
+
+    if debug.program {
+        eprintln!("[Program]\n{}", compiled);
+    }
+
+    Ok(compiled)
+}
+
+/// Build the execution context with pqlite's table functions registered.
+/// Shared by the `Query` and `CreateTableAs` paths.
+fn build_exec_context() -> ExecutionContext {
+    let mut exec_context = ExecutionContext::new();
+    exec_context.register_table_function("rand", std::sync::Arc::new(common::RandTableFunction));
+    exec_context.register_table_function("mem", std::sync::Arc::new(common::MemTableFunction));
+    exec_context.register_table_function(
+        "scan_ion",
+        std::sync::Arc::new(common::ScanIonTableFunction),
+    );
+    exec_context
+}
+
+fn execute_query(
+    query_str: &str,
+    debug: &DebugFlags,
+    db_source: DbSource,
+) -> Result<(), Box<dyn std::error::Error>> {
     let query = query_str.to_string();
 
     let catalog = create_table_fn_catalog();
@@ -388,14 +478,81 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
     let logical = match statement {
         LogicalStatement::Query(plan) => plan,
         LogicalStatement::CreateTableAs { table_name, query } => {
-            // `{}` (Display) on the plan, not `{:?}`: LogicalPlan has a readable
-            // Display impl; Debug would dump the raw nodes/edges struct.
-            println!(
-                "Planned CREATE TABLE {} AS:",
-                format_table_name(&table_name)
+            let key = canonical_table_key(&table_name);
+
+            // Resolve the database. The REPL passes its already-open session
+            // handle; `exec` opens lazily from --db here, so a plain query via
+            // `exec` never opens or creates a file. `lazily_opened` owns the
+            // exec-path handle for the rest of this arm (deferred-init local so
+            // the borrow in the `Lazy` branch outlives the match).
+            let lazily_opened;
+            let db: &HeedDB = match db_source {
+                DbSource::Open(db) => db,
+                DbSource::Lazy(path) => {
+                    let path = path.ok_or(
+                        "Error: The `--db <PATH>` option is required for CREATE TABLE AS.",
+                    )?;
+                    lazily_opened = HeedDB::open(path).map_err(|e| {
+                        format!(
+                            "Error: could not open database at {}: {}",
+                            path.display(),
+                            e
+                        )
+                    })?;
+                    &lazily_opened
+                }
+            };
+
+            // Compile and execute the inner query exactly like a plain query,
+            // but stream the rows into storage instead of stdout.
+            let compile_start = Instant::now();
+            let compiled = build_compiled(&query, debug)?;
+            let compile_time = compile_start.elapsed();
+
+            let exec_start = Instant::now();
+            let exec_context = build_exec_context();
+            let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+                .map_err(|e| format!("Execution setup error: {:?}", e))?;
+
+            let n = match vm.execute() {
+                Ok(partiql_eval::ExecutionResult::Query(iter)) => {
+                    // Map each VM row to Result<(), StorageError>: PR 2 discards
+                    // the (not-yet-serialized) row data and keeps only
+                    // success/failure. The VM's error type is stringified here
+                    // so storage stays independent of partiql-eval.
+                    let rows = iter.map(|r| {
+                        r.map(|_row| ())
+                            .map_err(|e| StorageError::Execution(format!("{:?}", e)))
+                    });
+                    match db.create_table_from_rows(&key, rows) {
+                        Ok(n) => n,
+                        // Every StorageError carries its own user-facing message
+                        // via Display (e.g. "table already exists: foo"), so route
+                        // them all through one uniform prefix rather than
+                        // special-casing any single variant.
+                        Err(e) => return Err(format!("Error: {}", e).into()),
+                    }
+                }
+                Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
+            };
+            let exec_time = exec_start.elapsed();
+
+            // stdout stays empty for a write; confirmation + timing go to stderr.
+            eprintln!(
+                "Created table {} ({} rows)",
+                format_table_name(&table_name),
+                n
             );
-            println!("{}", query);
-            print_ddl_planned_footer(parse_time + lower_time);
+            let total_time = parse_time + lower_time + compile_time + exec_time;
+            eprintln!(
+                "({} rows in {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
+                n,
+                total_time.as_secs_f64() * 1000.0,
+                parse_time.as_secs_f64() * 1000.0,
+                lower_time.as_secs_f64() * 1000.0,
+                compile_time.as_secs_f64() * 1000.0,
+                exec_time.as_secs_f64() * 1000.0,
+            );
             return Ok(());
         }
         LogicalStatement::CreateTable { table_name } => {
@@ -408,44 +565,14 @@ fn execute_query(query_str: &str, debug: &DebugFlags) -> Result<(), Box<dyn std:
         }
     };
 
-    if debug.plan {
-        eprintln!("[Plan] {:?}", logical);
-    }
-
     // Phase 3: Compile (Logical → CompiledPlan)
     let compile_start = Instant::now();
-
-    // Set up compilation context with table function support
-    let mut context = CompilationContext::new();
-
-    // Use TableFnCompilationCatalog which supports both table lookups and table functions
-    let column_names = vec!["a".to_string(), "b".to_string()];
-    let comp_catalog: std::sync::Arc<dyn partiql_eval::CompilationCatalog> =
-        std::sync::Arc::new(common::TableFnCompilationCatalog::new(column_names));
-    let _catalog_id = context.add_catalog("default", comp_catalog);
-
-    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
-    let compiled = compiler
-        .compile(&logical)
-        .map_err(|e| format!("Compile error: {:?}", e))?;
+    let compiled = build_compiled(&logical, debug)?;
     let compile_time = compile_start.elapsed();
-
-    if debug.program {
-        eprintln!("[Program]\n{}", compiled);
-    }
 
     // Phase 4: Execute
     let exec_start = Instant::now();
-
-    // Create ExecutionContext with table functions registered
-    let mut exec_context = ExecutionContext::new();
-    exec_context.register_table_function("rand", std::sync::Arc::new(common::RandTableFunction));
-    exec_context.register_table_function("mem", std::sync::Arc::new(common::MemTableFunction));
-    exec_context.register_table_function(
-        "scan_ion",
-        std::sync::Arc::new(common::ScanIonTableFunction),
-    );
-
+    let exec_context = build_exec_context();
     let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
         .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
@@ -606,5 +733,31 @@ fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
             }
             Value::Bag(Box::new(items.into()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use partiql_value::BindingsName;
+    use std::borrow::Cow;
+
+    #[test]
+    fn canonical_key_folds_case_insensitive_to_lowercase() {
+        let n = BindingsName::CaseInsensitive(Cow::Borrowed("FOO"));
+        assert_eq!(canonical_table_key(&n), "foo");
+    }
+
+    #[test]
+    fn canonical_key_preserves_case_sensitive_verbatim() {
+        let n = BindingsName::CaseSensitive(Cow::Borrowed("Foo"));
+        assert_eq!(canonical_table_key(&n), "Foo");
+    }
+
+    #[test]
+    fn canonical_key_collides_bare_names_regardless_of_case() {
+        let a = BindingsName::CaseInsensitive(Cow::Borrowed("Foo"));
+        let b = BindingsName::CaseInsensitive(Cow::Borrowed("FOO"));
+        assert_eq!(canonical_table_key(&a), canonical_table_key(&b));
     }
 }

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -372,12 +372,10 @@ fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
 /// ASCII-equivalent to the engine's `UniCase` fold; full Unicode-consistent
 /// folding is a later-PR refinement.
 ///
-/// NOTE: `name` may contain arbitrary bytes from a quoted identifier. The
-/// downstream `HeedDB::create_table_from_rows` passes this key to heed's
-/// `create_database`, which calls `CString::new(name).unwrap()` internally —
-/// an interior NUL byte would panic there (rolling back the txn, so no
-/// corruption, but an ugly panic). A future hardening can reject interior-NUL
-/// names here; PR 2 does not, as it is not a corruption risk.
+/// NOTE: `name` may contain arbitrary bytes from a quoted identifier. An
+/// interior NUL byte would otherwise panic heed's internal
+/// `CString::new(name).unwrap()`; `HeedDB::create_table_from_rows` guards
+/// against that up front and returns `StorageError::InvalidName` instead.
 fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
     match name {
         partiql_value::BindingsName::CaseInsensitive(s) => s.to_lowercase(),
@@ -538,6 +536,8 @@ fn execute_query(
             let exec_time = exec_start.elapsed();
 
             // stdout stays empty for a write; confirmation + timing go to stderr.
+            // The confirmation line carries the row count; the timing line is
+            // purely the per-phase breakdown so the count is not repeated.
             eprintln!(
                 "Created table {} ({} rows)",
                 format_table_name(&table_name),
@@ -545,8 +545,7 @@ fn execute_query(
             );
             let total_time = parse_time + lower_time + compile_time + exec_time;
             eprintln!(
-                "({} rows in {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-                n,
+                "(took {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
                 total_time.as_secs_f64() * 1000.0,
                 parse_time.as_secs_f64() * 1000.0,
                 lower_time.as_secs_f64() * 1000.0,

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -41,6 +41,9 @@ pub enum StorageError {
     TableExists(String),
     /// A `CREATE TABLE AS` used a reserved name (`_`-prefixed system namespace).
     ReservedName(String),
+    /// A table name heed cannot use as a database name (it contains an interior
+    /// NUL byte, which would panic heed's internal `CString::new`).
+    InvalidName(String),
     /// A VM execution error, pre-stringified by the caller so this layer does
     /// not depend on `partiql-eval`'s error type.
     Execution(String),
@@ -52,11 +55,13 @@ impl std::fmt::Display for StorageError {
             StorageError::Io(e) => write!(f, "storage I/O error: {e}"),
             StorageError::Heed(e) => write!(f, "storage engine error: {e}"),
             StorageError::TableExists(name) => write!(f, "table already exists: {name}"),
-            // User-facing: surfaced verbatim to CLI users, hence the full sentence.
             StorageError::ReservedName(name) => write!(
                 f,
-                "Table name '{name}' is reserved (names starting with '_' are for system use)"
+                "reserved table name '{name}' (names starting with '_' are for system use)"
             ),
+            StorageError::InvalidName(name) => {
+                write!(f, "invalid table name {name:?}: contains a NUL byte")
+            }
             StorageError::Execution(msg) => write!(f, "execution error: {msg}"),
         }
     }
@@ -69,6 +74,7 @@ impl std::error::Error for StorageError {
             StorageError::Heed(e) => Some(e),
             StorageError::TableExists(_)
             | StorageError::ReservedName(_)
+            | StorageError::InvalidName(_)
             | StorageError::Execution(_) => None,
         }
     }
@@ -157,6 +163,14 @@ impl HeedDB {
         // and corrupt it. Reject the whole `_` namespace up front.
         if name.starts_with('_') {
             return Err(StorageError::ReservedName(name.to_string()));
+        }
+
+        // A name with an interior NUL would panic heed's internal
+        // `CString::new(name).unwrap()` in `create_database`. Reject it here as a
+        // clean error rather than letting a user-supplied quoted identifier
+        // (e.g. `CREATE TABLE "a\0b" AS ...`) reach that unwrap.
+        if name.contains('\0') {
+            return Err(StorageError::InvalidName(name.to_string()));
         }
 
         let mut wtxn = self.env.write_txn()?;
@@ -298,6 +312,24 @@ mod tests {
     }
 
     #[test]
+    fn create_table_from_rows_rejects_interior_nul_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nul.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        // An interior NUL would otherwise panic heed's CString::new; the guard
+        // turns it into a clean error and never opens a transaction.
+        let res = db.create_table_from_rows("a\0b", vec![Ok(())]);
+        assert!(
+            matches!(res, Err(StorageError::InvalidName(_))),
+            "interior-NUL name should be InvalidName, got: {res:?}"
+        );
+
+        let rtxn = db.env().read_txn().unwrap();
+        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
+    }
+
+    #[test]
     fn create_table_from_rows_rolls_back_on_mid_stream_error() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollback.pqlite");
@@ -352,6 +384,11 @@ mod tests {
         let s = rn.to_string();
         assert!(s.contains("reserved"), "got: {s}");
         assert!(s.contains("_x"), "got: {s}");
+
+        let inv = StorageError::InvalidName("a\0b".to_string());
+        let s = inv.to_string();
+        assert!(s.contains("invalid table name"), "got: {s}");
+        assert!(s.contains("NUL"), "got: {s}");
 
         let ex = StorageError::Execution("boom".to_string());
         assert!(ex.to_string().contains("boom"), "got: {ex}");

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -92,6 +92,29 @@ impl From<heed::Error> for StorageError {
     }
 }
 
+/// Normalize a database path so heed can open a not-yet-existing single-file
+/// (`NO_SUB_DIR`) database given as a bare filename.
+///
+/// For a file that doesn't exist yet, heed recovers by canonicalizing
+/// `path.parent()` and re-joining the file name. But `parent()` of a bare name
+/// like `foo.pqlite` is the empty path `""`, and canonicalizing `""` is ENOENT —
+/// so `pqlite --db foo.pqlite` would spuriously fail even though the current
+/// directory exists and every other UNIX tool (`sqlite3 foo.db`, `touch`, ...)
+/// would just create the file there. Joining a bare name onto `.` gives heed a
+/// real parent (`.`) to canonicalize.
+///
+/// This neither invents a default path nor creates any directory: a path that
+/// already has a directory component is returned unchanged, so a genuinely
+/// missing parent (`missing_dir/foo.pqlite`) still errors — the behavior the
+/// `--db` contract wants.
+fn normalize_db_path(path: &Path) -> PathBuf {
+    if path.parent() == Some(Path::new("")) {
+        Path::new(".").join(path)
+    } else {
+        path.to_path_buf()
+    }
+}
+
 /// Owns the LMDB environment and the `_tables` system catalog handle.
 ///
 /// The `Env` and the `Database` handle share a lifecycle: the catalog handle is
@@ -114,6 +137,10 @@ impl HeedDB {
         // the parent directory is missing the filesystem error bubbles up
         // naturally — matching how standard UNIX tools behave.
 
+        // Normalize a bare filename to an explicit `./name` before handing it
+        // to heed (see `normalize_db_path` for the why).
+        let normalized = normalize_db_path(path);
+
         // Open the environment. `flags` and `open` are both unsafe in heed
         // 0.20, so the whole builder chain is in one unsafe block.
         // SAFETY: NO_SUB_DIR only changes the on-disk layout (single file vs.
@@ -126,7 +153,7 @@ impl HeedDB {
                 .map_size(DEFAULT_MAP_SIZE)
                 .max_dbs(MAX_DBS)
                 .flags(heed::EnvFlags::NO_SUB_DIR)
-                .open(path)?
+                .open(&normalized)?
         };
 
         // Open/create the `_tables` catalog in a write transaction.
@@ -431,5 +458,27 @@ mod tests {
         } // first handle dropped, env closed
         let reopened = HeedDB::open(&path);
         assert!(reopened.is_ok(), "reopening an existing db must succeed");
+    }
+
+    #[test]
+    fn normalize_db_path_prefixes_bare_filename_with_dot() {
+        // A bare filename (empty parent) gets an explicit `.` parent so heed can
+        // canonicalize it; anything with a real directory component is untouched.
+        assert_eq!(
+            normalize_db_path(Path::new("foo.pqlite")),
+            Path::new("./foo.pqlite")
+        );
+        assert_eq!(
+            normalize_db_path(Path::new("./foo.pqlite")),
+            Path::new("./foo.pqlite")
+        );
+        assert_eq!(
+            normalize_db_path(Path::new("sub/foo.pqlite")),
+            Path::new("sub/foo.pqlite")
+        );
+        assert_eq!(
+            normalize_db_path(Path::new("/tmp/foo.pqlite")),
+            Path::new("/tmp/foo.pqlite")
+        );
     }
 }

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -21,13 +21,29 @@ const TABLES_DB: &str = "_tables";
 /// value format is deliberately left opaque until the table-registration PR.
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
-/// Errors from opening or initializing the storage environment.
+/// Row-store key codec: a `u64` row id, big-endian so LMDB's lexicographic key
+/// order matches numeric order.
+type RowKey = heed::types::U64<heed::byteorder::BigEndian>;
+
+/// A user table's row store: `u64` row-id keys to opaque byte values. PR 2
+/// writes a constant `&[0x00]` value per row; Ion-encoded values land in PR 3.
+type RowDb = heed::Database<RowKey, heed::types::Bytes>;
+
+/// Errors from opening or initializing the storage environment, or from
+/// executing a write path against it.
 #[derive(Debug)]
 pub enum StorageError {
     /// Filesystem-level error surfaced while working with the database file.
     Io(std::io::Error),
     /// Error from the heed/LMDB layer.
     Heed(heed::Error),
+    /// A `CREATE TABLE AS` named a table already registered in the catalog.
+    TableExists(String),
+    /// A `CREATE TABLE AS` used a reserved name (`_`-prefixed system namespace).
+    ReservedName(String),
+    /// A VM execution error, pre-stringified by the caller so this layer does
+    /// not depend on `partiql-eval`'s error type.
+    Execution(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -35,6 +51,13 @@ impl std::fmt::Display for StorageError {
         match self {
             StorageError::Io(e) => write!(f, "storage I/O error: {e}"),
             StorageError::Heed(e) => write!(f, "storage engine error: {e}"),
+            StorageError::TableExists(name) => write!(f, "table already exists: {name}"),
+            // User-facing: surfaced verbatim to CLI users, hence the full sentence.
+            StorageError::ReservedName(name) => write!(
+                f,
+                "Table name '{name}' is reserved (names starting with '_' are for system use)"
+            ),
+            StorageError::Execution(msg) => write!(f, "execution error: {msg}"),
         }
     }
 }
@@ -44,6 +67,9 @@ impl std::error::Error for StorageError {
         match self {
             StorageError::Io(e) => Some(e),
             StorageError::Heed(e) => Some(e),
+            StorageError::TableExists(_)
+            | StorageError::ReservedName(_)
+            | StorageError::Execution(_) => None,
         }
     }
 }
@@ -111,6 +137,52 @@ impl HeedDB {
         })
     }
 
+    /// Create a new table from a stream of rows, in a single write transaction.
+    ///
+    /// PR 2 writes a constant `&[0x00]` value per row; Ion serialization lands
+    /// in PR 3. Only the transaction boundary, table creation, catalog
+    /// registration, and row-iteration loop are exercised here.
+    ///
+    /// `name` must already be canonicalized by the caller (bare identifiers
+    /// folded to lowercase, quoted identifiers verbatim). Returns the number
+    /// of rows written. Any error drops the `RwTxn` before commit, so LMDB
+    /// rolls the whole operation back and nothing partial persists.
+    pub fn create_table_from_rows<I>(&self, name: &str, rows: I) -> Result<u64, StorageError>
+    where
+        I: IntoIterator<Item = Result<(), StorageError>>,
+    {
+        // Reserved-name guard runs FIRST, before any transaction. heed performs
+        // no runtime codec check when reopening a named db, so creating a table
+        // called `_tables` would reopen the catalog's own dbi with integer keys
+        // and corrupt it. Reject the whole `_` namespace up front.
+        if name.starts_with('_') {
+            return Err(StorageError::ReservedName(name.to_string()));
+        }
+
+        let mut wtxn = self.env.write_txn()?;
+
+        // Duplicate check against the catalog, in the same txn. `RwTxn` derefs
+        // to `RoTxn`, so the existence check and the creation are atomic.
+        if self.tables.get(&wtxn, name)?.is_some() {
+            return Err(StorageError::TableExists(name.to_string()));
+        }
+
+        // Create the per-table row store and register the table in the catalog.
+        let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
+        self.tables.put(&mut wtxn, name, &[0x00])?;
+
+        // Dummy write loop: sequential u64 key, constant byte value.
+        let mut row_id: u64 = 0;
+        for row in rows {
+            row?; // a VM error (Execution) bubbles out; dropping wtxn rolls back.
+            table.put(&mut wtxn, &row_id, &[0x00])?;
+            row_id += 1;
+        }
+
+        wtxn.commit()?;
+        Ok(row_id)
+    }
+
     // TODO: these accessors expose heed types (`Env`, `Database`) directly,
     // which leaks the storage engine across the module boundary. If a later
     // milestone abstracts storage away from heed (e.g. custom index
@@ -137,6 +209,130 @@ mod tests {
     use super::*;
 
     #[test]
+    fn create_table_from_rows_writes_all_rows_and_registers_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ctas.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let rows: Vec<Result<(), StorageError>> = vec![Ok(()), Ok(()), Ok(())];
+        let n = db.create_table_from_rows("widgets", rows).unwrap();
+        assert_eq!(n, 3);
+
+        let rtxn = db.env().read_txn().unwrap();
+
+        // The table is registered in the catalog.
+        assert!(
+            db.tables().get(&rtxn, "widgets").unwrap().is_some(),
+            "widgets should be registered in _tables"
+        );
+
+        // The row store has exactly keys 0, 1, 2.
+        let rowdb: RowDb = db
+            .env()
+            .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("widgets"))
+            .unwrap()
+            .expect("widgets row db should exist");
+        assert_eq!(rowdb.len(&rtxn).unwrap(), 3);
+        for i in 0u64..3 {
+            assert!(rowdb.get(&rtxn, &i).unwrap().is_some(), "row {i} missing");
+        }
+    }
+
+    #[test]
+    fn create_table_from_rows_with_no_rows_creates_empty_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let rows: Vec<Result<(), StorageError>> = Vec::new();
+        let n = db.create_table_from_rows("blank", rows).unwrap();
+        assert_eq!(n, 0);
+
+        let rtxn = db.env().read_txn().unwrap();
+        assert!(db.tables().get(&rtxn, "blank").unwrap().is_some());
+        let rowdb: RowDb = db
+            .env()
+            .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("blank"))
+            .unwrap()
+            .expect("blank row db should exist");
+        assert_eq!(rowdb.len(&rtxn).unwrap(), 0);
+    }
+
+    #[test]
+    fn create_table_from_rows_rejects_duplicate_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dup.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        db.create_table_from_rows("t", vec![Ok(()), Ok(())])
+            .unwrap();
+
+        let again = db.create_table_from_rows("t", vec![Ok(())]);
+        assert!(
+            matches!(again, Err(StorageError::TableExists(ref n)) if n == "t"),
+            "second create should be TableExists, got: {again:?}"
+        );
+
+        // The original table is untouched: catalog still has exactly one entry.
+        let rtxn = db.env().read_txn().unwrap();
+        assert_eq!(db.tables().len(&rtxn).unwrap(), 1);
+    }
+
+    #[test]
+    fn create_table_from_rows_rejects_reserved_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reserved.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        for name in ["_tables", "_indexes", "_x"] {
+            let res = db.create_table_from_rows(name, vec![Ok(())]);
+            assert!(
+                matches!(res, Err(StorageError::ReservedName(_))),
+                "{name} should be reserved, got: {res:?}"
+            );
+        }
+
+        // The guard runs before any transaction, so the catalog is untouched.
+        let rtxn = db.env().read_txn().unwrap();
+        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
+    }
+
+    #[test]
+    fn create_table_from_rows_rolls_back_on_mid_stream_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollback.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let rows: Vec<Result<(), StorageError>> = vec![
+            Ok(()),
+            Ok(()),
+            Err(StorageError::Execution("boom".to_string())),
+        ];
+        let res = db.create_table_from_rows("partial", rows);
+        assert!(
+            matches!(res, Err(StorageError::Execution(_))),
+            "expected the mid-stream Execution error to surface, got: {res:?}"
+        );
+
+        // Rollback: the txn was never committed, so the catalog has no entry.
+        let rtxn = db.env().read_txn().unwrap();
+        assert_eq!(
+            db.tables().len(&rtxn).unwrap(),
+            0,
+            "the failed CTAS must not register the table"
+        );
+
+        // The orphan row-store db must also be absent — rollback dropped it.
+        assert!(
+            db.env()
+                .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("partial"))
+                .unwrap()
+                .is_none(),
+            "the failed CTAS must not leave a row-store db behind"
+        );
+    }
+
+    #[test]
     fn storage_error_displays_and_converts_from_io() {
         let io = std::io::Error::new(std::io::ErrorKind::NotFound, "boom");
         let err: StorageError = io.into();
@@ -147,9 +343,24 @@ mod tests {
     }
 
     #[test]
+    fn new_storage_errors_display() {
+        let te = StorageError::TableExists("foo".to_string());
+        assert!(te.to_string().contains("already exists"), "got: {te}");
+        assert!(te.to_string().contains("foo"), "got: {te}");
+
+        let rn = StorageError::ReservedName("_x".to_string());
+        let s = rn.to_string();
+        assert!(s.contains("reserved"), "got: {s}");
+        assert!(s.contains("_x"), "got: {s}");
+
+        let ex = StorageError::Execution("boom".to_string());
+        assert!(ex.to_string().contains("boom"), "got: {ex}");
+    }
+
+    #[test]
     fn open_creates_empty_tables_catalog() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cat.pal");
+        let path = dir.path().join("cat.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
         // NO_SUB_DIR mode stores the environment as a single file, not a dir.
@@ -177,7 +388,7 @@ mod tests {
     #[test]
     fn open_is_idempotent_on_reopen() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("reopen.pal");
+        let path = dir.path().join("reopen.pqlite");
         {
             let _db = HeedDB::open(&path).unwrap();
         } // first handle dropped, env closed

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -109,6 +109,57 @@ fn ctas_with_db_creates_table_and_persists_file() {
 }
 
 #[test]
+fn ctas_with_bare_db_filename_creates_file_in_cwd() {
+    // Regression: `pqlite --db foo.pqlite` with a BARE filename (no directory
+    // component) must create the file in the current directory, like any UNIX
+    // tool — not fail with ENOENT. The child runs with its cwd set to a temp
+    // dir, so the bare name resolves there.
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = Command::new(PQLITE)
+        .arg("--db")
+        .arg("bare.pqlite") // bare name: parent() is "" — the bug case
+        .arg("exec")
+        .arg("CREATE TABLE t AS (SELECT t.a FROM mem(2,2) t)")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn pqlite");
+
+    assert!(
+        out.status.success(),
+        "bare --db filename should create the db in cwd; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        dir.path().join("bare.pqlite").is_file(),
+        "the bare-named db file should exist in the cwd after CTAS"
+    );
+}
+
+#[test]
+fn ctas_with_missing_parent_dir_errors() {
+    // The flip side of the bare-name fix: a path whose parent directory does
+    // NOT exist must still error (we never create directories on the user's
+    // behalf). This guards against the normalization over-reaching.
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does_not_exist").join("x.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)",
+        Some(&missing),
+    );
+    assert!(!ok, "CTAS into a missing parent dir must fail");
+    assert!(
+        stderr.contains("could not open database"),
+        "expected an open error for the missing parent, got: {stderr}"
+    );
+    assert!(
+        !missing.exists(),
+        "we must not create the file or its parent dir"
+    );
+}
+
+#[test]
 fn duplicate_ctas_is_rejected_and_names_the_table() {
     let dir = tempfile::tempdir().unwrap();
     let db = dir.path().join("dup.pqlite");

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -1,0 +1,128 @@
+//! End-to-end tests for the `pqlite` binary's CLI contract.
+//!
+//! These drive the built binary as a subprocess (via Cargo's
+//! `CARGO_BIN_EXE_pqlite`) so the load-bearing CLI behavior is verified in CI,
+//! not just by hand:
+//!   * the lazy-open contract — a plain `SELECT` via `exec` needs no `--db` and
+//!     creates no file;
+//!   * `CREATE TABLE AS` requires `--db` and errors cleanly without it;
+//!   * `CREATE TABLE AS` with `--db` creates the table and persists the file;
+//!   * a duplicate `CREATE TABLE AS` is rejected.
+//!
+//! No extra dev-dependencies: just `std::process::Command` and `tempfile`
+//! (already a dev-dependency).
+
+use std::process::Command;
+
+/// Path to the freshly built `pqlite` binary, provided by Cargo for integration
+/// tests of a binary target in the same package.
+const PQLITE: &str = env!("CARGO_BIN_EXE_pqlite");
+
+/// Run `pqlite exec <query>`, optionally with `--db <path>`. Returns
+/// (exit_success, stdout, stderr).
+fn run_exec(query: &str, db: Option<&std::path::Path>) -> (bool, String, String) {
+    let mut cmd = Command::new(PQLITE);
+    cmd.arg("exec").arg(query);
+    if let Some(path) = db {
+        cmd.arg("--db").arg(path);
+    }
+    let out = cmd.output().expect("failed to spawn pqlite");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn plain_select_via_exec_needs_no_db_and_creates_no_file() {
+    // Run from inside a temp dir so we can assert nothing was written there.
+    // (The `exec` subcommand never builds the REPL history file, so there is
+    // nothing to escape cleanup — only the lazy-open db file is at issue here.)
+    let dir = tempfile::tempdir().unwrap();
+
+    let out = Command::new(PQLITE)
+        .arg("exec")
+        .arg("SELECT t.a FROM mem(3,2) t")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn pqlite");
+
+    assert!(
+        out.status.success(),
+        "plain SELECT via exec should succeed without --db; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("'a': 0") && stdout.contains("'a': 2"),
+        "expected the 3-row bag on stdout, got: {stdout}"
+    );
+
+    // The lazy-open contract: no database file was created anywhere in the cwd.
+    let stray: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "a plain SELECT must create no files, but found: {stray:?}"
+    );
+}
+
+#[test]
+fn ctas_without_db_errors_cleanly() {
+    let (ok, stdout, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)", None);
+
+    assert!(!ok, "CTAS without --db must fail");
+    assert!(
+        stderr.contains("--db") && stderr.contains("CREATE TABLE AS"),
+        "expected a --db-required error mentioning CREATE TABLE AS, got: {stderr}"
+    );
+    assert!(
+        stdout.is_empty(),
+        "a failed write must print nothing to stdout"
+    );
+}
+
+#[test]
+fn ctas_with_db_creates_table_and_persists_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("ctas.pqlite");
+
+    let (ok, stdout, stderr) = run_exec(
+        "CREATE TABLE widgets AS (SELECT t.a FROM mem(5,2) t)",
+        Some(&db),
+    );
+
+    assert!(ok, "CTAS with --db should succeed; stderr: {stderr}");
+    assert!(
+        stdout.is_empty(),
+        "a write must leave stdout empty, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("Created table") && stderr.contains("widgets") && stderr.contains("5 rows"),
+        "expected the creation confirmation on stderr, got: {stderr}"
+    );
+    assert!(db.is_file(), "the --db file should exist after CTAS");
+}
+
+#[test]
+fn duplicate_ctas_is_rejected_and_names_the_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("dup.pqlite");
+
+    let (ok1, _, _) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(2,2) t)", Some(&db));
+    assert!(ok1, "first CTAS should succeed");
+
+    let (ok2, _, stderr2) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)", Some(&db));
+    assert!(!ok2, "second CTAS for the same table must fail");
+    // Anchor the table name to the error context. A bare `contains('t')` would
+    // be tautological: the word "table" in the message already supplies a 't",
+    // so it would pass even if the name were dropped from the error.
+    assert!(
+        stderr2.contains("already exists: t"),
+        "duplicate error should name the table, got: {stderr2}"
+    );
+}


### PR DESCRIPTION
Wires up CREATE TABLE AS end to end: run the inner query through the VM and write one dummy byte per row into a new LMDB table. Real Ion serialization comes in a later PR. Storage is designed so a plain query via exec doesn't need --db. CREATE TABLE AS opens the --db path when it actually needs it, and the REPL just reuses its session handle.

- HeedDB::create_table_from_rows does the write in a single txn: reserved-name guard for the _ namespace, catalog duplicate check, table creation, then the row loop. Any error partway through drops the txn and LMDB rolls it back.
- canonical_table_key lowercases bare identifiers and leaves quoted ones alone, which matches how PartiQL treats identifier case for the catalog key.
- Pulled build_compiled and build_exec_context out of execute_query so the query and CTAS paths share the same compile and exec setup.
- All storage errors now go through Display, so the error text on stderr is consistent. stdout stays empty on a write.
- Renamed the two leftover .pal test fixtures to .pqlite to finish off that rename.