### PR TITLE
feat: implement zero-allocation binary row serialization

### DIFF
--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -570,32 +570,29 @@ fn execute_query(
                         }
                     };
 
-                    let driver_result = db.create_table_from_rows(&key, |push_row| {
-                        // SAFETY-RELEVANT: QueryIterator::next uses unsafe
-                        // lifetime extension on the RegisterReader it yields
-                        // (partiql-eval/src/engine/plan.rs:892-895). Aliasing
-                        // a RegisterReader across iter.next() is UB. We
-                        // consume `row` synchronously inside serialize_row,
-                        // then drop it; push_row sees only the encoded bytes.
-                        if let Some(ref bytes) = first_row_bytes {
-                            push_row(bytes)?;
-                        }
-                        for r in iter.by_ref() {
-                            let row = r.map_err(|e| StorageError::Execution(format!("{:?}", e)))?;
-                            partiql_tools::row_codec::serialize_row(
-                                &row,
-                                &row_shape,
-                                &mut scratch_buf,
-                            )
-                            .map_err(|e| StorageError::Codec(format!("{e}")))?;
-                            push_row(&scratch_buf)?;
-                        }
-                        Ok(())
-                    });
-                    match driver_result {
-                        Ok(n) => n,
-                        Err(e) => return Err(format!("Error: {}", e).into()),
+                    let mut writer = db.create_table(&key).map_err(|e| format!("Error: {}", e))?;
+                    // SAFETY-RELEVANT: QueryIterator::next uses unsafe lifetime
+                    // extension on the RegisterReader it yields. Aliasing across
+                    // iter.next() is UB. We consume `row` synchronously inside
+                    // serialize_row, drop it, then push the bytes.
+                    if let Some(ref bytes) = first_row_bytes {
+                        writer
+                            .push_row(bytes)
+                            .map_err(|e| format!("Error: {}", e))?;
                     }
+                    for r in iter.by_ref() {
+                        let row = r.map_err(|e| {
+                            format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
+                        })?;
+                        partiql_tools::row_codec::serialize_row(&row, &row_shape, &mut scratch_buf)
+                            .map_err(|e| {
+                                format!("Error: {}", StorageError::Codec(format!("{e}")))
+                            })?;
+                        writer
+                            .push_row(&scratch_buf)
+                            .map_err(|e| format!("Error: {}", e))?;
+                    }
+                    writer.commit().map_err(|e| format!("Error: {}", e))?
                 }
                 Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
             };

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -76,11 +76,6 @@ enum Commands {
 /// whole session and passes it as `Open`; `exec` passes `Lazy` so the database
 /// is opened only if a write statement actually requires it — a plain query via
 /// `exec` never opens or creates a file.
-///
-/// This is CLI dispatch plumbing, not a storage abstraction: it encodes the
-/// three valid call states (live handle / lazy path / no path) as two variants
-/// so an illegal "both a handle and a path" state is unrepresentable. It is
-/// unrelated to any future engine-agnostic storage trait.
 #[derive(Clone, Copy)]
 enum DbSource<'a> {
     /// An already-open handle (the REPL session database).
@@ -115,11 +110,9 @@ fn main() {
                 std::process::exit(1);
             });
 
-            // Open the database up front. A database that silently stops
-            // persisting is worse than one that refuses to start, so this
-            // hard-fails (unlike the REPL history file, which falls back to
-            // in-memory by design). The parent directory must already exist;
-            // the filesystem error bubbles up naturally if it does not.
+            // Open the database up front. Hard-fail rather than fall back (a
+            // silently-non-persisting db is worse than one that refuses to
+            // start). The parent directory must already exist.
             let db = match HeedDB::open(&db_path) {
                 Ok(db) => db,
                 Err(e) => {
@@ -320,14 +313,9 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
                     }
                 }
 
-                // Strip the trailing `;` terminator (preserving internal
-                // newlines) before handing the full multi-line text to the
-                // engine — shared with the `exec` subcommand for consistency.
                 let query = normalize_query(trimmed);
 
-                // A lone `;` (e.g. on its own line) leaves nothing to run once
-                // the terminator is stripped — skip it rather than handing an
-                // empty string to the parser.
+                // A lone `;` strips to empty — skip rather than parse "".
                 if query.is_empty() {
                     continue;
                 }
@@ -374,8 +362,8 @@ fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
 ///
 /// NOTE: `name` may contain arbitrary bytes from a quoted identifier. An
 /// interior NUL byte would otherwise panic heed's internal
-/// `CString::new(name).unwrap()`; `HeedDB::create_table_from_rows` guards
-/// against that up front and returns `StorageError::InvalidName` instead.
+/// `CString::new(name).unwrap()`; `HeedDB::create_table` guards against that
+/// up front and returns `StorageError::InvalidName` instead.
 fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
     match name {
         partiql_value::BindingsName::CaseInsensitive(s) => s.to_lowercase(),
@@ -470,22 +458,13 @@ fn execute_query(
         lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;
     let lower_time = lower_start.elapsed();
 
-    // DDL statements are planning-only for now: print the lowered plan and stop.
-    // (Compile/execute and storage are a later slice; the consumer would
-    // orchestrate writes around the inner query's execution.)
     let logical = match statement {
         LogicalStatement::Query(plan) => plan,
         LogicalStatement::CreateTableAs { table_name, query } => {
             let key = canonical_table_key(&table_name);
 
-            // Validate --db early but DO NOT open the env yet. Deferring the
-            // open until after compile + VM setup means a parse, compile, or
-            // ROW-0 schema-rejection exits without creating any .pqlite file
-            // on disk. A mid-stream rejection (row 50 hits a Bool, etc.)
-            // safely rolls back the wtxn — no catalog entry, no row bytes —
-            // but the env file on disk persists. That is the streaming-engine
-            // trade-off; protecting mid-stream would require buffering the
-            // whole result set, which defeats the per-row write model.
+            // Resolve --db before compile + VM setup so a missing --db on a
+            // CTAS path is a clean CLI error before any expensive work.
             let db_path: Option<&std::path::Path> = match db_source {
                 DbSource::Open(_) => None,
                 DbSource::Lazy(path) => Some(
@@ -502,85 +481,38 @@ fn execute_query(
             let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
                 .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
-            // Capture the result RowShape BEFORE vm.execute() — that call
-            // borrows the VM mutably for the iterator's lifetime, after which
-            // vm.shape() is unreachable inside the loop.
+            // Capture RowShape before vm.execute() borrows the VM mutably.
             let row_shape = vm.shape().row_shape().clone();
 
-            // One scratch buffer for the entire CTAS. 4 KiB matches LMDB's
-            // typical B+tree page size; larger OS pages (e.g. 16 KiB on Apple
-            // Silicon) just pay one growth realloc on the first wide row.
-            // `serialize_row` clears the buffer's bytes but keeps the heap
-            // allocation, and `push_row(&scratch_buf)` hands storage a borrow
-            // — zero allocations per row after warmup.
+            // 4 KiB scratch: matches LMDB's typical page size; reused per row.
             let mut scratch_buf: Vec<u8> = Vec::with_capacity(4096);
 
-            // Peek-then-open: encode row 0 before opening the env. A row-0
-            // schema rejection (Bool literal in a projection, etc.) exits
-            // without ever touching the filesystem. Row 0's encoded bytes
-            // are stashed in `first_row_bytes`; the driver closure writes
-            // them first, then resumes the normal loop for rows 1..N. A
-            // mid-stream rejection on row K (K >= 1) rolls back the wtxn
-            // — catalog stays clean, row bytes are discarded — but the
-            // .pqlite file itself remains on disk from the env-open above.
+            // Open the env up front. Mid-stream rejection rolls back the wtxn
+            // (no catalog entry, no row bytes), but the env file itself may
+            // remain on disk.
+            let lazily_opened;
+            let db: &HeedDB = match db_source {
+                DbSource::Open(db) => db,
+                DbSource::Lazy(_) => {
+                    let path = db_path.expect("Lazy implies a path");
+                    lazily_opened = HeedDB::open(path).map_err(|e| {
+                        format!(
+                            "Error: could not open database at {}: {}",
+                            path.display(),
+                            e
+                        )
+                    })?;
+                    &lazily_opened
+                }
+            };
+
             let n = match vm.execute() {
-                Ok(partiql_eval::ExecutionResult::Query(mut iter)) => {
-                    let first_row_bytes: Option<Vec<u8>> = match iter.next() {
-                        None => None,
-                        Some(r) => {
-                            // Route row-0 VM errors through the same
-                            // StorageError::Execution Display chain as the
-                            // mid-stream path, so both stderr lines read
-                            // "Error: execution error: {Debug}" — keeps
-                            // stderr-grepping scripts stable across paths.
-                            // SerializeError surfaces directly (its Display
-                            // already starts with "unsupported: "), so codec
-                            // rejections read "Error: unsupported: ..." —
-                            // matches PartiQL's single-level error style.
-                            let row = r.map_err(|e| {
-                                format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
-                            })?;
-                            partiql_tools::row_codec::serialize_row(
-                                &row,
-                                &row_shape,
-                                &mut scratch_buf,
-                            )
-                            .map_err(|e| format!("Error: {e}"))?;
-                            Some(scratch_buf.clone())
-                        }
-                    };
-
-                    // First-row encode passed (or zero rows). Now safe to open
-                    // the env: any later error rolls back via wtxn drop, but
-                    // the env file on disk would persist regardless. By only
-                    // opening here, a rejected CTAS leaves the FS untouched.
-                    let lazily_opened;
-                    let db: &HeedDB = match db_source {
-                        DbSource::Open(db) => db,
-                        DbSource::Lazy(_) => {
-                            let path = db_path.expect("Lazy implies a path");
-                            lazily_opened = HeedDB::open(path).map_err(|e| {
-                                format!(
-                                    "Error: could not open database at {}: {}",
-                                    path.display(),
-                                    e
-                                )
-                            })?;
-                            &lazily_opened
-                        }
-                    };
-
+                Ok(partiql_eval::ExecutionResult::Query(iter)) => {
                     let mut writer = db.create_table(&key).map_err(|e| format!("Error: {}", e))?;
-                    // SAFETY-RELEVANT: QueryIterator::next uses unsafe lifetime
-                    // extension on the RegisterReader it yields. Aliasing across
-                    // iter.next() is UB. We consume `row` synchronously inside
-                    // serialize_row, drop it, then push the bytes.
-                    if let Some(ref bytes) = first_row_bytes {
-                        writer
-                            .push_row(bytes)
-                            .map_err(|e| format!("Error: {}", e))?;
-                    }
-                    for r in iter.by_ref() {
+                    // SAFETY: QueryIterator::next uses unsafe lifetime extension
+                    // on its RegisterReader. Aliasing across iter.next() is UB.
+                    // Consume `row` synchronously, drop it, then push the bytes.
+                    for r in iter {
                         let row = r.map_err(|e| {
                             format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
                         })?;
@@ -599,8 +531,6 @@ fn execute_query(
             let exec_time = exec_start.elapsed();
 
             // stdout stays empty for a write; confirmation + timing go to stderr.
-            // The confirmation line carries the row count; the timing line is
-            // purely the per-phase breakdown so the count is not repeated.
             eprintln!(
                 "Created table {} ({} rows)",
                 format_table_name(&table_name),

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -528,14 +528,15 @@ fn execute_query(
                     let first_row_bytes: Option<Vec<u8>> = match iter.next() {
                         None => None,
                         Some(r) => {
-                            // Route the row-0 VM error through the same
-                            // StorageError::Execution Display chain that the
-                            // mid-stream path uses, so both stderr lines read
-                            // "Error: execution error: {Debug}". Without
-                            // this, row 0 would emit "Error: Execution error
-                            // on first row: ..." — same failure, different
-                            // wording, which makes scripts that grep stderr
-                            // brittle.
+                            // Route row-0 VM errors through the same
+                            // StorageError::Execution Display chain as the
+                            // mid-stream path, so both stderr lines read
+                            // "Error: execution error: {Debug}" — keeps
+                            // stderr-grepping scripts stable across paths.
+                            // SerializeError surfaces directly (its Display
+                            // already starts with "unsupported: "), so codec
+                            // rejections read "Error: unsupported: ..." —
+                            // matches PartiQL's single-level error style.
                             let row = r.map_err(|e| {
                                 format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
                             })?;
@@ -544,7 +545,7 @@ fn execute_query(
                                 &row_shape,
                                 &mut scratch_buf,
                             )
-                            .map_err(|e| format!("Error: execution error: {e}"))?;
+                            .map_err(|e| format!("Error: {e}"))?;
                             Some(scratch_buf.clone())
                         }
                     };
@@ -586,7 +587,7 @@ fn execute_query(
                                 &row_shape,
                                 &mut scratch_buf,
                             )
-                            .map_err(|e| StorageError::Execution(format!("{e}")))?;
+                            .map_err(|e| StorageError::Codec(format!("{e}")))?;
                             push_row(&scratch_buf)?;
                         }
                         Ok(())

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -435,7 +435,6 @@ fn execute_query(
 
     let catalog = create_table_fn_catalog();
 
-    // Phase 1: Parse
     let parse_start = Instant::now();
     let parsed = parse(&query).map_err(|e| format!("Parse error: {:?}", e))?;
     let parse_time = parse_start.elapsed();
@@ -444,7 +443,6 @@ fn execute_query(
         eprintln!("[AST] {:?}", parsed);
     }
 
-    // Phase 2: Lower (AST → Logical Statement)
     // pqlite runs exactly one statement per submission; reject anything else here,
     // since lowering operates on a single statement.
     let stmt = match parsed.statements.as_slice() {
@@ -530,7 +528,6 @@ fn execute_query(
             };
             let exec_time = exec_start.elapsed();
 
-            // stdout stays empty for a write; confirmation + timing go to stderr.
             eprintln!(
                 "Created table {} ({} rows)",
                 format_table_name(&table_name),
@@ -557,12 +554,10 @@ fn execute_query(
         }
     };
 
-    // Phase 3: Compile (Logical → CompiledPlan)
     let compile_start = Instant::now();
     let compiled = build_compiled(&logical, debug)?;
     let compile_time = compile_start.elapsed();
 
-    // Phase 4: Execute
     let exec_start = Instant::now();
     let exec_context = build_exec_context();
     let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -478,31 +478,21 @@ fn execute_query(
         LogicalStatement::CreateTableAs { table_name, query } => {
             let key = canonical_table_key(&table_name);
 
-            // Resolve the database. The REPL passes its already-open session
-            // handle; `exec` opens lazily from --db here, so a plain query via
-            // `exec` never opens or creates a file. `lazily_opened` owns the
-            // exec-path handle for the rest of this arm (deferred-init local so
-            // the borrow in the `Lazy` branch outlives the match).
-            let lazily_opened;
-            let db: &HeedDB = match db_source {
-                DbSource::Open(db) => db,
-                DbSource::Lazy(path) => {
-                    let path = path.ok_or(
-                        "Error: The `--db <PATH>` option is required for CREATE TABLE AS.",
-                    )?;
-                    lazily_opened = HeedDB::open(path).map_err(|e| {
-                        format!(
-                            "Error: could not open database at {}: {}",
-                            path.display(),
-                            e
-                        )
-                    })?;
-                    &lazily_opened
-                }
+            // Validate --db early but DO NOT open the env yet. Deferring the
+            // open until after compile + VM setup means a parse, compile, or
+            // ROW-0 schema-rejection exits without creating any .pqlite file
+            // on disk. A mid-stream rejection (row 50 hits a Bool, etc.)
+            // safely rolls back the wtxn — no catalog entry, no row bytes —
+            // but the env file on disk persists. That is the streaming-engine
+            // trade-off; protecting mid-stream would require buffering the
+            // whole result set, which defeats the per-row write model.
+            let db_path: Option<&std::path::Path> = match db_source {
+                DbSource::Open(_) => None,
+                DbSource::Lazy(path) => Some(
+                    path.ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?,
+                ),
             };
 
-            // Compile and execute the inner query exactly like a plain query,
-            // but stream the rows into storage instead of stdout.
             let compile_start = Instant::now();
             let compiled = build_compiled(&query, debug)?;
             let compile_time = compile_start.elapsed();
@@ -512,22 +502,97 @@ fn execute_query(
             let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
                 .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
+            // Capture the result RowShape BEFORE vm.execute() — that call
+            // borrows the VM mutably for the iterator's lifetime, after which
+            // vm.shape() is unreachable inside the loop.
+            let row_shape = vm.shape().row_shape().clone();
+
+            // One scratch buffer for the entire CTAS. 4 KiB matches LMDB's
+            // typical B+tree page size; larger OS pages (e.g. 16 KiB on Apple
+            // Silicon) just pay one growth realloc on the first wide row.
+            // `serialize_row` clears the buffer's bytes but keeps the heap
+            // allocation, and `push_row(&scratch_buf)` hands storage a borrow
+            // — zero allocations per row after warmup.
+            let mut scratch_buf: Vec<u8> = Vec::with_capacity(4096);
+
+            // Peek-then-open: encode row 0 before opening the env. A row-0
+            // schema rejection (Bool literal in a projection, etc.) exits
+            // without ever touching the filesystem. Row 0's encoded bytes
+            // are stashed in `first_row_bytes`; the driver closure writes
+            // them first, then resumes the normal loop for rows 1..N. A
+            // mid-stream rejection on row K (K >= 1) rolls back the wtxn
+            // — catalog stays clean, row bytes are discarded — but the
+            // .pqlite file itself remains on disk from the env-open above.
             let n = match vm.execute() {
-                Ok(partiql_eval::ExecutionResult::Query(iter)) => {
-                    // Map each VM row to Result<(), StorageError>: PR 2 discards
-                    // the (not-yet-serialized) row data and keeps only
-                    // success/failure. The VM's error type is stringified here
-                    // so storage stays independent of partiql-eval.
-                    let rows = iter.map(|r| {
-                        r.map(|_row| ())
-                            .map_err(|e| StorageError::Execution(format!("{:?}", e)))
+                Ok(partiql_eval::ExecutionResult::Query(mut iter)) => {
+                    let first_row_bytes: Option<Vec<u8>> = match iter.next() {
+                        None => None,
+                        Some(r) => {
+                            // Route the row-0 VM error through the same
+                            // StorageError::Execution Display chain that the
+                            // mid-stream path uses, so both stderr lines read
+                            // "Error: execution error: {Debug}". Without
+                            // this, row 0 would emit "Error: Execution error
+                            // on first row: ..." — same failure, different
+                            // wording, which makes scripts that grep stderr
+                            // brittle.
+                            let row = r.map_err(|e| {
+                                format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
+                            })?;
+                            partiql_tools::row_codec::serialize_row(
+                                &row,
+                                &row_shape,
+                                &mut scratch_buf,
+                            )
+                            .map_err(|e| format!("Error: execution error: {e}"))?;
+                            Some(scratch_buf.clone())
+                        }
+                    };
+
+                    // First-row encode passed (or zero rows). Now safe to open
+                    // the env: any later error rolls back via wtxn drop, but
+                    // the env file on disk would persist regardless. By only
+                    // opening here, a rejected CTAS leaves the FS untouched.
+                    let lazily_opened;
+                    let db: &HeedDB = match db_source {
+                        DbSource::Open(db) => db,
+                        DbSource::Lazy(_) => {
+                            let path = db_path.expect("Lazy implies a path");
+                            lazily_opened = HeedDB::open(path).map_err(|e| {
+                                format!(
+                                    "Error: could not open database at {}: {}",
+                                    path.display(),
+                                    e
+                                )
+                            })?;
+                            &lazily_opened
+                        }
+                    };
+
+                    let driver_result = db.create_table_from_rows(&key, |push_row| {
+                        // SAFETY-RELEVANT: QueryIterator::next uses unsafe
+                        // lifetime extension on the RegisterReader it yields
+                        // (partiql-eval/src/engine/plan.rs:892-895). Aliasing
+                        // a RegisterReader across iter.next() is UB. We
+                        // consume `row` synchronously inside serialize_row,
+                        // then drop it; push_row sees only the encoded bytes.
+                        if let Some(ref bytes) = first_row_bytes {
+                            push_row(bytes)?;
+                        }
+                        for r in iter.by_ref() {
+                            let row = r.map_err(|e| StorageError::Execution(format!("{:?}", e)))?;
+                            partiql_tools::row_codec::serialize_row(
+                                &row,
+                                &row_shape,
+                                &mut scratch_buf,
+                            )
+                            .map_err(|e| StorageError::Execution(format!("{e}")))?;
+                            push_row(&scratch_buf)?;
+                        }
+                        Ok(())
                     });
-                    match db.create_table_from_rows(&key, rows) {
+                    match driver_result {
                         Ok(n) => n,
-                        // Every StorageError carries its own user-facing message
-                        // via Display (e.g. "table already exists: foo"), so route
-                        // them all through one uniform prefix rather than
-                        // special-casing any single variant.
                         Err(e) => return Err(format!("Error: {}", e).into()),
                     }
                 }

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,3 +1,4 @@
 // Public modules for use in benchmarks and binaries
 pub mod common;
+pub mod row_codec;
 pub mod storage;

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,7 +1,3 @@
-// Public modules for use in benchmarks and binaries.
 pub mod common;
-// `pub` (not `pub(crate)`) because the `pqlite` binary in `src/bin/` is a
-// separate crate from this library and imports `serialize_row` + the tag/
-// version constants directly. Integration tests in `tests/` do the same.
 pub mod row_codec;
 pub mod storage;

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,4 +1,7 @@
-// Public modules for use in benchmarks and binaries
+// Public modules for use in benchmarks and binaries.
 pub mod common;
+// `pub` (not `pub(crate)`) because the `pqlite` binary in `src/bin/` is a
+// separate crate from this library and imports `serialize_row` + the tag/
+// version constants directly. Integration tests in `tests/` do the same.
 pub mod row_codec;
 pub mod storage;

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -146,18 +146,17 @@ fn write_struct_row(
                 )));
             }
         };
-        let view = row
-            .get_value_view(slot)
-            .expect("register slot from shape must exist in the row");
+        let view = row.get_value_view(slot).expect("register slot from shape");
         validate_value_type(view.get_type(), Some(name))?;
     }
 
     // Pre-flight passed: write the row.
     buf.push(FORMAT_VERSION);
     buf.push(TAG_STRUCT);
-    let field_count: u32 = fields.len().try_into().expect(
-        "row has more than u32::MAX columns — wire format requires field_count fits in u32",
-    );
+    let field_count: u32 = fields
+        .len()
+        .try_into()
+        .expect("field_count exceeds u32::MAX");
     buf.extend_from_slice(&field_count.to_le_bytes());
     for field in fields.iter() {
         let name = match &field.name {
@@ -172,7 +171,7 @@ fn write_struct_row(
         let name_len: u32 = name_bytes
             .len()
             .try_into()
-            .expect("column name longer than u32::MAX bytes");
+            .expect("name_len exceeds u32::MAX");
         buf.extend_from_slice(&name_len.to_le_bytes());
         buf.extend_from_slice(name_bytes);
         write_tagged_value(row, slot, buf);
@@ -235,27 +234,15 @@ fn write_tagged_value(row: &RegisterReader<'_>, slot: usize, buf: &mut Vec<u8>) 
         }
         ValueType::Integer => {
             buf.push(TAG_INTEGER);
-            buf.extend_from_slice(
-                &view
-                    .get_i64()
-                    .expect("ValueType::Integer must yield i64 — VM invariant")
-                    .to_le_bytes(),
-            );
+            buf.extend_from_slice(&view.get_i64().expect("i64 view").to_le_bytes());
         }
         ValueType::Float => {
             buf.push(TAG_FLOAT);
-            buf.extend_from_slice(
-                &view
-                    .get_f64()
-                    .expect("ValueType::Float must yield f64 — VM invariant")
-                    .to_le_bytes(),
-            );
+            buf.extend_from_slice(&view.get_f64().expect("f64 view").to_le_bytes());
         }
         ValueType::Decimal => {
             buf.push(TAG_DECIMAL);
-            let d = view
-                .get_decimal()
-                .expect("ValueType::Decimal must yield Decimal — VM invariant");
+            let d = view.get_decimal().expect("decimal view");
             // rust_decimal: scale() is u32 in 0..=28; the i32 cast is lossless.
             let scale_i32: i32 = d.scale() as i32;
             buf.extend_from_slice(&scale_i32.to_le_bytes());
@@ -263,14 +250,9 @@ fn write_tagged_value(row: &RegisterReader<'_>, slot: usize, buf: &mut Vec<u8>) 
         }
         ValueType::String => {
             buf.push(TAG_STRING);
-            let s = view
-                .get_str()
-                .expect("ValueType::String must yield &str — VM invariant");
+            let s = view.get_str().expect("string view");
             let sb = s.as_bytes();
-            let str_len: u32 = sb
-                .len()
-                .try_into()
-                .expect("string column value longer than u32::MAX bytes");
+            let str_len: u32 = sb.len().try_into().expect("str_len exceeds u32::MAX");
             buf.extend_from_slice(&str_len.to_le_bytes());
             buf.extend_from_slice(sb);
         }

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -22,14 +22,14 @@ use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
 /// `struct_body = field_count + (name_len + name + tagged_value){N}`.
 pub const FORMAT_VERSION: u8 = 0x01;
 
-/// Maximum columns per row. Real CTAS rows top out at hundreds; 1024 is
-/// ample headroom while catching corruption (a flipped byte producing a
-/// huge u32 field_count) before `Vec::with_capacity` allocates gigabytes.
+/// Sanity cap on `field_count` consumed by the reader. Real CTAS rows top
+/// out at hundreds; 1024 is ample headroom while catching a flipped byte
+/// producing a huge u32 before `Vec::with_capacity` allocates gigabytes.
 pub const MAX_FIELDS_PER_ROW: u32 = 1024;
 
-/// Maximum byte length of a column name. PartiQL identifiers are typically
-/// <100 bytes; 1 MiB catches corruption while staying well above any
-/// real-world name. The cap applies to UTF-8 byte length, not char count.
+/// Sanity cap on `name_len` consumed by the reader. PartiQL identifiers are
+/// typically <100 bytes; 1 MiB catches corruption while staying well above
+/// any real-world name. UTF-8 byte length, not char count.
 pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 
 // Tag constants. `pub` so the reader and encoder share one source of truth.
@@ -48,9 +48,9 @@ pub const TAG_NULL: u8 = 0x06;
 /// is a separate crate from this library.
 #[derive(Debug)]
 pub enum SerializeError {
-    /// An unsupported type or shape: containers, dynamic column names,
-    /// MISSING, BOOL, BYTES, nested struct values, empty column names. The
-    /// string identifies the offending column or top-level value.
+    /// An unsupported type or shape encountered mid-stream: containers,
+    /// dynamic column names, MISSING, BOOL, BYTES, nested struct values.
+    /// The string identifies the offending column or top-level value.
     Unsupported(String),
 }
 
@@ -87,13 +87,14 @@ pub fn serialize_row(
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
     buf.clear();
+    buf.push(FORMAT_VERSION);
     match row_shape {
-        RowShape::Struct(fields) => write_struct_row(row, fields, buf),
-        RowShape::Register(slot, _) => write_scalar_row(row, *slot, buf),
+        RowShape::Struct(fields) => write_struct(row, fields, buf),
+        RowShape::Register(slot, _) => write_value(row, *slot, None, buf),
     }
 }
 
-fn write_struct_row(
+fn write_struct(
     row: &RegisterReader<'_>,
     fields: &[partiql_eval::value::FieldShape],
     buf: &mut Vec<u8>,
@@ -105,15 +106,13 @@ fn write_struct_row(
             MAX_FIELDS_PER_ROW
         )));
     }
-    // Pre-flight: validate every column before pushing any payload bytes.
+    buf.push(TAG_STRUCT);
+    // Safe: the cap above bounds fields.len() to MAX_FIELDS_PER_ROW (u32).
+    let field_count: u32 = fields.len() as u32;
+    buf.extend_from_slice(&field_count.to_le_bytes());
     for (col, field) in fields.iter().enumerate() {
         let name = match &field.name {
-            FieldName::Static(s) if !s.is_empty() => s.as_str(),
-            FieldName::Static(_) => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column {col}: empty column name not supported"
-                )));
-            }
+            FieldName::Static(s) => s.as_str(),
             FieldName::Register(_) => {
                 return Err(SerializeError::Unsupported(format!(
                     "column {col}: dynamic column names are not supported yet"
@@ -127,107 +126,31 @@ fn write_struct_row(
                 MAX_NAME_LEN_BYTES
             )));
         }
-        // Duplicate-name check: bounded by MAX_FIELDS_PER_ROW so the O(K²)
-        // is acceptable.
-        for prior in &fields[..col] {
-            if let FieldName::Static(prior_name) = &prior.name {
-                if prior_name == name {
-                    return Err(SerializeError::Unsupported(format!(
-                        "column {col}: duplicate column name '{name}' (already used)"
-                    )));
-                }
-            }
-        }
-        let slot = match &field.value {
-            RowShape::Register(idx, _) => *idx,
+        // Safe: the cap above bounds name.len() to MAX_NAME_LEN_BYTES (u32).
+        let name_len: u32 = name.len() as u32;
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(name.as_bytes());
+        match &field.value {
+            RowShape::Register(idx, _) => write_value(row, *idx, Some(name), buf)?,
             RowShape::Struct(_) => {
                 return Err(SerializeError::Unsupported(format!(
                     "column '{name}': nested struct values are not supported yet"
                 )));
             }
-        };
-        let view = row.get_value_view(slot).expect("register slot from shape");
-        validate_value_type(view.get_type(), Some(name))?;
-    }
-
-    // Pre-flight passed: write the row.
-    buf.push(FORMAT_VERSION);
-    buf.push(TAG_STRUCT);
-    let field_count: u32 = fields
-        .len()
-        .try_into()
-        .expect("field_count exceeds u32::MAX");
-    buf.extend_from_slice(&field_count.to_le_bytes());
-    for field in fields.iter() {
-        let name = match &field.name {
-            FieldName::Static(s) => s.as_str(),
-            FieldName::Register(_) => unreachable!("pre-flight rejects FieldName::Register"),
-        };
-        let slot = match &field.value {
-            RowShape::Register(idx, _) => *idx,
-            RowShape::Struct(_) => unreachable!("pre-flight rejects nested-struct field values"),
-        };
-        let name_bytes = name.as_bytes();
-        let name_len: u32 = name_bytes
-            .len()
-            .try_into()
-            .expect("name_len exceeds u32::MAX");
-        buf.extend_from_slice(&name_len.to_le_bytes());
-        buf.extend_from_slice(name_bytes);
-        write_tagged_value(row, slot, buf);
+        }
     }
     Ok(())
 }
 
-fn write_scalar_row(
+/// Write `tag + payload` for the value at register `slot`. Unsupported types
+/// return `Err`; the caller propagates and the in-flight wtxn rolls back.
+fn write_value(
     row: &RegisterReader<'_>,
     slot: usize,
+    col_name: Option<&str>,
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
-    let view = row
-        .get_value_view(slot)
-        .expect("register slot from shape must exist in the row");
-    validate_value_type(view.get_type(), None)?;
-    buf.push(FORMAT_VERSION);
-    write_tagged_value(row, slot, buf);
-    Ok(())
-}
-
-/// Reject unsupported types. `col_name` is `Some(name)` for a struct-field
-/// walk and `None` for a top-level scalar row; the error wording branches
-/// accordingly.
-fn validate_value_type(ty: ValueType, col_name: Option<&str>) -> Result<(), SerializeError> {
-    let prefix = match col_name {
-        Some(name) => format!("column '{name}'"),
-        None => "top-level value".to_string(),
-    };
-    match ty {
-        ValueType::Null
-        | ValueType::Integer
-        | ValueType::Float
-        | ValueType::Decimal
-        | ValueType::String => Ok(()),
-        ValueType::Bool => Err(SerializeError::Unsupported(format!(
-            "{prefix}: Bool is not yet supported"
-        ))),
-        ValueType::Bytes => Err(SerializeError::Unsupported(format!(
-            "{prefix}: Bytes is not yet supported"
-        ))),
-        ValueType::Missing => Err(SerializeError::Unsupported(format!(
-            "{prefix}: MISSING is not yet supported"
-        ))),
-        ValueType::Tuple | ValueType::List | ValueType::Bag => Err(SerializeError::Unsupported(
-            format!("{prefix}: container type ({ty:?}) is not yet supported"),
-        )),
-    }
-}
-
-/// Write `tag + payload` for the value at register `slot`. The caller is
-/// responsible for having pre-flight-validated the type.
-fn write_tagged_value(row: &RegisterReader<'_>, slot: usize, buf: &mut Vec<u8>) {
-    let view = row
-        .get_value_view(slot)
-        .expect("register slot from shape must exist in the row");
+    let view = row.get_value_view(slot).expect("register slot from shape");
     match view.get_type() {
         ValueType::Null => {
             buf.push(TAG_NULL);
@@ -256,11 +179,20 @@ fn write_tagged_value(row: &RegisterReader<'_>, slot: usize, buf: &mut Vec<u8>) 
             buf.extend_from_slice(&str_len.to_le_bytes());
             buf.extend_from_slice(sb);
         }
-        ValueType::Bool
+        ty @ (ValueType::Bool
         | ValueType::Bytes
         | ValueType::Missing
         | ValueType::Tuple
         | ValueType::List
-        | ValueType::Bag => unreachable!("pre-flight rejects all reserved/container types"),
+        | ValueType::Bag) => {
+            let prefix = match col_name {
+                Some(name) => format!("column '{name}'"),
+                None => "top-level value".to_string(),
+            };
+            return Err(SerializeError::Unsupported(format!(
+                "{prefix}: {ty:?} is not yet supported"
+            )));
+        }
     }
+    Ok(())
 }

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -44,8 +44,8 @@ pub const TAG_NULL: u8 = 0x06;
 #[derive(Debug)]
 pub enum SerializeError {
     /// An unsupported type or shape encountered mid-stream: containers,
-    /// dynamic column names, MISSING, BOOL, BYTES. The string identifies
-    /// the offending column or top-level value.
+    /// dynamic field names, MISSING, BOOL, BYTES. The string identifies
+    /// the offending tuple field or top-level value.
     Unsupported(String),
 }
 

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -1,0 +1,302 @@
+//! Custom tagged-union row serialization for the CTAS write path.
+//!
+//! Operates on the VM's [`RegisterReader`] + [`RowShape`] surface (not on
+//! `partiql_value::Value`). The CTAS arm in `pqlite.rs` calls
+//! [`serialize_row`] inside the driver closure passed to
+//! `HeedDB::create_table_from_rows`, then hands the resulting bytes to
+//! storage via `push_row(&buf)` — zero per-row allocations after warmup.
+//!
+//! Wire format:
+//!   ROW = ver(u8=0x01) struct_tag(u8=0x03) struct_body
+//!   struct_body = field_count(u32 LE)
+//!                 ( name_len(u32 LE) name_utf8 tagged_value ){field_count}
+//!   tagged_value = tag(u8) payload
+//!
+//! VALUE bytes are little-endian. The row-id KEY in LMDB stays big-endian:
+//! storage encodes it as `row_id.to_be_bytes()` and stores it under a
+//! `heed::types::Bytes` key codec, so the B+tree's lexicographic key order
+//! matches numeric order with zero per-row key allocations.
+
+use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
+
+/// Format-version byte. PR 3 = 0x01. The byte gates the ENTIRE struct_body
+/// grammar, not just per-tag interpretation. Under 0x01, struct_body is
+/// `field_count + (name_len + name + tagged_value){N}`. A future PR that
+/// adds a schema registry will bump to 0x02 and drop per-row field names;
+/// readers refuse unknown versions.
+pub const FORMAT_VERSION: u8 = 0x01;
+
+/// Maximum columns per row. Real CTAS rows top out at hundreds; 1024 is
+/// ample headroom while catching corruption (a flipped byte producing a
+/// huge u32 field_count) before `Vec::with_capacity` allocates gigabytes.
+pub const MAX_FIELDS_PER_ROW: u32 = 1024;
+
+/// Maximum byte length of a column name. PartiQL identifiers are typically
+/// <100 bytes; 1 MiB catches corruption while staying well above any
+/// real-world name. The cap applies to UTF-8 byte length, not char count.
+pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
+
+// Tag constants. `pub` so PR 4's reader imports the same source of truth
+// as the encoder — see the LE/BE invariant in the function docstring; the
+// same drift risk applies to tag-byte numerals.
+pub const TAG_INTEGER: u8 = 0x00;
+pub const TAG_DECIMAL: u8 = 0x01;
+pub const TAG_FLOAT: u8 = 0x02;
+pub const TAG_STRUCT: u8 = 0x03;
+// 0x04 = TAG_BAG — reserved; PR 3 rejects, encoder write path lands later.
+pub const TAG_STRING: u8 = 0x05;
+pub const TAG_NULL: u8 = 0x06;
+// 0x07 = TAG_MISSING — reserved; PR 3 rejects.
+// 0x08 = TAG_BOOL    — reserved; PR 3 rejects.
+// 0x09 = TAG_BYTES   — reserved; PR 3 rejects.
+
+/// Errors raised by [`serialize_row`].
+///
+/// One variant by design: PR 3 lumps "type not supported yet" and "shape not
+/// supported yet" under `Unsupported(String)` because every consumer flattens
+/// them through `Display` at the CTAS-arm boundary. Richer discrimination
+/// lands when a non-pqlite consumer needs it. `storage.rs` never sees this
+/// type.
+///
+/// `pub` (not `pub(crate)`) because the `pqlite` binary in `src/bin/` is a
+/// separate crate from the library; same for [`serialize_row`] and the
+/// `row_codec` module declaration in `lib.rs`.
+#[derive(Debug)]
+pub enum SerializeError {
+    /// A type or shape PR 3 doesn't implement (containers, dynamic column
+    /// names, MISSING, BOOL, BYTES, nested struct values, empty column
+    /// names, bare-scalar rows). The string names the offending column.
+    Unsupported(String),
+}
+
+impl std::fmt::Display for SerializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SerializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SerializeError {}
+
+/// Serialize one VM row into `buf` as a tagged-union byte sequence.
+///
+/// `buf` is cleared on entry. On success, `buf` contains:
+///   * `FORMAT_VERSION` (1 byte)
+///   * `TAG_STRUCT` (1 byte)
+///   * struct body: u32 LE field_count, then per field
+///     (u32 LE name_len + UTF-8 name + tag byte + value payload)
+///
+/// All integer fields are little-endian. The row-id key in LMDB stays
+/// big-endian: storage writes it as `row_id.to_be_bytes()` under a
+/// `heed::types::Bytes` key codec. Only VALUE bytes are LE.
+///
+/// # Rejection contract
+///
+/// Walks the row shape and peeks `view.get_type()` for every column BEFORE
+/// pushing any bytes. Returns `Err(Unsupported)` immediately if any column
+/// trips the reject set (Tuple, List, Bag, Missing, Bool, Bytes) or if the
+/// shape is structurally unsupported (top-level scalar, dynamic field name,
+/// nested struct value, empty field name). `buf` is left empty (already
+/// cleared) on any rejection.
+///
+/// # Endianness invariant
+///
+/// Every multi-byte field (`field_count`, `name_len`, `i64`, `f64`, `i32`
+/// scale, `i128` mantissa, `u32` string length) is written via
+/// `to_le_bytes()`. The corresponding test parser in
+/// `partiql-tools/tests/pqlite_cli.rs::parse_row` uses `from_le_bytes()` to
+/// match. If you add a new tag, write it `to_le_bytes()` here AND read it
+/// `from_le_bytes()` there — an LE/BE asymmetry compiles cleanly and
+/// silently corrupts every persisted row.
+pub fn serialize_row(
+    row: &RegisterReader<'_>,
+    row_shape: &RowShape,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    buf.clear();
+
+    // PR 3 supports exactly RowShape::Struct at the top of a row. A bare
+    // scalar at the top has no column name and is rejected with an
+    // actionable message; the user can wrap the projection (`AS <name>`).
+    let fields = match row_shape {
+        RowShape::Struct(fs) => fs,
+        RowShape::Register(_, _) => {
+            return Err(SerializeError::Unsupported(
+                "CTAS source must produce a struct; got a bare scalar (add an AS alias)".into(),
+            ));
+        }
+    };
+
+    // Row-shape cap: catches a corrupt/oversize column count before the
+    // per-field walk allocates anything proportional to the count.
+    if fields.len() > MAX_FIELDS_PER_ROW as usize {
+        return Err(SerializeError::Unsupported(format!(
+            "row has {} columns, exceeds MAX_FIELDS_PER_ROW ({})",
+            fields.len(),
+            MAX_FIELDS_PER_ROW
+        )));
+    }
+
+    // ── Pre-flight: validate the whole row before writing any bytes ─────────
+    for (col, field) in fields.iter().enumerate() {
+        let name = match &field.name {
+            FieldName::Static(s) if !s.is_empty() => s.as_str(),
+            FieldName::Static(_) => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column {col}: empty column name not supported"
+                )));
+            }
+            FieldName::Register(_) => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column {col}: dynamic name (FieldName::Register) not supported in PR 3"
+                )));
+            }
+        };
+        if name.len() > MAX_NAME_LEN_BYTES as usize {
+            return Err(SerializeError::Unsupported(format!(
+                "column {col}: name length {} bytes exceeds MAX_NAME_LEN_BYTES ({})",
+                name.len(),
+                MAX_NAME_LEN_BYTES
+            )));
+        }
+        // Duplicate-name check: PR 4's reader and PR 5's schema registry
+        // both need column names to be a unique key. Quadratic in column
+        // count, but the count is bounded by MAX_FIELDS_PER_ROW above.
+        for prior in &fields[..col] {
+            if let FieldName::Static(prior_name) = &prior.name {
+                if prior_name == name {
+                    return Err(SerializeError::Unsupported(format!(
+                        "column {col}: duplicate column name '{name}' (already used)"
+                    )));
+                }
+            }
+        }
+        let slot = match &field.value {
+            RowShape::Register(idx, _) => *idx,
+            RowShape::Struct(_) => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column '{name}': nested struct values not supported in PR 3"
+                )));
+            }
+        };
+        // The slot index was emitted by the same compiler pass that built
+        // this register file; a None here is a planner/VM invariant
+        // violation, not a recoverable runtime condition.
+        let view = row
+            .get_value_view(slot)
+            .expect("register slot from shape must exist in the row");
+        match view.get_type() {
+            ValueType::Null
+            | ValueType::Integer
+            | ValueType::Float
+            | ValueType::Decimal
+            | ValueType::String => {}
+            ValueType::Bool => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column '{name}': Bool — tag reserved, write path lands in a later PR"
+                )));
+            }
+            ValueType::Bytes => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column '{name}': Bytes — tag reserved, write path lands in a later PR"
+                )));
+            }
+            ValueType::Missing => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column '{name}': MISSING wire encoding deferred to the deserializer PR"
+                )));
+            }
+            ValueType::Tuple | ValueType::List | ValueType::Bag => {
+                return Err(SerializeError::Unsupported(format!(
+                    "column '{name}': container types ({:?}) land in PR 5",
+                    view.get_type()
+                )));
+            }
+        }
+    }
+
+    // ── Pre-flight passed: write the row ────────────────────────────────────
+    buf.push(FORMAT_VERSION);
+    buf.push(TAG_STRUCT);
+    // Lengths and counts use `try_into().expect(...)` rather than `as u32`
+    // throughout serialize_row: silent truncation on >u32::MAX inputs would
+    // corrupt the row format (the reader would parse the truncated length
+    // and read garbage thereafter). Panic with a pointed message instead;
+    // this layer has no recovery anyway — the row's already materialized in
+    // VM registers.
+    let field_count: u32 = fields.len().try_into().expect(
+        "row has more than u32::MAX columns — wire format requires field_count fits in u32",
+    );
+    buf.extend_from_slice(&field_count.to_le_bytes());
+
+    for field in fields.iter() {
+        // SAFETY of unwrap: pre-flight validated FieldName::Static(non-empty)
+        // and RowShape::Register for every field.
+        let name = match &field.name {
+            FieldName::Static(s) => s.as_str(),
+            FieldName::Register(_) => unreachable!("pre-flight rejects FieldName::Register"),
+        };
+        let slot = match &field.value {
+            RowShape::Register(idx, _) => *idx,
+            RowShape::Struct(_) => unreachable!("pre-flight rejects nested-struct field values"),
+        };
+
+        // Write the field name: u32 LE length + raw UTF-8 (no terminator).
+        let name_bytes = name.as_bytes();
+        let name_len: u32 = name_bytes
+            .len()
+            .try_into()
+            .expect("column name longer than u32::MAX bytes");
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(name_bytes);
+
+        let view = row
+            .get_value_view(slot)
+            .expect("register slot from shape must exist in the row");
+        match view.get_type() {
+            ValueType::Null => {
+                buf.push(TAG_NULL);
+            }
+            ValueType::Integer => {
+                buf.push(TAG_INTEGER);
+                buf.extend_from_slice(&view.get_i64().unwrap().to_le_bytes());
+            }
+            ValueType::Float => {
+                buf.push(TAG_FLOAT);
+                buf.extend_from_slice(&view.get_f64().unwrap().to_le_bytes());
+            }
+            ValueType::Decimal => {
+                buf.push(TAG_DECIMAL);
+                let d = view.get_decimal().unwrap();
+                // rust_decimal: scale() -> u32 with documented range 0..=28
+                // across all 1.x; mantissa() -> i128 (widened from native
+                // 96-bit; upper 32 bits sign-extended). Wire format per the
+                // spec: 4-byte i32 LE scale + 16-byte i128 LE mantissa.
+                // The `as i32` cast is provably safe (scale ≤ 28 fits in i32).
+                let scale_i32: i32 = d.scale() as i32;
+                buf.extend_from_slice(&scale_i32.to_le_bytes());
+                buf.extend_from_slice(&d.mantissa().to_le_bytes());
+            }
+            ValueType::String => {
+                buf.push(TAG_STRING);
+                let s = view.get_str().unwrap();
+                let sb = s.as_bytes();
+                let str_len: u32 = sb
+                    .len()
+                    .try_into()
+                    .expect("string column value longer than u32::MAX bytes — wire format requires length fits in u32");
+                buf.extend_from_slice(&str_len.to_le_bytes());
+                buf.extend_from_slice(sb);
+            }
+            ValueType::Bool
+            | ValueType::Bytes
+            | ValueType::Missing
+            | ValueType::Tuple
+            | ValueType::List
+            | ValueType::Bag => unreachable!("pre-flight rejects all reserved/container types"),
+        }
+    }
+
+    Ok(())
+}

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -6,9 +6,9 @@
 //! warmup.
 //!
 //! Wire format:
-//!   ROW   = ver(u8=0x01) tagged_value
+//!   ROW          = tagged_value
 //!   tagged_value = tag(u8) payload
-//!   payload(TAG_STRUCT) = field_count(u32 LE) (name_len(u32 LE) name_utf8 tagged_value){N}
+//!   payload(TAG_TUPLE) = field_count(u32 LE) (name_len(u32 LE) name_utf8 tagged_value){N}
 //!
 //! All multi-byte VALUE bytes are little-endian. Row-id KEYS in LMDB stay
 //! big-endian: storage encodes them as `row_id.to_be_bytes()` under a
@@ -16,11 +16,6 @@
 //! matches numeric order with zero per-row key allocations.
 
 use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
-
-/// Format-version byte gating the entire wire grammar (not just per-tag
-/// interpretation). Readers must refuse unknown versions. Currently 0x01:
-/// `struct_body = field_count + (name_len + name + tagged_value){N}`.
-pub const FORMAT_VERSION: u8 = 0x01;
 
 /// Sanity cap on `field_count` consumed by the reader. Real CTAS rows top
 /// out at hundreds; 1024 is ample headroom while catching a flipped byte
@@ -36,7 +31,7 @@ pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 pub const TAG_INTEGER: u8 = 0x00;
 pub const TAG_DECIMAL: u8 = 0x01;
 pub const TAG_FLOAT: u8 = 0x02;
-pub const TAG_STRUCT: u8 = 0x03;
+pub const TAG_TUPLE: u8 = 0x03;
 // 0x04 = TAG_BAG     — reserved; rejected.
 pub const TAG_STRING: u8 = 0x05;
 pub const TAG_NULL: u8 = 0x06;
@@ -49,8 +44,8 @@ pub const TAG_NULL: u8 = 0x06;
 #[derive(Debug)]
 pub enum SerializeError {
     /// An unsupported type or shape encountered mid-stream: containers,
-    /// dynamic column names, MISSING, BOOL, BYTES, nested struct values.
-    /// The string identifies the offending column or top-level value.
+    /// dynamic column names, MISSING, BOOL, BYTES. The string identifies
+    /// the offending column or top-level value.
     Unsupported(String),
 }
 
@@ -66,10 +61,10 @@ impl std::error::Error for SerializeError {}
 
 /// Serialize one VM row into `buf` as a tagged-union byte sequence.
 ///
-/// `buf` is cleared on entry. On success, `buf` contains:
-///   * `FORMAT_VERSION` (1 byte)
-///   * top-level tag (1 byte: TAG_STRUCT for struct rows, or a scalar tag)
-///   * payload for that tag (struct_body for TAG_STRUCT, value bytes for scalars)
+/// `buf` is cleared on entry. On success, `buf` contains a single
+/// `tagged_value`: one tag byte followed by its payload. A top-level tuple
+/// is TAG_TUPLE + struct body; a top-level scalar is its scalar tag +
+/// value bytes.
 ///
 /// All integer fields are little-endian. The row-id key in LMDB stays
 /// big-endian under `heed::types::Bytes`. Only VALUE bytes are LE.
@@ -87,26 +82,25 @@ pub fn serialize_row(
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
     buf.clear();
-    buf.push(FORMAT_VERSION);
     match row_shape {
-        RowShape::Struct(fields) => write_struct(row, fields, buf),
+        RowShape::Struct(fields) => write_tuple(row, fields, buf),
         RowShape::Register(slot, _) => write_value(row, *slot, None, buf),
     }
 }
 
-fn write_struct(
+fn write_tuple(
     row: &RegisterReader<'_>,
     fields: &[partiql_eval::value::FieldShape],
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
     if fields.len() > MAX_FIELDS_PER_ROW as usize {
         return Err(SerializeError::Unsupported(format!(
-            "row has {} columns, exceeds MAX_FIELDS_PER_ROW ({})",
+            "tuple has {} fields, exceeds MAX_FIELDS_PER_ROW ({})",
             fields.len(),
             MAX_FIELDS_PER_ROW
         )));
     }
-    buf.push(TAG_STRUCT);
+    buf.push(TAG_TUPLE);
     // Safe: the cap above bounds fields.len() to MAX_FIELDS_PER_ROW (u32).
     let field_count: u32 = fields.len() as u32;
     buf.extend_from_slice(&field_count.to_le_bytes());
@@ -115,13 +109,13 @@ fn write_struct(
             FieldName::Static(s) => s.as_str(),
             FieldName::Register(_) => {
                 return Err(SerializeError::Unsupported(format!(
-                    "column {col}: dynamic column names are not supported yet"
+                    "field {col}: dynamic field names are not supported yet"
                 )));
             }
         };
         if name.len() > MAX_NAME_LEN_BYTES as usize {
             return Err(SerializeError::Unsupported(format!(
-                "column {col}: name length {} bytes exceeds MAX_NAME_LEN_BYTES ({})",
+                "field {col}: name length {} bytes exceeds MAX_NAME_LEN_BYTES ({})",
                 name.len(),
                 MAX_NAME_LEN_BYTES
             )));
@@ -132,11 +126,7 @@ fn write_struct(
         buf.extend_from_slice(name.as_bytes());
         match &field.value {
             RowShape::Register(idx, _) => write_value(row, *idx, Some(name), buf)?,
-            RowShape::Struct(_) => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': nested struct values are not supported yet"
-                )));
-            }
+            RowShape::Struct(nested_fields) => write_tuple(row, nested_fields, buf)?,
         }
     }
     Ok(())
@@ -147,7 +137,7 @@ fn write_struct(
 fn write_value(
     row: &RegisterReader<'_>,
     slot: usize,
-    col_name: Option<&str>,
+    field_name: Option<&str>,
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
     let view = row.get_value_view(slot).expect("register slot from shape");
@@ -185,8 +175,8 @@ fn write_value(
         | ValueType::Tuple
         | ValueType::List
         | ValueType::Bag) => {
-            let prefix = match col_name {
-                Some(name) => format!("column '{name}'"),
+            let prefix = match field_name {
+                Some(name) => format!("field '{name}'"),
                 None => "top-level value".to_string(),
             };
             return Err(SerializeError::Unsupported(format!(

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -260,15 +260,27 @@ pub fn serialize_row(
             }
             ValueType::Integer => {
                 buf.push(TAG_INTEGER);
-                buf.extend_from_slice(&view.get_i64().unwrap().to_le_bytes());
+                buf.extend_from_slice(
+                    &view
+                        .get_i64()
+                        .expect("ValueType::Integer must yield i64 — VM invariant")
+                        .to_le_bytes(),
+                );
             }
             ValueType::Float => {
                 buf.push(TAG_FLOAT);
-                buf.extend_from_slice(&view.get_f64().unwrap().to_le_bytes());
+                buf.extend_from_slice(
+                    &view
+                        .get_f64()
+                        .expect("ValueType::Float must yield f64 — VM invariant")
+                        .to_le_bytes(),
+                );
             }
             ValueType::Decimal => {
                 buf.push(TAG_DECIMAL);
-                let d = view.get_decimal().unwrap();
+                let d = view
+                    .get_decimal()
+                    .expect("ValueType::Decimal must yield Decimal — VM invariant");
                 // rust_decimal: scale() -> u32 with documented range 0..=28
                 // across all 1.x; mantissa() -> i128 (widened from native
                 // 96-bit; upper 32 bits sign-extended). Wire format per the
@@ -280,7 +292,9 @@ pub fn serialize_row(
             }
             ValueType::String => {
                 buf.push(TAG_STRING);
-                let s = view.get_str().unwrap();
+                let s = view
+                    .get_str()
+                    .expect("ValueType::String must yield &str — VM invariant");
                 let sb = s.as_bytes();
                 let str_len: u32 = sb
                     .len()

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -1,29 +1,25 @@
 //! Custom tagged-union row serialization for the CTAS write path.
 //!
-//! Operates on the VM's [`RegisterReader`] + [`RowShape`] surface (not on
-//! `partiql_value::Value`). The CTAS arm in `pqlite.rs` calls
-//! [`serialize_row`] inside the driver closure passed to
-//! `HeedDB::create_table_from_rows`, then hands the resulting bytes to
-//! storage via `push_row(&buf)` — zero per-row allocations after warmup.
+//! Operates on the VM's RegisterReader + RowShape surface, no `partiql_value::Value`
+//! materialization. The CTAS arm in `pqlite.rs` calls `serialize_row` and passes
+//! the encoded bytes to `TableWriter::push_row` — zero per-row allocations after
+//! warmup.
 //!
 //! Wire format:
-//!   ROW = ver(u8=0x01) struct_tag(u8=0x03) struct_body
-//!   struct_body = field_count(u32 LE)
-//!                 ( name_len(u32 LE) name_utf8 tagged_value ){field_count}
+//!   ROW   = ver(u8=0x01) tagged_value
 //!   tagged_value = tag(u8) payload
+//!   payload(TAG_STRUCT) = field_count(u32 LE) (name_len(u32 LE) name_utf8 tagged_value){N}
 //!
-//! VALUE bytes are little-endian. The row-id KEY in LMDB stays big-endian:
-//! storage encodes it as `row_id.to_be_bytes()` and stores it under a
-//! `heed::types::Bytes` key codec, so the B+tree's lexicographic key order
+//! All multi-byte VALUE bytes are little-endian. Row-id KEYS in LMDB stay
+//! big-endian: storage encodes them as `row_id.to_be_bytes()` under a
+//! `heed::types::Bytes` key codec so the B+tree's lexicographic key order
 //! matches numeric order with zero per-row key allocations.
 
 use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
 
-/// Format-version byte. PR 3 = 0x01. The byte gates the ENTIRE struct_body
-/// grammar, not just per-tag interpretation. Under 0x01, struct_body is
-/// `field_count + (name_len + name + tagged_value){N}`. A future PR that
-/// adds a schema registry will bump to 0x02 and drop per-row field names;
-/// readers refuse unknown versions.
+/// Format-version byte gating the entire wire grammar (not just per-tag
+/// interpretation). Readers must refuse unknown versions. Currently 0x01:
+/// `struct_body = field_count + (name_len + name + tagged_value){N}`.
 pub const FORMAT_VERSION: u8 = 0x01;
 
 /// Maximum columns per row. Real CTAS rows top out at hundreds; 1024 is
@@ -36,36 +32,25 @@ pub const MAX_FIELDS_PER_ROW: u32 = 1024;
 /// real-world name. The cap applies to UTF-8 byte length, not char count.
 pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 
-// Tag constants. `pub` so PR 4's reader imports the same source of truth
-// as the encoder — see the LE/BE invariant in the function docstring; the
-// same drift risk applies to tag-byte numerals.
+// Tag constants. `pub` so the reader and encoder share one source of truth.
 pub const TAG_INTEGER: u8 = 0x00;
 pub const TAG_DECIMAL: u8 = 0x01;
 pub const TAG_FLOAT: u8 = 0x02;
 pub const TAG_STRUCT: u8 = 0x03;
-// 0x04 = TAG_BAG — reserved; PR 3 rejects, encoder write path lands later.
+// 0x04 = TAG_BAG     — reserved; rejected.
 pub const TAG_STRING: u8 = 0x05;
 pub const TAG_NULL: u8 = 0x06;
-// 0x07 = TAG_MISSING — reserved; PR 3 rejects.
-// 0x08 = TAG_BOOL    — reserved; PR 3 rejects.
-// 0x09 = TAG_BYTES   — reserved; PR 3 rejects.
+// 0x07 = TAG_MISSING — reserved; rejected.
+// 0x08 = TAG_BOOL    — reserved; rejected.
+// 0x09 = TAG_BYTES   — reserved; rejected.
 
-/// Errors raised by [`serialize_row`].
-///
-/// One variant by design: PR 3 lumps "type not supported yet" and "shape not
-/// supported yet" under `Unsupported(String)` because every consumer flattens
-/// them through `Display` at the CTAS-arm boundary. Richer discrimination
-/// lands when a non-pqlite consumer needs it. `storage.rs` never sees this
-/// type.
-///
-/// `pub` (not `pub(crate)`) because the `pqlite` binary in `src/bin/` is a
-/// separate crate from the library; same for [`serialize_row`] and the
-/// `row_codec` module declaration in `lib.rs`.
+/// Errors raised by [`serialize_row`]. `pub` because the binary in `src/bin/`
+/// is a separate crate from this library.
 #[derive(Debug)]
 pub enum SerializeError {
-    /// A type or shape PR 3 doesn't implement (containers, dynamic column
-    /// names, MISSING, BOOL, BYTES, nested struct values, empty column
-    /// names, bare-scalar rows). The string names the offending column.
+    /// An unsupported type or shape: containers, dynamic column names,
+    /// MISSING, BOOL, BYTES, nested struct values, empty column names. The
+    /// string identifies the offending column or top-level value.
     Unsupported(String),
 }
 
@@ -83,28 +68,15 @@ impl std::error::Error for SerializeError {}
 ///
 /// `buf` is cleared on entry. On success, `buf` contains:
 ///   * `FORMAT_VERSION` (1 byte)
-///   * `TAG_STRUCT` (1 byte)
-///   * struct body: u32 LE field_count, then per field
-///     (u32 LE name_len + UTF-8 name + tag byte + value payload)
+///   * top-level tag (1 byte: TAG_STRUCT for struct rows, or a scalar tag)
+///   * payload for that tag (struct_body for TAG_STRUCT, value bytes for scalars)
 ///
 /// All integer fields are little-endian. The row-id key in LMDB stays
-/// big-endian: storage writes it as `row_id.to_be_bytes()` under a
-/// `heed::types::Bytes` key codec. Only VALUE bytes are LE.
-///
-/// # Rejection contract
-///
-/// Walks the row shape and peeks `view.get_type()` for every column BEFORE
-/// pushing any bytes. Returns `Err(Unsupported)` immediately if any column
-/// trips the reject set (Tuple, List, Bag, Missing, Bool, Bytes) or if the
-/// shape is structurally unsupported (top-level scalar, dynamic field name,
-/// nested struct value, empty field name). `buf` is left empty (already
-/// cleared) on any rejection.
+/// big-endian under `heed::types::Bytes`. Only VALUE bytes are LE.
 ///
 /// # Endianness invariant
 ///
-/// Every multi-byte field (`field_count`, `name_len`, `i64`, `f64`, `i32`
-/// scale, `i128` mantissa, `u32` string length) is written via
-/// `to_le_bytes()`. The corresponding test parser in
+/// Every multi-byte field is written `to_le_bytes()`. The test parser in
 /// `partiql-tools/tests/pqlite_cli.rs::parse_row` uses `from_le_bytes()` to
 /// match. If you add a new tag, write it `to_le_bytes()` here AND read it
 /// `from_le_bytes()` there — an LE/BE asymmetry compiles cleanly and
@@ -115,21 +87,17 @@ pub fn serialize_row(
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
     buf.clear();
+    match row_shape {
+        RowShape::Struct(fields) => write_struct_row(row, fields, buf),
+        RowShape::Register(slot, _) => write_scalar_row(row, *slot, buf),
+    }
+}
 
-    // PR 3 supports exactly RowShape::Struct at the top of a row. A bare
-    // scalar at the top has no column name and is rejected with an
-    // actionable message; the user can wrap the projection (`AS <name>`).
-    let fields = match row_shape {
-        RowShape::Struct(fs) => fs,
-        RowShape::Register(_, _) => {
-            return Err(SerializeError::Unsupported(
-                "CTAS source must produce a struct; got a bare scalar (add an AS alias)".into(),
-            ));
-        }
-    };
-
-    // Row-shape cap: catches a corrupt/oversize column count before the
-    // per-field walk allocates anything proportional to the count.
+fn write_struct_row(
+    row: &RegisterReader<'_>,
+    fields: &[partiql_eval::value::FieldShape],
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
     if fields.len() > MAX_FIELDS_PER_ROW as usize {
         return Err(SerializeError::Unsupported(format!(
             "row has {} columns, exceeds MAX_FIELDS_PER_ROW ({})",
@@ -137,8 +105,7 @@ pub fn serialize_row(
             MAX_FIELDS_PER_ROW
         )));
     }
-
-    // ── Pre-flight: validate the whole row before writing any bytes ─────────
+    // Pre-flight: validate every column before pushing any payload bytes.
     for (col, field) in fields.iter().enumerate() {
         let name = match &field.name {
             FieldName::Static(s) if !s.is_empty() => s.as_str(),
@@ -149,7 +116,7 @@ pub fn serialize_row(
             }
             FieldName::Register(_) => {
                 return Err(SerializeError::Unsupported(format!(
-                    "column {col}: dynamic name (FieldName::Register) not supported in PR 3"
+                    "column {col}: dynamic column names are not supported yet"
                 )));
             }
         };
@@ -160,9 +127,8 @@ pub fn serialize_row(
                 MAX_NAME_LEN_BYTES
             )));
         }
-        // Duplicate-name check: PR 4's reader and PR 5's schema registry
-        // both need column names to be a unique key. Quadratic in column
-        // count, but the count is bounded by MAX_FIELDS_PER_ROW above.
+        // Duplicate-name check: bounded by MAX_FIELDS_PER_ROW so the O(K²)
+        // is acceptable.
         for prior in &fields[..col] {
             if let FieldName::Static(prior_name) = &prior.name {
                 if prior_name == name {
@@ -176,63 +142,24 @@ pub fn serialize_row(
             RowShape::Register(idx, _) => *idx,
             RowShape::Struct(_) => {
                 return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': nested struct values not supported in PR 3"
+                    "column '{name}': nested struct values are not supported yet"
                 )));
             }
         };
-        // The slot index was emitted by the same compiler pass that built
-        // this register file; a None here is a planner/VM invariant
-        // violation, not a recoverable runtime condition.
         let view = row
             .get_value_view(slot)
             .expect("register slot from shape must exist in the row");
-        match view.get_type() {
-            ValueType::Null
-            | ValueType::Integer
-            | ValueType::Float
-            | ValueType::Decimal
-            | ValueType::String => {}
-            ValueType::Bool => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': Bool — tag reserved, write path lands in a later PR"
-                )));
-            }
-            ValueType::Bytes => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': Bytes — tag reserved, write path lands in a later PR"
-                )));
-            }
-            ValueType::Missing => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': MISSING wire encoding deferred to the deserializer PR"
-                )));
-            }
-            ValueType::Tuple | ValueType::List | ValueType::Bag => {
-                return Err(SerializeError::Unsupported(format!(
-                    "column '{name}': container types ({:?}) land in PR 5",
-                    view.get_type()
-                )));
-            }
-        }
+        validate_value_type(view.get_type(), Some(name))?;
     }
 
-    // ── Pre-flight passed: write the row ────────────────────────────────────
+    // Pre-flight passed: write the row.
     buf.push(FORMAT_VERSION);
     buf.push(TAG_STRUCT);
-    // Lengths and counts use `try_into().expect(...)` rather than `as u32`
-    // throughout serialize_row: silent truncation on >u32::MAX inputs would
-    // corrupt the row format (the reader would parse the truncated length
-    // and read garbage thereafter). Panic with a pointed message instead;
-    // this layer has no recovery anyway — the row's already materialized in
-    // VM registers.
     let field_count: u32 = fields.len().try_into().expect(
         "row has more than u32::MAX columns — wire format requires field_count fits in u32",
     );
     buf.extend_from_slice(&field_count.to_le_bytes());
-
     for field in fields.iter() {
-        // SAFETY of unwrap: pre-flight validated FieldName::Static(non-empty)
-        // and RowShape::Register for every field.
         let name = match &field.name {
             FieldName::Static(s) => s.as_str(),
             FieldName::Register(_) => unreachable!("pre-flight rejects FieldName::Register"),
@@ -241,8 +168,6 @@ pub fn serialize_row(
             RowShape::Register(idx, _) => *idx,
             RowShape::Struct(_) => unreachable!("pre-flight rejects nested-struct field values"),
         };
-
-        // Write the field name: u32 LE length + raw UTF-8 (no terminator).
         let name_bytes = name.as_bytes();
         let name_len: u32 = name_bytes
             .len()
@@ -250,67 +175,110 @@ pub fn serialize_row(
             .expect("column name longer than u32::MAX bytes");
         buf.extend_from_slice(&name_len.to_le_bytes());
         buf.extend_from_slice(name_bytes);
-
-        let view = row
-            .get_value_view(slot)
-            .expect("register slot from shape must exist in the row");
-        match view.get_type() {
-            ValueType::Null => {
-                buf.push(TAG_NULL);
-            }
-            ValueType::Integer => {
-                buf.push(TAG_INTEGER);
-                buf.extend_from_slice(
-                    &view
-                        .get_i64()
-                        .expect("ValueType::Integer must yield i64 — VM invariant")
-                        .to_le_bytes(),
-                );
-            }
-            ValueType::Float => {
-                buf.push(TAG_FLOAT);
-                buf.extend_from_slice(
-                    &view
-                        .get_f64()
-                        .expect("ValueType::Float must yield f64 — VM invariant")
-                        .to_le_bytes(),
-                );
-            }
-            ValueType::Decimal => {
-                buf.push(TAG_DECIMAL);
-                let d = view
-                    .get_decimal()
-                    .expect("ValueType::Decimal must yield Decimal — VM invariant");
-                // rust_decimal: scale() -> u32 with documented range 0..=28
-                // across all 1.x; mantissa() -> i128 (widened from native
-                // 96-bit; upper 32 bits sign-extended). Wire format per the
-                // spec: 4-byte i32 LE scale + 16-byte i128 LE mantissa.
-                // The `as i32` cast is provably safe (scale ≤ 28 fits in i32).
-                let scale_i32: i32 = d.scale() as i32;
-                buf.extend_from_slice(&scale_i32.to_le_bytes());
-                buf.extend_from_slice(&d.mantissa().to_le_bytes());
-            }
-            ValueType::String => {
-                buf.push(TAG_STRING);
-                let s = view
-                    .get_str()
-                    .expect("ValueType::String must yield &str — VM invariant");
-                let sb = s.as_bytes();
-                let str_len: u32 = sb
-                    .len()
-                    .try_into()
-                    .expect("string column value longer than u32::MAX bytes — wire format requires length fits in u32");
-                buf.extend_from_slice(&str_len.to_le_bytes());
-                buf.extend_from_slice(sb);
-            }
-            ValueType::Bool
-            | ValueType::Bytes
-            | ValueType::Missing
-            | ValueType::Tuple
-            | ValueType::List
-            | ValueType::Bag => unreachable!("pre-flight rejects all reserved/container types"),
-        }
+        write_tagged_value(row, slot, buf);
     }
-
     Ok(())
+}
+
+fn write_scalar_row(
+    row: &RegisterReader<'_>,
+    slot: usize,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    let view = row
+        .get_value_view(slot)
+        .expect("register slot from shape must exist in the row");
+    validate_value_type(view.get_type(), None)?;
+    buf.push(FORMAT_VERSION);
+    write_tagged_value(row, slot, buf);
+    Ok(())
+}
+
+/// Reject unsupported types. `col_name` is `Some(name)` for a struct-field
+/// walk and `None` for a top-level scalar row; the error wording branches
+/// accordingly.
+fn validate_value_type(ty: ValueType, col_name: Option<&str>) -> Result<(), SerializeError> {
+    let prefix = match col_name {
+        Some(name) => format!("column '{name}'"),
+        None => "top-level value".to_string(),
+    };
+    match ty {
+        ValueType::Null
+        | ValueType::Integer
+        | ValueType::Float
+        | ValueType::Decimal
+        | ValueType::String => Ok(()),
+        ValueType::Bool => Err(SerializeError::Unsupported(format!(
+            "{prefix}: Bool is not yet supported"
+        ))),
+        ValueType::Bytes => Err(SerializeError::Unsupported(format!(
+            "{prefix}: Bytes is not yet supported"
+        ))),
+        ValueType::Missing => Err(SerializeError::Unsupported(format!(
+            "{prefix}: MISSING is not yet supported"
+        ))),
+        ValueType::Tuple | ValueType::List | ValueType::Bag => Err(SerializeError::Unsupported(
+            format!("{prefix}: container type ({ty:?}) is not yet supported"),
+        )),
+    }
+}
+
+/// Write `tag + payload` for the value at register `slot`. The caller is
+/// responsible for having pre-flight-validated the type.
+fn write_tagged_value(row: &RegisterReader<'_>, slot: usize, buf: &mut Vec<u8>) {
+    let view = row
+        .get_value_view(slot)
+        .expect("register slot from shape must exist in the row");
+    match view.get_type() {
+        ValueType::Null => {
+            buf.push(TAG_NULL);
+        }
+        ValueType::Integer => {
+            buf.push(TAG_INTEGER);
+            buf.extend_from_slice(
+                &view
+                    .get_i64()
+                    .expect("ValueType::Integer must yield i64 — VM invariant")
+                    .to_le_bytes(),
+            );
+        }
+        ValueType::Float => {
+            buf.push(TAG_FLOAT);
+            buf.extend_from_slice(
+                &view
+                    .get_f64()
+                    .expect("ValueType::Float must yield f64 — VM invariant")
+                    .to_le_bytes(),
+            );
+        }
+        ValueType::Decimal => {
+            buf.push(TAG_DECIMAL);
+            let d = view
+                .get_decimal()
+                .expect("ValueType::Decimal must yield Decimal — VM invariant");
+            // rust_decimal: scale() is u32 in 0..=28; the i32 cast is lossless.
+            let scale_i32: i32 = d.scale() as i32;
+            buf.extend_from_slice(&scale_i32.to_le_bytes());
+            buf.extend_from_slice(&d.mantissa().to_le_bytes());
+        }
+        ValueType::String => {
+            buf.push(TAG_STRING);
+            let s = view
+                .get_str()
+                .expect("ValueType::String must yield &str — VM invariant");
+            let sb = s.as_bytes();
+            let str_len: u32 = sb
+                .len()
+                .try_into()
+                .expect("string column value longer than u32::MAX bytes");
+            buf.extend_from_slice(&str_len.to_le_bytes());
+            buf.extend_from_slice(sb);
+        }
+        ValueType::Bool
+        | ValueType::Bytes
+        | ValueType::Missing
+        | ValueType::Tuple
+        | ValueType::List
+        | ValueType::Bag => unreachable!("pre-flight rejects all reserved/container types"),
+    }
 }

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -1,49 +1,28 @@
 //! LMDB-backed storage for pqlite.
-//!
-//! All heed/LMDB contact lives here so the binary stays thin and the storage
-//! logic is unit-testable in isolation.
 
 use std::path::{Path, PathBuf};
 
-/// Virtual address space reserved for the LMDB map. Sparse (not pre-allocated
-/// on disk); LMDB grows actual usage up to this ceiling.
+/// Virtual address space reserved for the LMDB map. Sparse on disk.
 const DEFAULT_MAP_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
 
-/// Upper bound on named databases in the environment. One catalog plus
-/// headroom for one named db per user table.
+/// One catalog plus headroom for one named db per user table.
 const MAX_DBS: u32 = 128;
 
-/// Name of the system catalog database inside the environment.
 const TABLES_DB: &str = "_tables";
 
-/// The `_tables` catalog database: table-name keys to opaque byte values.
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
-/// Row-store key codec: an 8-byte big-endian `u64` row id passed as raw bytes.
-/// We use `heed::types::Bytes` (not `heed::types::U64<BigEndian>`) because
-/// `U64`'s `BytesEncode` impl heap-allocates an 8-byte `Vec` on every `put`,
-/// while `Bytes` returns `Cow::Borrowed(&[u8])` — zero allocations per row.
-/// Big-endian is preserved at the call site (the caller fills a stack-local
-/// `[u8; 8]` via `row_id.to_be_bytes()`). LMDB's B+tree keys are
-/// byte-comparison-ordered, so BE keeps lexicographic key order matching
-/// numeric order; LE would reverse iteration order.
+/// Row-store keys are an 8-byte big-endian `u64` row id passed as raw bytes.
+/// `Bytes` (not `U64<BigEndian>`) so the caller can pass a stack-local
+/// `[u8; 8]` — zero allocations per put. BE keeps lexicographic key order
+/// matching numeric order.
 type RowKey = heed::types::Bytes;
 
-/// `RowDb` is the per-table B+tree keyed by big-endian u64 row ID. Bytes
-/// pushed via `TableWriter::push_row` are stored verbatim — storage adds
-/// no framing.
 type RowDb = heed::Database<RowKey, heed::types::Bytes>;
 
-/// Write-side handle for a single CTAS operation.
-///
-/// Holds the open `wtxn` and the table's `RowDb` between `create_table` and
-/// `commit`. Drop without `commit` triggers `wtxn`'s rollback — no catalog
-/// entry, no row bytes.
-///
-/// The `row_id` counter encodes as big-endian into a stack-local `[u8; 8]`
-/// key buffer reused across every `push_row` call. Combined with `RowKey =
-/// heed::types::Bytes` (Cow::Borrowed), this gives zero heap allocations per
-/// row for the key side of the put.
+/// Write-side handle for a single CTAS operation. Drop without `commit`
+/// triggers `wtxn`'s rollback. `key_buf` is reused across pushes for a
+/// zero-alloc key path.
 pub struct TableWriter<'env> {
     wtxn: heed::RwTxn<'env>,
     table: RowDb,
@@ -51,10 +30,7 @@ pub struct TableWriter<'env> {
     key_buf: [u8; 8],
 }
 
-// `heed::RwTxn` does not impl `Debug`, so derive can't be used. Hand-rolled
-// impl skips the txn field and surfaces the row counter — enough to read in
-// test diagnostics (`{:?}` on `Result<TableWriter, _>` in the name-rejection
-// tests) without leaking heed internals.
+// Hand-rolled `Debug` because `heed::RwTxn` does not implement it.
 impl<'env> std::fmt::Debug for TableWriter<'env> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TableWriter")
@@ -80,8 +56,6 @@ impl<'env> TableWriter<'env> {
     }
 }
 
-/// Errors from opening or initializing the storage environment, or from
-/// executing a write path against it.
 #[derive(Debug)]
 pub enum StorageError {
     Io(std::io::Error),
@@ -140,21 +114,10 @@ impl From<heed::Error> for StorageError {
     }
 }
 
-/// Normalize a database path so heed can open a not-yet-existing single-file
-/// (`NO_SUB_DIR`) database given as a bare filename.
-///
-/// For a file that doesn't exist yet, heed recovers by canonicalizing
-/// `path.parent()` and re-joining the file name. But `parent()` of a bare name
-/// like `foo.pqlite` is the empty path `""`, and canonicalizing `""` is ENOENT —
-/// so `pqlite --db foo.pqlite` would spuriously fail even though the current
-/// directory exists and every other UNIX tool (`sqlite3 foo.db`, `touch`, ...)
-/// would just create the file there. Joining a bare name onto `.` gives heed a
-/// real parent (`.`) to canonicalize.
-///
-/// This neither invents a default path nor creates any directory: a path that
-/// already has a directory component is returned unchanged, so a genuinely
-/// missing parent (`missing_dir/foo.pqlite`) still errors — the behavior the
-/// `--db` contract wants.
+/// Prefix a bare filename with `./` so heed can canonicalize its parent.
+/// Without this, `--db foo.pqlite` fails ENOENT because `parent()` of a
+/// bare name is the empty path. Paths with a real directory component are
+/// returned unchanged, so a genuinely missing parent still errors.
 fn normalize_db_path(path: &Path) -> PathBuf {
     if path.parent() == Some(Path::new("")) {
         Path::new(".").join(path)
@@ -163,12 +126,8 @@ fn normalize_db_path(path: &Path) -> PathBuf {
     }
 }
 
-/// Owns the LMDB environment and the `_tables` system catalog handle.
-///
-/// The `Env` and the `Database` handle share a lifecycle: the catalog handle is
-/// valid only while the `Env` is alive, so both live on this struct together.
-/// Later PRs reuse `env()` to begin transactions and `tables()` across them
-/// without re-resolving the catalog by name.
+/// Owns the LMDB environment and the `_tables` catalog handle. The catalog
+/// handle is valid only while the env is alive, so both live together.
 #[derive(Debug)]
 pub struct HeedDB {
     env: heed::Env,
@@ -180,22 +139,11 @@ impl HeedDB {
     /// Open (or create) the LMDB environment at `path` as a single file, and
     /// open/create the `_tables` system catalog inside it.
     pub fn open(path: &Path) -> Result<HeedDB, StorageError> {
-        // We do not create the parent directory on the user's behalf. In
-        // single-file (`NO_SUB_DIR`) mode LMDB opens the file directly, so if
-        // the parent directory is missing the filesystem error bubbles up
-        // naturally — matching how standard UNIX tools behave.
-
-        // Normalize a bare filename to an explicit `./name` before handing it
-        // to heed (see `normalize_db_path` for the why).
         let normalized = normalize_db_path(path);
 
-        // Open the environment. `flags` and `open` are both unsafe in heed
-        // 0.20, so the whole builder chain is in one unsafe block.
         // SAFETY: NO_SUB_DIR only changes the on-disk layout (single file vs.
-        // directory) and carries none of the corruption-prone semantics of the
-        // dangerous flags (NO_SYNC / NO_META_SYNC / NO_LOCK). open() memory-maps
-        // the file; inter-process coordination is handled by LMDB's sibling
-        // lock file, and pqlite opens each env path at most once per process.
+        // directory). The dangerous flags (NO_SYNC / NO_META_SYNC / NO_LOCK)
+        // are not set, and pqlite opens each env path at most once per process.
         let env = unsafe {
             heed::EnvOpenOptions::new()
                 .map_size(DEFAULT_MAP_SIZE)
@@ -204,7 +152,7 @@ impl HeedDB {
                 .open(&normalized)?
         };
 
-        // `create_database` is idempotent — reopening an existing db is fine.
+        // `create_database` is idempotent.
         let mut wtxn = env.write_txn()?;
         let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
         wtxn.commit()?;
@@ -259,7 +207,6 @@ impl HeedDB {
         &self.tables
     }
 
-    /// The resolved on-disk path this environment was opened at.
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -26,16 +26,14 @@ type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 /// `U64`'s `BytesEncode` impl heap-allocates an 8-byte `Vec` on every `put`,
 /// while `Bytes` returns `Cow::Borrowed(&[u8])` — zero allocations per row.
 /// Big-endian is preserved at the call site (the caller fills a stack-local
-/// `[u8; 8]` via `row_id.to_be_bytes()`); LMDB's B+tree keys are
+/// `[u8; 8]` via `row_id.to_be_bytes()`). LMDB's B+tree keys are
 /// byte-comparison-ordered, so BE keeps lexicographic key order matching
-/// numeric order. Switching to LE would reverse iteration order and break
-/// PR4's row enumeration.
+/// numeric order; LE would reverse iteration order.
 type RowKey = heed::types::Bytes;
 
-/// A user table's row store: 8-byte big-endian `u64` row-id keys to opaque
-/// byte values. Storage is codec-agnostic — whatever bytes the caller pushes
-/// via the `create_table_from_rows` driver are persisted verbatim. The
-/// encoder lives in `crate::row_codec` since PR 3.
+/// `RowDb` is the per-table B+tree keyed by big-endian u64 row ID. Bytes
+/// pushed via `TableWriter::push_row` are stored verbatim — storage adds
+/// no framing.
 type RowDb = heed::Database<RowKey, heed::types::Bytes>;
 
 /// Write-side handle for a single CTAS operation.
@@ -102,11 +100,10 @@ pub enum StorageError {
     /// A VM execution error, pre-stringified by the caller so this layer does
     /// not depend on `partiql-eval`'s error type.
     Execution(String),
-    /// A row-codec rejection (e.g. unsupported type/shape) bubbled up through
-    /// the `create_table_from_rows` driver closure. The carried string already
-    /// reads as a complete error sentence (e.g. "unsupported: column 'b': Bool
-    /// — tag reserved..."); Display surfaces it verbatim so stderr stays
-    /// single-level ("Error: unsupported: ..."), matching PartiQL's style.
+    /// A row-codec rejection (e.g. unsupported type/shape). The carried string
+    /// already reads as a complete error sentence (e.g. "unsupported: column
+    /// 'b': Bool — tag reserved..."); Display surfaces it verbatim so stderr
+    /// stays single-level ("Error: unsupported: ..."), matching PartiQL's style.
     Codec(String),
 }
 
@@ -219,9 +216,7 @@ impl HeedDB {
                 .open(&normalized)?
         };
 
-        // Open/create the `_tables` catalog in a write transaction.
-        // `create_database` borrows the RwTxn mutably and opens the db if it
-        // already exists, so reopening is not an error.
+        // `create_database` is idempotent — reopening an existing db is fine.
         let mut wtxn = env.write_txn()?;
         let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
         wtxn.commit()?;
@@ -252,6 +247,9 @@ impl HeedDB {
             return Err(StorageError::TableExists(name.to_string()));
         }
         let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
+        // Catalog value is the format-version byte. Zero-row tables have no
+        // rows to read it from, and a `[0x00]` sentinel would collide with
+        // TAG_INTEGER if a tool ran the catalog cell through the row parser.
         self.tables
             .put(&mut wtxn, name, &[crate::row_codec::FORMAT_VERSION])?;
         Ok(TableWriter {

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -56,6 +56,12 @@ pub enum StorageError {
     /// A VM execution error, pre-stringified by the caller so this layer does
     /// not depend on `partiql-eval`'s error type.
     Execution(String),
+    /// A row-codec rejection (e.g. unsupported type/shape) bubbled up through
+    /// the `create_table_from_rows` driver closure. The carried string already
+    /// reads as a complete error sentence (e.g. "unsupported: column 'b': Bool
+    /// — tag reserved..."); Display surfaces it verbatim so stderr stays
+    /// single-level ("Error: unsupported: ..."), matching PartiQL's style.
+    Codec(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -72,6 +78,7 @@ impl std::fmt::Display for StorageError {
                 write!(f, "invalid table name {name:?}: contains a NUL byte")
             }
             StorageError::Execution(msg) => write!(f, "execution error: {msg}"),
+            StorageError::Codec(msg) => write!(f, "{msg}"),
         }
     }
 }
@@ -84,7 +91,8 @@ impl std::error::Error for StorageError {
             StorageError::TableExists(_)
             | StorageError::ReservedName(_)
             | StorageError::InvalidName(_)
-            | StorageError::Execution(_) => None,
+            | StorageError::Execution(_)
+            | StorageError::Codec(_) => None,
         }
     }
 }

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -1,8 +1,7 @@
 //! LMDB-backed storage for pqlite.
 //!
-//! All heed/LMDB contact lives here so the binary stays thin and this logic is
-//! unit-testable in isolation. PR 1 opens the environment and creates the
-//! `_tables` system catalog; it writes nothing into the catalog.
+//! All heed/LMDB contact lives here so the binary stays thin and the storage
+//! logic is unit-testable in isolation.
 
 use std::path::{Path, PathBuf};
 
@@ -10,15 +9,14 @@ use std::path::{Path, PathBuf};
 /// on disk); LMDB grows actual usage up to this ceiling.
 const DEFAULT_MAP_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
 
-/// Upper bound on named databases in the environment. One catalog db now, with
-/// headroom for one named db per user table in later PRs.
+/// Upper bound on named databases in the environment. One catalog plus
+/// headroom for one named db per user table.
 const MAX_DBS: u32 = 128;
 
 /// Name of the system catalog database inside the environment.
 const TABLES_DB: &str = "_tables";
 
-/// The `_tables` catalog database: table-name keys to opaque byte values. The
-/// value format is deliberately left opaque until the table-registration PR.
+/// The `_tables` catalog database: table-name keys to opaque byte values.
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
 /// Row-store key codec: an 8-byte big-endian `u64` row id passed as raw bytes.
@@ -260,18 +258,16 @@ impl HeedDB {
         })
     }
 
-    // TODO: these accessors expose heed types (`Env`, `Database`) directly,
-    // which leaks the storage engine across the module boundary. If a later
-    // milestone abstracts storage away from heed (e.g. custom index
-    // structures), wrap these behind an engine-agnostic interface instead.
-
-    /// The live environment. Used by later PRs to begin transactions.
-    pub fn env(&self) -> &heed::Env {
+    /// The live LMDB environment. Test-only; heed types do not leak across
+    /// the module boundary.
+    #[cfg(test)]
+    pub(crate) fn env(&self) -> &heed::Env {
         &self.env
     }
 
-    /// The `_tables` system catalog handle (opaque byte values for now).
-    pub fn tables(&self) -> &TablesDb {
+    /// The `_tables` system catalog handle. Test-only.
+    #[cfg(test)]
+    pub(crate) fn tables(&self) -> &TablesDb {
         &self.tables
     }
 

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -38,6 +38,52 @@ type RowKey = heed::types::Bytes;
 /// encoder lives in `crate::row_codec` since PR 3.
 type RowDb = heed::Database<RowKey, heed::types::Bytes>;
 
+/// Write-side handle for a single CTAS operation.
+///
+/// Holds the open `wtxn` and the table's `RowDb` between `create_table` and
+/// `commit`. Drop without `commit` triggers `wtxn`'s rollback — no catalog
+/// entry, no row bytes.
+///
+/// The `row_id` counter encodes as big-endian into a stack-local `[u8; 8]`
+/// key buffer reused across every `push_row` call. Combined with `RowKey =
+/// heed::types::Bytes` (Cow::Borrowed), this gives zero heap allocations per
+/// row for the key side of the put.
+pub struct TableWriter<'env> {
+    wtxn: heed::RwTxn<'env>,
+    table: RowDb,
+    row_id: u64,
+    key_buf: [u8; 8],
+}
+
+// `heed::RwTxn` does not impl `Debug`, so derive can't be used. Hand-rolled
+// impl skips the txn field and surfaces the row counter — enough to read in
+// test diagnostics (`{:?}` on `Result<TableWriter, _>` in the name-rejection
+// tests) without leaking heed internals.
+impl<'env> std::fmt::Debug for TableWriter<'env> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableWriter")
+            .field("row_id", &self.row_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'env> TableWriter<'env> {
+    /// Encode the next row. `bytes` is the caller-encoded row payload —
+    /// storage adds no framing.
+    pub fn push_row(&mut self, bytes: &[u8]) -> Result<(), StorageError> {
+        self.key_buf = self.row_id.to_be_bytes();
+        self.table.put(&mut self.wtxn, &self.key_buf[..], bytes)?;
+        self.row_id += 1;
+        Ok(())
+    }
+
+    /// Commit the write txn and return the number of rows persisted.
+    pub fn commit(self) -> Result<u64, StorageError> {
+        self.wtxn.commit()?;
+        Ok(self.row_id)
+    }
+}
+
 /// Errors from opening or initializing the storage environment, or from
 /// executing a write path against it.
 #[derive(Debug)]
@@ -187,73 +233,33 @@ impl HeedDB {
         })
     }
 
-    /// Create a new table by driving a caller-supplied per-row writer in a
-    /// single write transaction.
+    /// Open a write handle for a new table named `name`.
     ///
-    /// Storage opens the write txn, creates the row store, registers the
-    /// table in the catalog, then invokes `driver_closure` with a
-    /// `push_row(&[u8])` callback. The caller calls `push_row` once per
-    /// encoded row; storage assigns the next `u64` row-id and persists the
-    /// bytes verbatim. Any error from `driver_closure` or `push_row` drops
-    /// the `RwTxn` before commit, so LMDB rolls the whole operation back and
-    /// nothing partial persists.
-    ///
-    /// The push-callback shape lets the caller hand storage a `&[u8]`
-    /// borrowed from a reusable buffer instead of cloning per row.
-    ///
-    /// `name` must already be canonicalized by the caller (bare identifiers
-    /// folded to lowercase, quoted identifiers verbatim). Returns the number
-    /// of rows written.
-    pub fn create_table_from_rows<F>(
-        &self,
-        name: &str,
-        mut driver_closure: F,
-    ) -> Result<u64, StorageError>
-    where
-        F: FnMut(&mut dyn FnMut(&[u8]) -> Result<(), StorageError>) -> Result<(), StorageError>,
-    {
-        // heed performs no runtime codec check when reopening a named db, so
-        // `CREATE TABLE _tables AS ...` would reopen the catalog's own dbi and
-        // corrupt it. Reject the whole `_` namespace before any transaction.
+    /// Runs all up-front catalog work (reserved-name guard, NUL guard, dup
+    /// check, format-version write) and opens a write transaction. The
+    /// returned `TableWriter` lives until `commit` (success) or drop
+    /// (rollback). `name` must already be canonicalized by the caller —
+    /// bare identifiers folded to lowercase, quoted identifiers verbatim.
+    pub fn create_table(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
         if name.starts_with('_') {
             return Err(StorageError::ReservedName(name.to_string()));
         }
-
-        // An interior NUL would panic heed's internal `CString::new(name)` in
-        // `create_database`. Reject it here as a clean error.
         if name.contains('\0') {
             return Err(StorageError::InvalidName(name.to_string()));
         }
-
         let mut wtxn = self.env.write_txn()?;
-
-        // Dup check in the same txn (`RwTxn` derefs to `RoTxn`).
         if self.tables.get(&wtxn, name)?.is_some() {
             return Err(StorageError::TableExists(name.to_string()));
         }
-
         let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
-        // Catalog value records the row format version. PR 4's reader needs
-        // this on zero-row tables (no row bytes to peek for the version) and
-        // it avoids the [0x00] tag collision with `row_codec::TAG_INTEGER`.
         self.tables
             .put(&mut wtxn, name, &[crate::row_codec::FORMAT_VERSION])?;
-
-        let mut row_id: u64 = 0;
-        // Stack-local 8-byte key buffer reused across every push. Combined
-        // with `RowKey = heed::types::Bytes` (Cow::Borrowed), this gives
-        // zero heap allocations per row for the key side of the put.
-        let mut key_buf: [u8; 8] = [0u8; 8];
-        let mut push_row = |row_bytes: &[u8]| -> Result<(), StorageError> {
-            key_buf = row_id.to_be_bytes();
-            table.put(&mut wtxn, &key_buf[..], row_bytes)?;
-            row_id += 1;
-            Ok(())
-        };
-        driver_closure(&mut push_row)?;
-
-        wtxn.commit()?;
-        Ok(row_id)
+        Ok(TableWriter {
+            wtxn,
+            table,
+            row_id: 0,
+            key_buf: [0u8; 8],
+        })
     }
 
     // TODO: these accessors expose heed types (`Env`, `Database`) directly,
@@ -282,7 +288,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn create_table_from_rows_writes_bytes_verbatim_and_registers_catalog() {
+    fn table_writer_round_trip_via_push_and_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("writer.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let mut w = db.create_table("widgets").expect("create_table");
+        w.push_row(&[0xDE, 0xAD]).unwrap();
+        w.push_row(&[0xBE, 0xEF, 0x01]).unwrap();
+        let n = w.commit().unwrap();
+        assert_eq!(n, 2);
+
+        let rtxn = db.env().read_txn().unwrap();
+        assert!(db.tables().get(&rtxn, "widgets").unwrap().is_some());
+        let rowdb: RowDb = db
+            .env()
+            .open_database(&rtxn, Some("widgets"))
+            .unwrap()
+            .expect("rowdb must exist after commit");
+        assert_eq!(rowdb.len(&rtxn).unwrap(), 2);
+    }
+
+    #[test]
+    fn create_table_writes_bytes_verbatim_and_registers_catalog() {
         // Bit-perfect roundtrip: storage's contract is "persist whatever bytes
         // the caller pushes." A concrete sentinel sequence proves it.
         let dir = tempfile::tempdir().unwrap();
@@ -294,14 +322,11 @@ mod tests {
             &[0x01],
             &[0xFF, 0x00, 0xFF, 0x00, 0xFF],
         ];
-        let n = db
-            .create_table_from_rows("widgets", |push_row| {
-                for p in payloads.iter() {
-                    push_row(p)?;
-                }
-                Ok(())
-            })
-            .unwrap();
+        let mut w = db.create_table("widgets").unwrap();
+        for p in payloads.iter() {
+            w.push_row(p).unwrap();
+        }
+        let n = w.commit().unwrap();
         assert_eq!(n, 3);
 
         let rtxn = db.env().read_txn().unwrap();
@@ -327,14 +352,12 @@ mod tests {
     }
 
     #[test]
-    fn create_table_from_rows_with_no_rows_creates_empty_table() {
+    fn create_table_with_no_rows_creates_empty_table() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        let n = db
-            .create_table_from_rows("blank", |_push_row| Ok(()))
-            .unwrap();
+        let n = db.create_table("blank").unwrap().commit().unwrap();
         assert_eq!(n, 0);
 
         let rtxn = db.env().read_txn().unwrap();
@@ -348,25 +371,19 @@ mod tests {
     }
 
     #[test]
-    fn create_table_from_rows_rejects_duplicate_name() {
+    fn create_table_rejects_duplicate_name() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dup.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        db.create_table_from_rows("t", |push_row| {
-            push_row(&[])?;
-            push_row(&[])?;
-            Ok(())
-        })
-        .unwrap();
-
-        let again = db.create_table_from_rows("t", |push_row| {
-            push_row(&[])?;
-            Ok(())
-        });
+        let mut w1 = db.create_table("t").unwrap();
+        w1.push_row(&[0x01]).unwrap();
+        w1.commit().unwrap();
+        let again = db.create_table("t");
         assert!(
             matches!(again, Err(StorageError::TableExists(ref n)) if n == "t"),
-            "second create should be TableExists, got: {again:?}"
+            "expected TableExists; got {:?}",
+            again
         );
 
         let rtxn = db.env().read_txn().unwrap();
@@ -374,19 +391,17 @@ mod tests {
     }
 
     #[test]
-    fn create_table_from_rows_rejects_reserved_names() {
+    fn create_table_rejects_reserved_names() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("reserved.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        for name in ["_tables", "_indexes", "_x"] {
-            let res = db.create_table_from_rows(name, |push_row| {
-                push_row(&[])?;
-                Ok(())
-            });
+        for name in ["_tables", "_x", "_"] {
+            let res = db.create_table(name);
             assert!(
                 matches!(res, Err(StorageError::ReservedName(_))),
-                "{name} should be reserved, got: {res:?}"
+                "expected ReservedName for {name:?}; got {:?}",
+                res
             );
         }
 
@@ -396,20 +411,18 @@ mod tests {
     }
 
     #[test]
-    fn create_table_from_rows_rejects_interior_nul_names() {
+    fn create_table_rejects_interior_nul_names() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nul.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
         // An interior NUL would otherwise panic heed's CString::new; the guard
         // turns it into a clean error and never opens a transaction.
-        let res = db.create_table_from_rows("a\0b", |push_row| {
-            push_row(&[])?;
-            Ok(())
-        });
+        let res = db.create_table("a\0b");
         assert!(
             matches!(res, Err(StorageError::InvalidName(_))),
-            "interior-NUL name should be InvalidName, got: {res:?}"
+            "expected InvalidName; got {:?}",
+            res
         );
 
         let rtxn = db.env().read_txn().unwrap();
@@ -417,36 +430,19 @@ mod tests {
     }
 
     #[test]
-    fn create_table_from_rows_rolls_back_on_mid_stream_error() {
+    fn dropping_writer_rolls_back_uncommitted_rows() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("rollback.pqlite");
+        let path = dir.path().join("rb.pqlite");
         let db = HeedDB::open(&path).unwrap();
-
-        let res = db.create_table_from_rows("partial", |push_row| {
-            push_row(&[0xAA])?;
-            push_row(&[0xBB])?;
-            Err(StorageError::Execution("boom".to_string()))
-        });
-        assert!(
-            matches!(res, Err(StorageError::Execution(_))),
-            "expected the mid-stream Execution error to surface, got: {res:?}"
-        );
-
-        // Rollback: the txn was never committed, so the catalog has no entry.
+        {
+            let mut w = db.create_table("partial").unwrap();
+            w.push_row(&[0x42]).unwrap();
+            // Drop w without commit — wtxn rolls back.
+        }
         let rtxn = db.env().read_txn().unwrap();
-        assert_eq!(
-            db.tables().len(&rtxn).unwrap(),
-            0,
-            "the failed CTAS must not register the table"
-        );
-
-        // The orphan row-store db must also be absent — rollback dropped it.
         assert!(
-            db.env()
-                .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("partial"))
-                .unwrap()
-                .is_none(),
-            "the failed CTAS must not leave a row-store db behind"
+            db.tables().get(&rtxn, "partial").unwrap().is_none(),
+            "rolled-back create must leave no catalog entry"
         );
     }
 

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -84,25 +84,14 @@ impl<'env> TableWriter<'env> {
 /// executing a write path against it.
 #[derive(Debug)]
 pub enum StorageError {
-    /// Filesystem-level error surfaced while working with the database file.
     Io(std::io::Error),
-    /// Error from the heed/LMDB layer.
     Heed(heed::Error),
-    /// A `CREATE TABLE AS` named a table already registered in the catalog.
     TableExists(String),
-    /// A `CREATE TABLE AS` used a reserved name (`_`-prefixed system namespace).
+    /// `_`-prefixed name; the namespace is reserved.
     ReservedName(String),
-    /// A table name heed cannot use as a database name (it contains an interior
-    /// NUL byte, which would panic heed's internal `CString::new`).
+    /// Name contains an interior NUL byte (heed would panic).
     InvalidName(String),
-    /// A VM execution error, pre-stringified by the caller so this layer does
-    /// not depend on `partiql-eval`'s error type.
     Execution(String),
-    /// A row-codec rejection (e.g. unsupported type/shape). The carried string
-    /// already reads as a complete error sentence (e.g. "unsupported: field
-    /// 'b': Bool is not yet supported"); Display surfaces it verbatim so
-    /// stderr stays single-level ("Error: unsupported: ..."), matching
-    /// PartiQL's style.
     Codec(String),
 }
 

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -245,11 +245,9 @@ impl HeedDB {
             return Err(StorageError::TableExists(name.to_string()));
         }
         let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
-        // Catalog value is the format-version byte. Zero-row tables have no
-        // rows to read it from, and a `[0x00]` sentinel would collide with
-        // TAG_INTEGER if a tool ran the catalog cell through the row parser.
-        self.tables
-            .put(&mut wtxn, name, &[crate::row_codec::FORMAT_VERSION])?;
+        // Catalog value is empty: the cell records existence only. Table-
+        // level metadata (schema, etc.) lands in a future PR.
+        self.tables.put(&mut wtxn, name, &[])?;
         Ok(TableWriter {
             wtxn,
             table,

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -21,12 +21,21 @@ const TABLES_DB: &str = "_tables";
 /// value format is deliberately left opaque until the table-registration PR.
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
-/// Row-store key codec: a `u64` row id, big-endian so LMDB's lexicographic key
-/// order matches numeric order.
-type RowKey = heed::types::U64<heed::byteorder::BigEndian>;
+/// Row-store key codec: an 8-byte big-endian `u64` row id passed as raw bytes.
+/// We use `heed::types::Bytes` (not `heed::types::U64<BigEndian>`) because
+/// `U64`'s `BytesEncode` impl heap-allocates an 8-byte `Vec` on every `put`,
+/// while `Bytes` returns `Cow::Borrowed(&[u8])` — zero allocations per row.
+/// Big-endian is preserved at the call site (the caller fills a stack-local
+/// `[u8; 8]` via `row_id.to_be_bytes()`); LMDB's B+tree keys are
+/// byte-comparison-ordered, so BE keeps lexicographic key order matching
+/// numeric order. Switching to LE would reverse iteration order and break
+/// PR4's row enumeration.
+type RowKey = heed::types::Bytes;
 
-/// A user table's row store: `u64` row-id keys to opaque byte values. PR 2
-/// writes a constant `&[0x00]` value per row; Ion-encoded values land in PR 3.
+/// A user table's row store: 8-byte big-endian `u64` row-id keys to opaque
+/// byte values. Storage is codec-agnostic — whatever bytes the caller pushes
+/// via the `create_table_from_rows` driver are persisted verbatim. The
+/// encoder lives in `crate::row_codec` since PR 3.
 type RowDb = heed::Database<RowKey, heed::types::Bytes>;
 
 /// Errors from opening or initializing the storage environment, or from
@@ -170,55 +179,70 @@ impl HeedDB {
         })
     }
 
-    /// Create a new table from a stream of rows, in a single write transaction.
+    /// Create a new table by driving a caller-supplied per-row writer in a
+    /// single write transaction.
     ///
-    /// PR 2 writes a constant `&[0x00]` value per row; Ion serialization lands
-    /// in PR 3. Only the transaction boundary, table creation, catalog
-    /// registration, and row-iteration loop are exercised here.
+    /// Storage opens the write txn, creates the row store, registers the
+    /// table in the catalog, then invokes `driver_closure` with a
+    /// `push_row(&[u8])` callback. The caller calls `push_row` once per
+    /// encoded row; storage assigns the next `u64` row-id and persists the
+    /// bytes verbatim. Any error from `driver_closure` or `push_row` drops
+    /// the `RwTxn` before commit, so LMDB rolls the whole operation back and
+    /// nothing partial persists.
+    ///
+    /// The push-callback shape lets the caller hand storage a `&[u8]`
+    /// borrowed from a reusable buffer instead of cloning per row.
     ///
     /// `name` must already be canonicalized by the caller (bare identifiers
     /// folded to lowercase, quoted identifiers verbatim). Returns the number
-    /// of rows written. Any error drops the `RwTxn` before commit, so LMDB
-    /// rolls the whole operation back and nothing partial persists.
-    pub fn create_table_from_rows<I>(&self, name: &str, rows: I) -> Result<u64, StorageError>
+    /// of rows written.
+    pub fn create_table_from_rows<F>(
+        &self,
+        name: &str,
+        mut driver_closure: F,
+    ) -> Result<u64, StorageError>
     where
-        I: IntoIterator<Item = Result<(), StorageError>>,
+        F: FnMut(&mut dyn FnMut(&[u8]) -> Result<(), StorageError>) -> Result<(), StorageError>,
     {
-        // Reserved-name guard runs FIRST, before any transaction. heed performs
-        // no runtime codec check when reopening a named db, so creating a table
-        // called `_tables` would reopen the catalog's own dbi with integer keys
-        // and corrupt it. Reject the whole `_` namespace up front.
+        // heed performs no runtime codec check when reopening a named db, so
+        // `CREATE TABLE _tables AS ...` would reopen the catalog's own dbi and
+        // corrupt it. Reject the whole `_` namespace before any transaction.
         if name.starts_with('_') {
             return Err(StorageError::ReservedName(name.to_string()));
         }
 
-        // A name with an interior NUL would panic heed's internal
-        // `CString::new(name).unwrap()` in `create_database`. Reject it here as a
-        // clean error rather than letting a user-supplied quoted identifier
-        // (e.g. `CREATE TABLE "a\0b" AS ...`) reach that unwrap.
+        // An interior NUL would panic heed's internal `CString::new(name)` in
+        // `create_database`. Reject it here as a clean error.
         if name.contains('\0') {
             return Err(StorageError::InvalidName(name.to_string()));
         }
 
         let mut wtxn = self.env.write_txn()?;
 
-        // Duplicate check against the catalog, in the same txn. `RwTxn` derefs
-        // to `RoTxn`, so the existence check and the creation are atomic.
+        // Dup check in the same txn (`RwTxn` derefs to `RoTxn`).
         if self.tables.get(&wtxn, name)?.is_some() {
             return Err(StorageError::TableExists(name.to_string()));
         }
 
-        // Create the per-table row store and register the table in the catalog.
         let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
-        self.tables.put(&mut wtxn, name, &[0x00])?;
+        // Catalog value records the row format version. PR 4's reader needs
+        // this on zero-row tables (no row bytes to peek for the version) and
+        // it avoids the [0x00] tag collision with `row_codec::TAG_INTEGER`.
+        self.tables
+            .put(&mut wtxn, name, &[crate::row_codec::FORMAT_VERSION])?;
 
-        // Dummy write loop: sequential u64 key, constant byte value.
         let mut row_id: u64 = 0;
-        for row in rows {
-            row?; // a VM error (Execution) bubbles out; dropping wtxn rolls back.
-            table.put(&mut wtxn, &row_id, &[0x00])?;
+        // Stack-local 8-byte key buffer reused across every push. Combined
+        // with `RowKey = heed::types::Bytes` (Cow::Borrowed), this gives
+        // zero heap allocations per row for the key side of the put.
+        let mut key_buf: [u8; 8] = [0u8; 8];
+        let mut push_row = |row_bytes: &[u8]| -> Result<(), StorageError> {
+            key_buf = row_id.to_be_bytes();
+            table.put(&mut wtxn, &key_buf[..], row_bytes)?;
             row_id += 1;
-        }
+            Ok(())
+        };
+        driver_closure(&mut push_row)?;
 
         wtxn.commit()?;
         Ok(row_id)
@@ -250,32 +274,47 @@ mod tests {
     use super::*;
 
     #[test]
-    fn create_table_from_rows_writes_all_rows_and_registers_catalog() {
+    fn create_table_from_rows_writes_bytes_verbatim_and_registers_catalog() {
+        // Bit-perfect roundtrip: storage's contract is "persist whatever bytes
+        // the caller pushes." A concrete sentinel sequence proves it.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ctas.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        let rows: Vec<Result<(), StorageError>> = vec![Ok(()), Ok(()), Ok(())];
-        let n = db.create_table_from_rows("widgets", rows).unwrap();
+        let payloads: [&[u8]; 3] = [
+            &[0xDE, 0xAD, 0xBE, 0xEF],
+            &[0x01],
+            &[0xFF, 0x00, 0xFF, 0x00, 0xFF],
+        ];
+        let n = db
+            .create_table_from_rows("widgets", |push_row| {
+                for p in payloads.iter() {
+                    push_row(p)?;
+                }
+                Ok(())
+            })
+            .unwrap();
         assert_eq!(n, 3);
 
         let rtxn = db.env().read_txn().unwrap();
-
-        // The table is registered in the catalog.
         assert!(
             db.tables().get(&rtxn, "widgets").unwrap().is_some(),
             "widgets should be registered in _tables"
         );
 
-        // The row store has exactly keys 0, 1, 2.
         let rowdb: RowDb = db
             .env()
             .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("widgets"))
             .unwrap()
             .expect("widgets row db should exist");
         assert_eq!(rowdb.len(&rtxn).unwrap(), 3);
-        for i in 0u64..3 {
-            assert!(rowdb.get(&rtxn, &i).unwrap().is_some(), "row {i} missing");
+        for (i, expected) in payloads.iter().enumerate() {
+            let key = (i as u64).to_be_bytes();
+            let got = rowdb
+                .get(&rtxn, &key[..])
+                .unwrap()
+                .expect("row should be present");
+            assert_eq!(got, *expected, "row {i} bytes must round-trip verbatim");
         }
     }
 
@@ -285,8 +324,9 @@ mod tests {
         let path = dir.path().join("empty.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        let rows: Vec<Result<(), StorageError>> = Vec::new();
-        let n = db.create_table_from_rows("blank", rows).unwrap();
+        let n = db
+            .create_table_from_rows("blank", |_push_row| Ok(()))
+            .unwrap();
         assert_eq!(n, 0);
 
         let rtxn = db.env().read_txn().unwrap();
@@ -305,16 +345,22 @@ mod tests {
         let path = dir.path().join("dup.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        db.create_table_from_rows("t", vec![Ok(()), Ok(())])
-            .unwrap();
+        db.create_table_from_rows("t", |push_row| {
+            push_row(&[])?;
+            push_row(&[])?;
+            Ok(())
+        })
+        .unwrap();
 
-        let again = db.create_table_from_rows("t", vec![Ok(())]);
+        let again = db.create_table_from_rows("t", |push_row| {
+            push_row(&[])?;
+            Ok(())
+        });
         assert!(
             matches!(again, Err(StorageError::TableExists(ref n)) if n == "t"),
             "second create should be TableExists, got: {again:?}"
         );
 
-        // The original table is untouched: catalog still has exactly one entry.
         let rtxn = db.env().read_txn().unwrap();
         assert_eq!(db.tables().len(&rtxn).unwrap(), 1);
     }
@@ -326,14 +372,17 @@ mod tests {
         let db = HeedDB::open(&path).unwrap();
 
         for name in ["_tables", "_indexes", "_x"] {
-            let res = db.create_table_from_rows(name, vec![Ok(())]);
+            let res = db.create_table_from_rows(name, |push_row| {
+                push_row(&[])?;
+                Ok(())
+            });
             assert!(
                 matches!(res, Err(StorageError::ReservedName(_))),
                 "{name} should be reserved, got: {res:?}"
             );
         }
 
-        // The guard runs before any transaction, so the catalog is untouched.
+        // Guard runs before any transaction, so the catalog is untouched.
         let rtxn = db.env().read_txn().unwrap();
         assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
     }
@@ -346,7 +395,10 @@ mod tests {
 
         // An interior NUL would otherwise panic heed's CString::new; the guard
         // turns it into a clean error and never opens a transaction.
-        let res = db.create_table_from_rows("a\0b", vec![Ok(())]);
+        let res = db.create_table_from_rows("a\0b", |push_row| {
+            push_row(&[])?;
+            Ok(())
+        });
         assert!(
             matches!(res, Err(StorageError::InvalidName(_))),
             "interior-NUL name should be InvalidName, got: {res:?}"
@@ -362,12 +414,11 @@ mod tests {
         let path = dir.path().join("rollback.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        let rows: Vec<Result<(), StorageError>> = vec![
-            Ok(()),
-            Ok(()),
-            Err(StorageError::Execution("boom".to_string())),
-        ];
-        let res = db.create_table_from_rows("partial", rows);
+        let res = db.create_table_from_rows("partial", |push_row| {
+            push_row(&[0xAA])?;
+            push_row(&[0xBB])?;
+            Err(StorageError::Execution("boom".to_string()))
+        });
         assert!(
             matches!(res, Err(StorageError::Execution(_))),
             "expected the mid-stream Execution error to surface, got: {res:?}"

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -99,9 +99,10 @@ pub enum StorageError {
     /// not depend on `partiql-eval`'s error type.
     Execution(String),
     /// A row-codec rejection (e.g. unsupported type/shape). The carried string
-    /// already reads as a complete error sentence (e.g. "unsupported: column
-    /// 'b': Bool — tag reserved..."); Display surfaces it verbatim so stderr
-    /// stays single-level ("Error: unsupported: ..."), matching PartiQL's style.
+    /// already reads as a complete error sentence (e.g. "unsupported: field
+    /// 'b': Bool is not yet supported"); Display surfaces it verbatim so
+    /// stderr stays single-level ("Error: unsupported: ..."), matching
+    /// PartiQL's style.
     Codec(String),
 }
 
@@ -229,7 +230,7 @@ impl HeedDB {
     /// Open a write handle for a new table named `name`.
     ///
     /// Runs all up-front catalog work (reserved-name guard, NUL guard, dup
-    /// check, format-version write) and opens a write transaction. The
+    /// check, catalog registration) and opens a write transaction. The
     /// returned `TableWriter` lives until `commit` (success) or drop
     /// (rollback). `name` must already be canonicalized by the caller —
     /// bare identifiers folded to lowercase, quoted identifiers verbatim.

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -625,16 +625,17 @@ fn ctas_scalar_and_string_boundaries() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
-fn ctas_rejects_bool_at_preflight_with_pointed_message() {
-    // The preflight pass must reject a Bool column before any bytes are
-    // written. Verifies both the rejection and the error wording.
+fn ctas_rejects_bool_with_pointed_message() {
+    // The encoder must reject a Bool column mid-stream. Err propagates so
+    // the wtxn rolls back; the env file may persist but the catalog stays
+    // clean.
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("bool.pqlite");
     let (ok, _stdout, stderr) = run_exec(
         "CREATE TABLE t AS (SELECT true AS b FROM mem(1,1) m)",
         Some(&db_path),
     );
-    assert!(!ok, "Bool column must trip preflight; stderr: {stderr}");
+    assert!(!ok, "Bool column must be rejected; stderr: {stderr}");
     assert!(
         stderr.contains("column 'b'") && stderr.contains("Bool"),
         "error must name the column and the rejected type; got: {stderr}",

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -177,3 +177,464 @@ fn duplicate_ctas_is_rejected_and_names_the_table() {
         "duplicate error should name the table, got: {stderr2}"
     );
 }
+
+// ── PR3 wire-format parser (hand-written, mirrors row_codec spec) ────────────
+
+use partiql_tools::row_codec::{
+    FORMAT_VERSION, MAX_FIELDS_PER_ROW, MAX_NAME_LEN_BYTES, TAG_DECIMAL, TAG_FLOAT, TAG_INTEGER,
+    TAG_NULL, TAG_STRING, TAG_STRUCT,
+};
+
+#[derive(Debug, PartialEq)]
+enum ParsedValue {
+    Integer(i64),
+    Decimal { scale: i32, mantissa: i128 },
+    Float(f64),
+    String(String),
+    Null,
+}
+
+#[derive(Debug)]
+struct ParsedRow {
+    fields: Vec<(String, ParsedValue)>,
+}
+
+/// Mirror of the PR3 wire-format spec. Returns ParsedRow or panics with a
+/// pointed message — these are tests, not a production reader.
+///
+/// Imports `FORMAT_VERSION`, `TAG_*`, `MAX_FIELDS_PER_ROW`, and
+/// `MAX_NAME_LEN_BYTES` from `partiql_tools::row_codec` so a tag-byte change
+/// or cap change in the encoder cannot drift here.
+///
+/// ENDIANNESS INVARIANT: every multi-byte field is little-endian, matching
+/// `row_codec::serialize_row`'s `to_le_bytes()` calls. If you add a new tag
+/// here, the corresponding encoder write MUST use `to_le_bytes()` and this
+/// reader MUST use `from_le_bytes()` — an LE/BE asymmetry compiles cleanly
+/// and silently corrupts every persisted row.
+fn parse_row(bytes: &[u8]) -> ParsedRow {
+    fn take<'a>(i: &mut usize, n: usize, bytes: &'a [u8]) -> &'a [u8] {
+        assert!(
+            *i + n <= bytes.len(),
+            "ran off the end at offset {i} taking {n}"
+        );
+        let s = &bytes[*i..*i + n];
+        *i += n;
+        s
+    }
+    fn take_u32(i: &mut usize, bytes: &[u8]) -> u32 {
+        u32::from_le_bytes(take(i, 4, bytes).try_into().unwrap())
+    }
+    fn take_i32(i: &mut usize, bytes: &[u8]) -> i32 {
+        i32::from_le_bytes(take(i, 4, bytes).try_into().unwrap())
+    }
+    fn take_i64(i: &mut usize, bytes: &[u8]) -> i64 {
+        i64::from_le_bytes(take(i, 8, bytes).try_into().unwrap())
+    }
+    fn take_f64(i: &mut usize, bytes: &[u8]) -> f64 {
+        f64::from_le_bytes(take(i, 8, bytes).try_into().unwrap())
+    }
+    fn take_i128(i: &mut usize, bytes: &[u8]) -> i128 {
+        i128::from_le_bytes(take(i, 16, bytes).try_into().unwrap())
+    }
+
+    let mut i = 0usize;
+    assert_eq!(
+        take(&mut i, 1, bytes)[0],
+        FORMAT_VERSION,
+        "format version must be FORMAT_VERSION ({FORMAT_VERSION:#04x})"
+    );
+    assert_eq!(
+        take(&mut i, 1, bytes)[0],
+        TAG_STRUCT,
+        "row tag must be TAG_STRUCT ({TAG_STRUCT:#04x})"
+    );
+    let field_count = take_u32(&mut i, bytes);
+    // Mirror the encoder's MAX_FIELDS_PER_ROW cap: a corrupt/oversize count
+    // would otherwise OOM the test runner via Vec::with_capacity.
+    assert!(
+        field_count <= MAX_FIELDS_PER_ROW,
+        "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
+    );
+
+    let mut fields = Vec::with_capacity(field_count as usize);
+    for _ in 0..field_count {
+        let name_len = take_u32(&mut i, bytes);
+        assert!(
+            name_len <= MAX_NAME_LEN_BYTES,
+            "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
+        );
+        let name = std::str::from_utf8(take(&mut i, name_len as usize, bytes))
+            .expect("field name must be valid UTF-8")
+            .to_string();
+        let tag = take(&mut i, 1, bytes)[0];
+        let value = match tag {
+            t if t == TAG_INTEGER => ParsedValue::Integer(take_i64(&mut i, bytes)),
+            t if t == TAG_DECIMAL => {
+                let scale = take_i32(&mut i, bytes);
+                let mantissa = take_i128(&mut i, bytes);
+                ParsedValue::Decimal { scale, mantissa }
+            }
+            t if t == TAG_FLOAT => ParsedValue::Float(take_f64(&mut i, bytes)),
+            t if t == TAG_STRING => {
+                let len = take_u32(&mut i, bytes) as usize;
+                ParsedValue::String(
+                    std::str::from_utf8(take(&mut i, len, bytes))
+                        .expect("string must be valid UTF-8")
+                        .to_string(),
+                )
+            }
+            t if t == TAG_NULL => ParsedValue::Null,
+            other => panic!("unknown tag {other:#04x} at offset {}", i - 1),
+        };
+        fields.push((name, value));
+    }
+    assert_eq!(
+        i,
+        bytes.len(),
+        "parser left {} trailing bytes",
+        bytes.len() - i
+    );
+    ParsedRow { fields }
+}
+
+/// Read every row in table `t` from the .pqlite file at `db_path`, returning
+/// ParsedRow values in row_id order.
+fn read_all_rows(db_path: &std::path::Path, table: &str) -> Vec<ParsedRow> {
+    let env = unsafe {
+        heed::EnvOpenOptions::new()
+            .map_size(1024 * 1024 * 1024)
+            .max_dbs(128)
+            .flags(heed::EnvFlags::NO_SUB_DIR)
+            .open(db_path)
+            .expect("re-open env")
+    };
+    let rtxn = env.read_txn().expect("read txn");
+    // Key codec matches storage: BE u64 bytes under `heed::types::Bytes`
+    // (storage switched from `U64<BigEndian>` to `Bytes` to drop the per-put
+    // Vec allocation; BE byte order preserves numeric key ordering).
+    let rowdb: heed::Database<heed::types::Bytes, heed::types::Bytes> = env
+        .open_database(&rtxn, Some(table))
+        .expect("open row db")
+        .expect("row db must exist");
+    let mut out = Vec::new();
+    for entry in rowdb.iter(&rtxn).expect("iter rows") {
+        let (_row_id, payload) = entry.expect("row entry");
+        out.push(parse_row(payload));
+    }
+    out
+}
+
+// ── PR3 tests ────────────────────────────────────────────────────────────────
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_persists_tagged_union_rows() {
+    // mem(3,2) yields i64 rows with column `a` taking 0, 1, 2.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("rt.pqlite");
+    let (ok, _stdout, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT t.a FROM mem(3,2) t)",
+        Some(&db_path),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+    assert!(db_path.is_file());
+
+    let rows = read_all_rows(&db_path, "t");
+    assert_eq!(rows.len(), 3, "expected 3 rows; got: {rows:?}");
+    for (idx, row) in rows.iter().enumerate() {
+        assert_eq!(row.fields.len(), 1, "row {idx}: expected 1 field");
+        let (name, value) = &row.fields[0];
+        assert_eq!(name, "a", "row {idx}: field name should be `a`");
+        match value {
+            ParsedValue::Integer(v) => {
+                assert_eq!(*v as usize, idx, "row {idx}: value should equal row index");
+            }
+            other => panic!("row {idx}: expected Integer, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
+    // Guard the two paths that mem(3,2)'s small rows don't exercise:
+    //   1) the reusable Vec<u8> in pqlite's CTAS arm grows past its 4 KiB
+    //      initial capacity (Vec doubles its allocation)
+    //   2) LMDB routes the value onto overflow pages (heed wraps mdb_put
+    //      which handles this transparently)
+    //
+    // We synthesize the oversize row via a 16 KiB string LITERAL embedded in
+    // the SQL projection, joined with mem(1,2) to satisfy the planner's
+    // FROM-clause requirement. This avoids adding a test-only table
+    // function to the production binary — the literal is materialized once
+    // by the parser and lives only for the duration of this CTAS.
+    const PAYLOAD_SIZE: usize = 16 * 1024;
+    let big_string: String = "x".repeat(PAYLOAD_SIZE);
+    let query = format!(
+        "CREATE TABLE t AS (SELECT '{}' AS s FROM mem(1,2) m)",
+        big_string
+    );
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("oversize.pqlite");
+    let (ok, _stdout, stderr) = run_exec(&query, Some(&db_path));
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+
+    let rows = read_all_rows(&db_path, "t");
+    assert_eq!(rows.len(), 1, "expected exactly 1 row; got: {}", rows.len());
+    assert_eq!(rows[0].fields.len(), 1, "row should have exactly one field");
+    let (name, value) = &rows[0].fields[0];
+    assert_eq!(name, "s", "field name should be `s`");
+    match value {
+        ParsedValue::String(s) => {
+            assert_eq!(
+                s.len(),
+                PAYLOAD_SIZE,
+                "string must be exactly {PAYLOAD_SIZE} bytes; got len={}",
+                s.len()
+            );
+            assert!(
+                s.chars().all(|c| c == 'x'),
+                "every char should be 'x' (corruption check)"
+            );
+        }
+        other => panic!("expected String, got {other:?}"),
+    }
+}
+
+// ── PR3 adversarial + boundary tests (Task 7 follow-up) ──────────────────────
+
+#[test]
+fn parser_adversarial_truncation_walk() {
+    // Hand-crafted valid 1-column row mirroring row_codec's wire format:
+    //   version(0x01), struct_tag(0x03),
+    //   field_count(1 u32 LE), name_len(1 u32 LE), name "a",
+    //   tag 0x00 (Integer), value 42 (i64 LE). 20 bytes total.
+    let valid_bytes: [u8; 20] = [
+        FORMAT_VERSION,
+        TAG_STRUCT,
+        0x01,
+        0x00,
+        0x00,
+        0x00, // field_count = 1
+        0x01,
+        0x00,
+        0x00,
+        0x00, // name_len = 1
+        b'a', // name
+        TAG_INTEGER,
+        0x2a,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00, // i64 LE = 42
+    ];
+
+    // Sanity: the full payload parses cleanly. If this fails, the loop below
+    // is testing the wrong baseline.
+    let row = parse_row(&valid_bytes);
+    assert_eq!(row.fields.len(), 1);
+    assert_eq!(row.fields[0].0, "a");
+    assert_eq!(row.fields[0].1, ParsedValue::Integer(42));
+
+    // Truncate at every offset 0..20. Every truncation MUST panic — never
+    // return a half-parsed ParsedRow, never read OOB. catch_unwind verifies
+    // the parser exits via a panic, not via a normal return.
+    for len in 0..valid_bytes.len() {
+        let truncated = &valid_bytes[..len];
+        let result = std::panic::catch_unwind(|| parse_row(truncated));
+        assert!(
+            result.is_err(),
+            "parser returned without panicking on truncation len={len}: must never return half-parsed bytes",
+        );
+    }
+}
+
+/// Extract the message string from a `catch_unwind` payload. Panic messages
+/// land as either `&'static str` or `String` depending on whether the panic
+/// site used `panic!("literal")` or formatted via `assert!(..., "msg")`.
+fn panic_message(err: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = err.downcast_ref::<String>() {
+        return s.clone();
+    }
+    if let Some(s) = err.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    String::from("<non-string panic payload>")
+}
+
+#[test]
+fn parser_sanity_cap_field_count_trips_before_allocation() {
+    // version + struct_tag + field_count = MAX_FIELDS_PER_ROW + 1 (= 1025,
+    // LE: 0x01 0x04 0x00 0x00). The cap rejects values > MAX_FIELDS_PER_ROW.
+    //
+    // The assertion pins the panic SOURCE to the sanity cap by matching the
+    // message text. A naive `result.is_err()` would silently pass if the cap
+    // were deleted (the downstream `take()` bounds-check would fire instead
+    // on this exact 6-byte payload). Matching `"sanity:"` and `"field_count"`
+    // makes cap removal, cap weakening, and cap-position regressions all
+    // surface a different message ("ran off the end ...") and fail this test.
+    let payload: [u8; 6] = [FORMAT_VERSION, TAG_STRUCT, 0x01, 0x04, 0x00, 0x00];
+    assert_eq!(
+        u32::from_le_bytes([0x01, 0x04, 0x00, 0x00]),
+        MAX_FIELDS_PER_ROW + 1,
+        "fixture must encode exactly MAX_FIELDS_PER_ROW + 1",
+    );
+    let result = std::panic::catch_unwind(|| parse_row(&payload));
+    let msg =
+        panic_message(result.expect_err("sanity cap must reject field_count > MAX_FIELDS_PER_ROW"));
+    assert!(
+        msg.contains("sanity:") && msg.contains("field_count"),
+        "expected the field_count sanity-cap panic; got: {msg}",
+    );
+}
+
+#[test]
+fn parser_sanity_cap_name_len_trips_before_allocation() {
+    // version + struct_tag + field_count=1 + name_len = MAX_NAME_LEN_BYTES + 1
+    // (= 1_048_577, LE: 0x01 0x00 0x10 0x00). The cap rejects name_len values
+    // > MAX_NAME_LEN_BYTES before attempting to read the name bytes.
+    //
+    // As with the field_count sibling, the assertion pins the panic SOURCE
+    // to the sanity cap by matching the message. Without this, removing or
+    // weakening the cap would still leave `take()`'s OOB check to fire,
+    // silently passing the test while shipping a real OOM regression.
+    let payload: [u8; 10] = [
+        FORMAT_VERSION,
+        TAG_STRUCT,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x10,
+        0x00,
+    ];
+    assert_eq!(
+        u32::from_le_bytes([0x01, 0x00, 0x10, 0x00]),
+        MAX_NAME_LEN_BYTES + 1,
+        "fixture must encode exactly MAX_NAME_LEN_BYTES + 1",
+    );
+    let result = std::panic::catch_unwind(|| parse_row(&payload));
+    let msg =
+        panic_message(result.expect_err("sanity cap must reject name_len > MAX_NAME_LEN_BYTES"));
+    assert!(
+        msg.contains("sanity:") && msg.contains("name_len"),
+        "expected the name_len sanity-cap panic; got: {msg}",
+    );
+}
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_scalar_and_string_boundaries() {
+    // Boundary values that exercise the LE byte-packing edges:
+    //   * i64::MAX (9_223_372_036_854_775_807) — every i64 bit position used
+    //   * negative Float / Decimal literal — sign bit + non-trivial mantissa
+    //   * 0.0000 — zero mantissa with non-zero scale (proves scale survives)
+    //   * empty string — proves length-prefix handles len=0 correctly
+    //
+    // We do NOT include i64::MIN — the PartiQL parser rejects the literal
+    // `-9223372036854775808` because it tokenizes as unary-minus applied to
+    // `9223372036854775808` (= i64::MAX + 1) which overflows i64. That is a
+    // parser-level constraint, not an encoder one; out of scope here.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("boundaries.pqlite");
+    let (ok, _stdout, stderr) = run_exec(
+        "CREATE TABLE t AS (            SELECT                 9223372036854775807 AS max_int,                -12345.6789 AS neg_float,                0.0000 AS zero_dec,                '' AS empty_str             FROM mem(1,1) m         )",
+        Some(&db_path),
+    );
+    assert!(ok, "boundary CTAS failed; stderr: {stderr}");
+
+    let rows = read_all_rows(&db_path, "t");
+    assert_eq!(rows.len(), 1);
+    let fields: std::collections::HashMap<String, ParsedValue> = rows
+        .into_iter()
+        .next()
+        .unwrap()
+        .fields
+        .into_iter()
+        .collect();
+
+    // i64::MAX must round-trip exactly — proves the high bit of the i64 LE
+    // encoding survives the to_le_bytes/from_le_bytes round trip.
+    assert_eq!(
+        fields.get("max_int"),
+        Some(&ParsedValue::Integer(i64::MAX)),
+        "i64::MAX must round-trip exactly",
+    );
+
+    // PartiQL may type `-12345.6789` as either Float or Decimal depending on
+    // planner literal-typing rules. Accept either; the numeric value must
+    // round-trip in both representations.
+    let neg = fields.get("neg_float").expect("neg_float column missing");
+    match neg {
+        ParsedValue::Float(v) => assert!(
+            (*v - (-12345.6789_f64)).abs() < 1e-9,
+            "negative float should round-trip: got {v}",
+        ),
+        ParsedValue::Decimal { scale, mantissa } => {
+            let reconstructed = (*mantissa as f64) / 10f64.powi(*scale);
+            assert!(
+                (reconstructed - (-12345.6789_f64)).abs() < 1e-9,
+                "negative decimal should round-trip: mantissa={mantissa} scale={scale}",
+            );
+        }
+        other => panic!("expected Float or Decimal for -12345.6789, got {other:?}"),
+    }
+
+    // 0.0000 must preserve scale even with mantissa=0 — load-bearing
+    // assertion for our 20-byte decimal encoding (4-byte i32 scale +
+    // 16-byte i128 mantissa). A bug that dropped scale would still pass an
+    // `== 0` check but corrupt non-zero decimals.
+    match fields.get("zero_dec").expect("zero_dec column missing") {
+        ParsedValue::Decimal { scale, mantissa } => {
+            assert_eq!(*mantissa, 0, "0.0000 mantissa must be exactly 0");
+            assert!(
+                *scale >= 1,
+                "0.0000 must preserve a non-zero scale, got {scale}"
+            );
+        }
+        other => panic!("expected Decimal for 0.0000, got {other:?}"),
+    }
+
+    // Empty string proves the u32 length prefix handles len=0 cleanly.
+    assert_eq!(
+        fields.get("empty_str"),
+        Some(&ParsedValue::String(String::new())),
+        "empty string must round-trip with len=0 in the u32 length prefix",
+    );
+}
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_rejects_bool_at_preflight_with_pointed_message() {
+    // Bool's tag (0x08) is reserved in PR3 — the encoder's preflight pass MUST
+    // reject the row before writing any bytes. Verifies both the rejection AND
+    // the error wording. Future PR4+ flipping Bool from reject to implement
+    // should DELETE this test, forcing a deliberate format decision rather
+    // than silently flipping it green via wording change.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("bool.pqlite");
+    let (ok, _stdout, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT true AS b FROM mem(1,1) m)",
+        Some(&db_path),
+    );
+    assert!(!ok, "Bool column must trip preflight; stderr: {stderr}");
+    assert!(
+        stderr.contains("column 'b': Bool") && stderr.contains("tag reserved"),
+        "error must name the column and mention the tag reservation; got: {stderr}",
+    );
+    // FS-contract: a row-0 schema rejection must leave the filesystem
+    // untouched. This is the load-bearing invariant of the peek-then-open
+    // pattern in the CTAS arm; without this assert, a regression that opens
+    // the env before the first-row peek would silently pass every other
+    // assertion in this test.
+    assert!(
+        !db_path.exists(),
+        "A row-0 schema rejection must leave a zero-byte file footprint on the user's disk."
+    );
+}

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -178,7 +178,7 @@ fn duplicate_ctas_is_rejected_and_names_the_table() {
     );
 }
 
-// ── PR3 wire-format parser (hand-written, mirrors row_codec spec) ────────────
+// Wire-format parser (hand-written, mirrors row_codec spec).
 
 use partiql_tools::row_codec::{
     FORMAT_VERSION, MAX_FIELDS_PER_ROW, MAX_NAME_LEN_BYTES, TAG_DECIMAL, TAG_FLOAT, TAG_INTEGER,
@@ -196,21 +196,28 @@ enum ParsedValue {
 
 #[derive(Debug)]
 struct ParsedRow {
-    fields: Vec<(String, ParsedValue)>,
+    payload: ParsedPayload,
 }
 
-/// Mirror of the PR3 wire-format spec. Returns ParsedRow or panics with a
-/// pointed message — these are tests, not a production reader.
+#[derive(Debug)]
+enum ParsedPayload {
+    /// Top-level TAG_STRUCT: a struct of named fields.
+    Struct(Vec<(String, ParsedValue)>),
+    /// Top-level scalar tag (Integer/Decimal/Float/String/Null).
+    Scalar(ParsedValue),
+}
+
+/// Mirror of the wire-format spec. Returns `ParsedRow` or panics with a
+/// pointed message; this is a test helper, not a production reader.
 ///
 /// Imports `FORMAT_VERSION`, `TAG_*`, `MAX_FIELDS_PER_ROW`, and
-/// `MAX_NAME_LEN_BYTES` from `partiql_tools::row_codec` so a tag-byte change
-/// or cap change in the encoder cannot drift here.
+/// `MAX_NAME_LEN_BYTES` from `partiql_tools::row_codec` so a tag-byte or
+/// cap change in the encoder cannot drift here.
 ///
 /// ENDIANNESS INVARIANT: every multi-byte field is little-endian, matching
-/// `row_codec::serialize_row`'s `to_le_bytes()` calls. If you add a new tag
-/// here, the corresponding encoder write MUST use `to_le_bytes()` and this
-/// reader MUST use `from_le_bytes()` — an LE/BE asymmetry compiles cleanly
-/// and silently corrupts every persisted row.
+/// `row_codec::serialize_row`'s `to_le_bytes()` calls. A new tag must be
+/// written `to_le_bytes()` there AND read `from_le_bytes()` here — an
+/// asymmetry compiles cleanly and silently corrupts every persisted row.
 fn parse_row(bytes: &[u8]) -> ParsedRow {
     fn take<'a>(i: &mut usize, n: usize, bytes: &'a [u8]) -> &'a [u8] {
         assert!(
@@ -236,6 +243,27 @@ fn parse_row(bytes: &[u8]) -> ParsedRow {
     fn take_i128(i: &mut usize, bytes: &[u8]) -> i128 {
         i128::from_le_bytes(take(i, 16, bytes).try_into().unwrap())
     }
+    fn take_value(i: &mut usize, bytes: &[u8], tag: u8) -> ParsedValue {
+        match tag {
+            t if t == TAG_INTEGER => ParsedValue::Integer(take_i64(i, bytes)),
+            t if t == TAG_DECIMAL => {
+                let scale = take_i32(i, bytes);
+                let mantissa = take_i128(i, bytes);
+                ParsedValue::Decimal { scale, mantissa }
+            }
+            t if t == TAG_FLOAT => ParsedValue::Float(take_f64(i, bytes)),
+            t if t == TAG_STRING => {
+                let len = take_u32(i, bytes) as usize;
+                ParsedValue::String(
+                    std::str::from_utf8(take(i, len, bytes))
+                        .expect("string must be valid UTF-8")
+                        .to_string(),
+                )
+            }
+            t if t == TAG_NULL => ParsedValue::Null,
+            other => panic!("unknown tag {other:#04x} at offset {}", *i - 1),
+        }
+    }
 
     let mut i = 0usize;
     assert_eq!(
@@ -243,58 +271,37 @@ fn parse_row(bytes: &[u8]) -> ParsedRow {
         FORMAT_VERSION,
         "format version must be FORMAT_VERSION ({FORMAT_VERSION:#04x})"
     );
-    assert_eq!(
-        take(&mut i, 1, bytes)[0],
-        TAG_STRUCT,
-        "row tag must be TAG_STRUCT ({TAG_STRUCT:#04x})"
-    );
-    let field_count = take_u32(&mut i, bytes);
-    // Mirror the encoder's MAX_FIELDS_PER_ROW cap: a corrupt/oversize count
-    // would otherwise OOM the test runner via Vec::with_capacity.
-    assert!(
-        field_count <= MAX_FIELDS_PER_ROW,
-        "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
-    );
-
-    let mut fields = Vec::with_capacity(field_count as usize);
-    for _ in 0..field_count {
-        let name_len = take_u32(&mut i, bytes);
+    let top_tag = take(&mut i, 1, bytes)[0];
+    let payload = if top_tag == TAG_STRUCT {
+        let field_count = take_u32(&mut i, bytes);
         assert!(
-            name_len <= MAX_NAME_LEN_BYTES,
-            "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
+            field_count <= MAX_FIELDS_PER_ROW,
+            "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
         );
-        let name = std::str::from_utf8(take(&mut i, name_len as usize, bytes))
-            .expect("field name must be valid UTF-8")
-            .to_string();
-        let tag = take(&mut i, 1, bytes)[0];
-        let value = match tag {
-            t if t == TAG_INTEGER => ParsedValue::Integer(take_i64(&mut i, bytes)),
-            t if t == TAG_DECIMAL => {
-                let scale = take_i32(&mut i, bytes);
-                let mantissa = take_i128(&mut i, bytes);
-                ParsedValue::Decimal { scale, mantissa }
-            }
-            t if t == TAG_FLOAT => ParsedValue::Float(take_f64(&mut i, bytes)),
-            t if t == TAG_STRING => {
-                let len = take_u32(&mut i, bytes) as usize;
-                ParsedValue::String(
-                    std::str::from_utf8(take(&mut i, len, bytes))
-                        .expect("string must be valid UTF-8")
-                        .to_string(),
-                )
-            }
-            t if t == TAG_NULL => ParsedValue::Null,
-            other => panic!("unknown tag {other:#04x} at offset {}", i - 1),
-        };
-        fields.push((name, value));
-    }
+        let mut fields = Vec::with_capacity(field_count as usize);
+        for _ in 0..field_count {
+            let name_len = take_u32(&mut i, bytes);
+            assert!(
+                name_len <= MAX_NAME_LEN_BYTES,
+                "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
+            );
+            let name = std::str::from_utf8(take(&mut i, name_len as usize, bytes))
+                .expect("field name must be valid UTF-8")
+                .to_string();
+            let tag = take(&mut i, 1, bytes)[0];
+            fields.push((name, take_value(&mut i, bytes, tag)));
+        }
+        ParsedPayload::Struct(fields)
+    } else {
+        ParsedPayload::Scalar(take_value(&mut i, bytes, top_tag))
+    };
     assert_eq!(
         i,
         bytes.len(),
         "parser left {} trailing bytes",
         bytes.len() - i
     );
-    ParsedRow { fields }
+    ParsedRow { payload }
 }
 
 /// Read every row in table `t` from the .pqlite file at `db_path`, returning
@@ -324,8 +331,6 @@ fn read_all_rows(db_path: &std::path::Path, table: &str) -> Vec<ParsedRow> {
     out
 }
 
-// ── PR3 tests ────────────────────────────────────────────────────────────────
-
 #[test]
 #[cfg_attr(windows, ignore)]
 fn ctas_persists_tagged_union_rows() {
@@ -342,8 +347,12 @@ fn ctas_persists_tagged_union_rows() {
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 3, "expected 3 rows; got: {rows:?}");
     for (idx, row) in rows.iter().enumerate() {
-        assert_eq!(row.fields.len(), 1, "row {idx}: expected 1 field");
-        let (name, value) = &row.fields[0];
+        let fields = match &row.payload {
+            ParsedPayload::Struct(f) => f,
+            other => panic!("row {idx}: expected Struct, got {other:?}"),
+        };
+        assert_eq!(fields.len(), 1, "row {idx}: expected 1 field");
+        let (name, value) = &fields[0];
         assert_eq!(name, "a", "row {idx}: field name should be `a`");
         match value {
             ParsedValue::Integer(v) => {
@@ -382,8 +391,12 @@ fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
 
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 1, "expected exactly 1 row; got: {}", rows.len());
-    assert_eq!(rows[0].fields.len(), 1, "row should have exactly one field");
-    let (name, value) = &rows[0].fields[0];
+    let fields = match &rows[0].payload {
+        ParsedPayload::Struct(f) => f,
+        other => panic!("expected Struct payload, got {other:?}"),
+    };
+    assert_eq!(fields.len(), 1, "row should have exactly one field");
+    let (name, value) = &fields[0];
     assert_eq!(name, "s", "field name should be `s`");
     match value {
         ParsedValue::String(s) => {
@@ -401,8 +414,6 @@ fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
         other => panic!("expected String, got {other:?}"),
     }
 }
-
-// ── PR3 adversarial + boundary tests (Task 7 follow-up) ──────────────────────
 
 #[test]
 fn parser_adversarial_truncation_walk() {
@@ -436,9 +447,13 @@ fn parser_adversarial_truncation_walk() {
     // Sanity: the full payload parses cleanly. If this fails, the loop below
     // is testing the wrong baseline.
     let row = parse_row(&valid_bytes);
-    assert_eq!(row.fields.len(), 1);
-    assert_eq!(row.fields[0].0, "a");
-    assert_eq!(row.fields[0].1, ParsedValue::Integer(42));
+    let fields = match &row.payload {
+        ParsedPayload::Struct(f) => f,
+        other => panic!("expected Struct payload, got {other:?}"),
+    };
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].0, "a");
+    assert_eq!(fields[0].1, ParsedValue::Integer(42));
 
     // Truncate at every offset 0..20. Every truncation MUST panic — never
     // return a half-parsed ParsedRow, never read OOB. catch_unwind verifies
@@ -551,13 +566,12 @@ fn ctas_scalar_and_string_boundaries() {
 
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 1);
-    let fields: std::collections::HashMap<String, ParsedValue> = rows
-        .into_iter()
-        .next()
-        .unwrap()
-        .fields
-        .into_iter()
-        .collect();
+    let struct_fields = match rows.into_iter().next().unwrap().payload {
+        ParsedPayload::Struct(f) => f,
+        other => panic!("expected Struct payload, got {other:?}"),
+    };
+    let fields: std::collections::HashMap<String, ParsedValue> =
+        struct_fields.into_iter().collect();
 
     // i64::MAX must round-trip exactly — proves the high bit of the i64 LE
     // encoding survives the to_le_bytes/from_le_bytes round trip.
@@ -612,11 +626,8 @@ fn ctas_scalar_and_string_boundaries() {
 #[test]
 #[cfg_attr(windows, ignore)]
 fn ctas_rejects_bool_at_preflight_with_pointed_message() {
-    // Bool's tag (0x08) is reserved in PR3 — the encoder's preflight pass MUST
-    // reject the row before writing any bytes. Verifies both the rejection AND
-    // the error wording. Future PR4+ flipping Bool from reject to implement
-    // should DELETE this test, forcing a deliberate format decision rather
-    // than silently flipping it green via wording change.
+    // The preflight pass must reject a Bool column before any bytes are
+    // written. Verifies both the rejection and the error wording.
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("bool.pqlite");
     let (ok, _stdout, stderr) = run_exec(
@@ -625,16 +636,50 @@ fn ctas_rejects_bool_at_preflight_with_pointed_message() {
     );
     assert!(!ok, "Bool column must trip preflight; stderr: {stderr}");
     assert!(
-        stderr.contains("column 'b': Bool") && stderr.contains("tag reserved"),
-        "error must name the column and mention the tag reservation; got: {stderr}",
+        stderr.contains("column 'b'") && stderr.contains("Bool"),
+        "error must name the column and the rejected type; got: {stderr}",
     );
-    // FS-contract: a row-0 schema rejection must leave the filesystem
-    // untouched. This is the load-bearing invariant of the peek-then-open
-    // pattern in the CTAS arm; without this assert, a regression that opens
-    // the env before the first-row peek would silently pass every other
-    // assertion in this test.
+    // Verify wtxn rollback by re-opening: the env file may persist on disk,
+    // but the catalog must not register `t`.
+    let env = unsafe {
+        heed::EnvOpenOptions::new()
+            .map_size(1024 * 1024 * 1024)
+            .max_dbs(128)
+            .flags(heed::EnvFlags::NO_SUB_DIR)
+            .open(&db_path)
+            .expect("re-open env")
+    };
+    let rtxn = env.read_txn().expect("read txn");
+    let catalog: heed::Database<heed::types::Str, heed::types::Bytes> = env
+        .open_database(&rtxn, Some("_tables"))
+        .expect("open catalog")
+        .expect("catalog must exist");
     assert!(
-        !db_path.exists(),
-        "A row-0 schema rejection must leave a zero-byte file footprint on the user's disk."
+        catalog.get(&rtxn, "t").expect("catalog get").is_none(),
+        "row-0 rejection must leave catalog clean even if env file persists"
     );
+}
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_persists_bare_scalar_rows() {
+    // Top-level shape is RowShape::Register(_) — a bag of scalars, not a
+    // bag of structs. Encoder writes ver + TAG_INTEGER + i64 LE per row.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("scalar.pqlite");
+    let (ok, _stdout, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE t.a FROM mem(3,2) t)",
+        Some(&db_path),
+    );
+    assert!(ok, "bare-scalar CTAS should succeed; stderr: {stderr}");
+    let rows = read_all_rows(&db_path, "t");
+    assert_eq!(rows.len(), 3, "expected 3 scalar rows; got: {rows:?}");
+    for (idx, row) in rows.iter().enumerate() {
+        match &row.payload {
+            ParsedPayload::Scalar(ParsedValue::Integer(v)) => {
+                assert_eq!(*v as usize, idx, "row {idx}: value should equal row index");
+            }
+            other => panic!("row {idx}: expected scalar Integer, got {other:?}"),
+        }
+    }
 }

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -181,8 +181,8 @@ fn duplicate_ctas_is_rejected_and_names_the_table() {
 // Wire-format parser (hand-written, mirrors row_codec spec).
 
 use partiql_tools::row_codec::{
-    FORMAT_VERSION, MAX_FIELDS_PER_ROW, MAX_NAME_LEN_BYTES, TAG_DECIMAL, TAG_FLOAT, TAG_INTEGER,
-    TAG_NULL, TAG_STRING, TAG_STRUCT,
+    MAX_FIELDS_PER_ROW, MAX_NAME_LEN_BYTES, TAG_DECIMAL, TAG_FLOAT, TAG_INTEGER, TAG_NULL,
+    TAG_STRING, TAG_TUPLE,
 };
 
 #[derive(Debug, PartialEq)]
@@ -192,33 +192,21 @@ enum ParsedValue {
     Float(f64),
     String(String),
     Null,
+    Tuple(Vec<(String, ParsedValue)>),
 }
 
-#[derive(Debug)]
-struct ParsedRow {
-    payload: ParsedPayload,
-}
-
-#[derive(Debug)]
-enum ParsedPayload {
-    /// Top-level TAG_STRUCT: a struct of named fields.
-    Struct(Vec<(String, ParsedValue)>),
-    /// Top-level scalar tag (Integer/Decimal/Float/String/Null).
-    Scalar(ParsedValue),
-}
-
-/// Mirror of the wire-format spec. Returns `ParsedRow` or panics with a
+/// Mirror of the wire-format spec. Returns `ParsedValue` or panics with a
 /// pointed message; this is a test helper, not a production reader.
 ///
-/// Imports `FORMAT_VERSION`, `TAG_*`, `MAX_FIELDS_PER_ROW`, and
-/// `MAX_NAME_LEN_BYTES` from `partiql_tools::row_codec` so a tag-byte or
-/// cap change in the encoder cannot drift here.
+/// Imports `TAG_*`, `MAX_FIELDS_PER_ROW`, and `MAX_NAME_LEN_BYTES` from
+/// `partiql_tools::row_codec` so a tag-byte or cap change in the encoder
+/// cannot drift here.
 ///
 /// ENDIANNESS INVARIANT: every multi-byte field is little-endian, matching
 /// `row_codec::serialize_row`'s `to_le_bytes()` calls. A new tag must be
 /// written `to_le_bytes()` there AND read `from_le_bytes()` here — an
 /// asymmetry compiles cleanly and silently corrupts every persisted row.
-fn parse_row(bytes: &[u8]) -> ParsedRow {
+fn parse_row(bytes: &[u8]) -> ParsedValue {
     fn take<'a>(i: &mut usize, n: usize, bytes: &'a [u8]) -> &'a [u8] {
         assert!(
             *i + n <= bytes.len(),
@@ -261,52 +249,46 @@ fn parse_row(bytes: &[u8]) -> ParsedRow {
                 )
             }
             t if t == TAG_NULL => ParsedValue::Null,
+            t if t == TAG_TUPLE => {
+                let field_count = take_u32(i, bytes);
+                assert!(
+                    field_count <= MAX_FIELDS_PER_ROW,
+                    "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
+                );
+                let mut fields = Vec::with_capacity(field_count as usize);
+                for _ in 0..field_count {
+                    let name_len = take_u32(i, bytes);
+                    assert!(
+                        name_len <= MAX_NAME_LEN_BYTES,
+                        "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
+                    );
+                    let name = std::str::from_utf8(take(i, name_len as usize, bytes))
+                        .expect("field name must be valid UTF-8")
+                        .to_string();
+                    let inner_tag = take(i, 1, bytes)[0];
+                    fields.push((name, take_value(i, bytes, inner_tag)));
+                }
+                ParsedValue::Tuple(fields)
+            }
             other => panic!("unknown tag {other:#04x} at offset {}", *i - 1),
         }
     }
 
     let mut i = 0usize;
-    assert_eq!(
-        take(&mut i, 1, bytes)[0],
-        FORMAT_VERSION,
-        "format version must be FORMAT_VERSION ({FORMAT_VERSION:#04x})"
-    );
     let top_tag = take(&mut i, 1, bytes)[0];
-    let payload = if top_tag == TAG_STRUCT {
-        let field_count = take_u32(&mut i, bytes);
-        assert!(
-            field_count <= MAX_FIELDS_PER_ROW,
-            "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
-        );
-        let mut fields = Vec::with_capacity(field_count as usize);
-        for _ in 0..field_count {
-            let name_len = take_u32(&mut i, bytes);
-            assert!(
-                name_len <= MAX_NAME_LEN_BYTES,
-                "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
-            );
-            let name = std::str::from_utf8(take(&mut i, name_len as usize, bytes))
-                .expect("field name must be valid UTF-8")
-                .to_string();
-            let tag = take(&mut i, 1, bytes)[0];
-            fields.push((name, take_value(&mut i, bytes, tag)));
-        }
-        ParsedPayload::Struct(fields)
-    } else {
-        ParsedPayload::Scalar(take_value(&mut i, bytes, top_tag))
-    };
+    let value = take_value(&mut i, bytes, top_tag);
     assert_eq!(
         i,
         bytes.len(),
         "parser left {} trailing bytes",
         bytes.len() - i
     );
-    ParsedRow { payload }
+    value
 }
 
 /// Read every row in table `t` from the .pqlite file at `db_path`, returning
-/// ParsedRow values in row_id order.
-fn read_all_rows(db_path: &std::path::Path, table: &str) -> Vec<ParsedRow> {
+/// ParsedValue rows in row_id order.
+fn read_all_rows(db_path: &std::path::Path, table: &str) -> Vec<ParsedValue> {
     let env = unsafe {
         heed::EnvOpenOptions::new()
             .map_size(1024 * 1024 * 1024)
@@ -347,9 +329,9 @@ fn ctas_persists_tagged_union_rows() {
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 3, "expected 3 rows; got: {rows:?}");
     for (idx, row) in rows.iter().enumerate() {
-        let fields = match &row.payload {
-            ParsedPayload::Struct(f) => f,
-            other => panic!("row {idx}: expected Struct, got {other:?}"),
+        let fields = match row {
+            ParsedValue::Tuple(f) => f,
+            other => panic!("row {idx}: expected Tuple, got {other:?}"),
         };
         assert_eq!(fields.len(), 1, "row {idx}: expected 1 field");
         let (name, value) = &fields[0];
@@ -391,9 +373,9 @@ fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
 
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 1, "expected exactly 1 row; got: {}", rows.len());
-    let fields = match &rows[0].payload {
-        ParsedPayload::Struct(f) => f,
-        other => panic!("expected Struct payload, got {other:?}"),
+    let fields = match &rows[0] {
+        ParsedValue::Tuple(f) => f,
+        other => panic!("expected Tuple row, got {other:?}"),
     };
     assert_eq!(fields.len(), 1, "row should have exactly one field");
     let (name, value) = &fields[0];
@@ -417,13 +399,12 @@ fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
 
 #[test]
 fn parser_adversarial_truncation_walk() {
-    // Hand-crafted valid 1-column row mirroring row_codec's wire format:
-    //   version(0x01), struct_tag(0x03),
+    // Hand-crafted valid 1-field tuple mirroring row_codec's wire format:
+    //   tuple_tag(0x03),
     //   field_count(1 u32 LE), name_len(1 u32 LE), name "a",
-    //   tag 0x00 (Integer), value 42 (i64 LE). 20 bytes total.
-    let valid_bytes: [u8; 20] = [
-        FORMAT_VERSION,
-        TAG_STRUCT,
+    //   tag 0x00 (Integer), value 42 (i64 LE). 19 bytes total.
+    let valid_bytes: [u8; 19] = [
+        TAG_TUPLE,
         0x01,
         0x00,
         0x00,
@@ -447,16 +428,16 @@ fn parser_adversarial_truncation_walk() {
     // Sanity: the full payload parses cleanly. If this fails, the loop below
     // is testing the wrong baseline.
     let row = parse_row(&valid_bytes);
-    let fields = match &row.payload {
-        ParsedPayload::Struct(f) => f,
-        other => panic!("expected Struct payload, got {other:?}"),
+    let fields = match &row {
+        ParsedValue::Tuple(f) => f,
+        other => panic!("expected Tuple row, got {other:?}"),
     };
     assert_eq!(fields.len(), 1);
     assert_eq!(fields[0].0, "a");
     assert_eq!(fields[0].1, ParsedValue::Integer(42));
 
-    // Truncate at every offset 0..20. Every truncation MUST panic — never
-    // return a half-parsed ParsedRow, never read OOB. catch_unwind verifies
+    // Truncate at every offset 0..19. Every truncation MUST panic — never
+    // return a half-parsed value, never read OOB. catch_unwind verifies
     // the parser exits via a panic, not via a normal return.
     for len in 0..valid_bytes.len() {
         let truncated = &valid_bytes[..len];
@@ -483,16 +464,16 @@ fn panic_message(err: Box<dyn std::any::Any + Send>) -> String {
 
 #[test]
 fn parser_sanity_cap_field_count_trips_before_allocation() {
-    // version + struct_tag + field_count = MAX_FIELDS_PER_ROW + 1 (= 1025,
-    // LE: 0x01 0x04 0x00 0x00). The cap rejects values > MAX_FIELDS_PER_ROW.
+    // tuple_tag + field_count = MAX_FIELDS_PER_ROW + 1 (= 1025, LE: 0x01
+    // 0x04 0x00 0x00). The cap rejects values > MAX_FIELDS_PER_ROW.
     //
     // The assertion pins the panic SOURCE to the sanity cap by matching the
     // message text. A naive `result.is_err()` would silently pass if the cap
     // were deleted (the downstream `take()` bounds-check would fire instead
-    // on this exact 6-byte payload). Matching `"sanity:"` and `"field_count"`
+    // on this exact 5-byte payload). Matching `"sanity:"` and `"field_count"`
     // makes cap removal, cap weakening, and cap-position regressions all
     // surface a different message ("ran off the end ...") and fail this test.
-    let payload: [u8; 6] = [FORMAT_VERSION, TAG_STRUCT, 0x01, 0x04, 0x00, 0x00];
+    let payload: [u8; 5] = [TAG_TUPLE, 0x01, 0x04, 0x00, 0x00];
     assert_eq!(
         u32::from_le_bytes([0x01, 0x04, 0x00, 0x00]),
         MAX_FIELDS_PER_ROW + 1,
@@ -509,7 +490,7 @@ fn parser_sanity_cap_field_count_trips_before_allocation() {
 
 #[test]
 fn parser_sanity_cap_name_len_trips_before_allocation() {
-    // version + struct_tag + field_count=1 + name_len = MAX_NAME_LEN_BYTES + 1
+    // tuple_tag + field_count=1 + name_len = MAX_NAME_LEN_BYTES + 1
     // (= 1_048_577, LE: 0x01 0x00 0x10 0x00). The cap rejects name_len values
     // > MAX_NAME_LEN_BYTES before attempting to read the name bytes.
     //
@@ -517,18 +498,7 @@ fn parser_sanity_cap_name_len_trips_before_allocation() {
     // to the sanity cap by matching the message. Without this, removing or
     // weakening the cap would still leave `take()`'s OOB check to fire,
     // silently passing the test while shipping a real OOM regression.
-    let payload: [u8; 10] = [
-        FORMAT_VERSION,
-        TAG_STRUCT,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x10,
-        0x00,
-    ];
+    let payload: [u8; 9] = [TAG_TUPLE, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x10, 0x00];
     assert_eq!(
         u32::from_le_bytes([0x01, 0x00, 0x10, 0x00]),
         MAX_NAME_LEN_BYTES + 1,
@@ -566,12 +536,11 @@ fn ctas_scalar_and_string_boundaries() {
 
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 1);
-    let struct_fields = match rows.into_iter().next().unwrap().payload {
-        ParsedPayload::Struct(f) => f,
-        other => panic!("expected Struct payload, got {other:?}"),
+    let tuple_fields = match rows.into_iter().next().unwrap() {
+        ParsedValue::Tuple(f) => f,
+        other => panic!("expected Tuple row, got {other:?}"),
     };
-    let fields: std::collections::HashMap<String, ParsedValue> =
-        struct_fields.into_iter().collect();
+    let fields: std::collections::HashMap<String, ParsedValue> = tuple_fields.into_iter().collect();
 
     // i64::MAX must round-trip exactly — proves the high bit of the i64 LE
     // encoding survives the to_le_bytes/from_le_bytes round trip.
@@ -637,7 +606,7 @@ fn ctas_rejects_bool_with_pointed_message() {
     );
     assert!(!ok, "Bool column must be rejected; stderr: {stderr}");
     assert!(
-        stderr.contains("column 'b'") && stderr.contains("Bool"),
+        stderr.contains("field 'b'") && stderr.contains("Bool"),
         "error must name the column and the rejected type; got: {stderr}",
     );
     // Verify wtxn rollback by re-opening: the env file may persist on disk,
@@ -664,8 +633,8 @@ fn ctas_rejects_bool_with_pointed_message() {
 #[test]
 #[cfg_attr(windows, ignore)]
 fn ctas_persists_bare_scalar_rows() {
-    // Top-level shape is RowShape::Register(_) — a bag of scalars, not a
-    // bag of structs. Encoder writes ver + TAG_INTEGER + i64 LE per row.
+    // Top-level shape is RowShape::Register(_) — a bag of scalars. Encoder
+    // writes TAG_INTEGER + i64 LE per row, no tuple framing.
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("scalar.pqlite");
     let (ok, _stdout, stderr) = run_exec(
@@ -676,11 +645,11 @@ fn ctas_persists_bare_scalar_rows() {
     let rows = read_all_rows(&db_path, "t");
     assert_eq!(rows.len(), 3, "expected 3 scalar rows; got: {rows:?}");
     for (idx, row) in rows.iter().enumerate() {
-        match &row.payload {
-            ParsedPayload::Scalar(ParsedValue::Integer(v)) => {
+        match row {
+            ParsedValue::Integer(v) => {
                 assert_eq!(*v as usize, idx, "row {idx}: value should equal row index");
             }
-            other => panic!("row {idx}: expected scalar Integer, got {other:?}"),
+            other => panic!("row {idx}: expected Integer, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
We chose custom binary encoding over Ion-rs for CTAS to get full control over our storage footprint and eliminate per-row heap overhead.

This PR implements a custom tagged-union format that encodes VM register state directly to disk. The new storage driver uses a push-based callback pattern instead of passing around vectors of bytes, the VM now pushes rows into a reused, scratch-pad buffer. This gets us to a true zero-allocation hot path after the initial buffer warmup.

Key changes:

- Wire Format: A lean, ordered binary format (LE values, BE keys) that bakes in schema versioning so the future reader knows exactly what it's looking at, even for empty tables.

- Filesystem Integrity: Added a peek-then-open check so that if the encoder rejects a row early on we can back out without ever leaving orphan database files on disk.

- Safety: Added caps (max fields, max name length) and duplicate column detection in the encoder beforehand, catching data issues before they ever reach the storage layer.

- Reliability: Updated our integration tests (27 tests total) to include bit-perfect roundtrip checks and some truncation testing.

### Performance Benchmarks (CTAS Write Path)

| N rows | Exec time | μs per row | RSS | Peak heap |
| :--- | :--- | :--- | :--- | :--- |
| 10K | 12.3 ms | 1.23 | 12 MB | 4.7 MB |
| 100K | 29.2 ms | 0.29 | 16 MB | 8.0 MB |
| 1M | 187.2 ms | 0.19 | 50 MB | 42 MB |
| 10M | 2.04 s | 0.20 | 378 MB | 388 MB |

Each row is one `pqlite exec` run by `/usr/bin/time -lp` on an M4 Pro Macbook by running `CREATE TABLE bench AS (SELECT t.a FROM mem(1, N) t)` at N = 10K, 100K, 1M, and 10M. mem(1,N) is a built in function that makes N rows with the shape {a: i64}, each row ends up being a total of 12 bytes (1B version + 1B struct tag + 4B field count + 4B name length + 1B name + 1B value + 8B i64). 

The reason we scaled to 10 million is because at that point the LMDB B+tree is 3 to 4 levels deep instead of 2 at 10K, and any extra overhead should show up in  μs/row . The flat μs/row from 100k to 10M is evidence that the path stays O(1).


### Updated Benchmarks (Dynamic Type-check and Builder pattern)


| N rows | Exec time | μs per row | RSS | Peak heap |
| :--- | :--- | :--- | :--- | :--- |
| 10K | 28.2 ms | 2.82 | 12 MB | 4.7 MB |
| 100K | 41.9 ms | 0.419 | 16 MB | 8.2 MB |
| 1M | 228.6 ms | 0.229 | 51 MB | 42.8 MB |
| 10M | 2.26 s | 0.226 | 396 MB | 388.8 MB |

Measured exactly the same way as the previous runs, but these are the benchmarks after adding the dynamic type-checking for non-struct values. The change to using builder pattern did allow scaling from 1M to 10M rows to show a **9.87x** multiplier which is less than the previous **10.89x**.

