### PR TITLE
feat(pqlite): add read path (CTAS → SELECT loop) 

### DIFF
--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -11,6 +11,9 @@ build = "build.rs"
 name = "partiql_tools"
 path = "src/lib.rs"
 
+[features]
+test-support = []
+
 [[bin]]
 name = "partiql-legacy"
 path = "src/bin/partiql_legacy.rs"
@@ -67,8 +70,12 @@ clap = { version = "4.6.1", features = ["derive"] }
 # we don't use; the LMDB backend and the Str/Bytes codecs are unaffected.
 heed = { version = "0.20", default-features = false }
 reedline = "0.48.0"
+rust_decimal = { version = "1", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = "0.5"
 proptest = "1.0"
 tempfile = "3.0"
+# Self-activate `test-support` for integration tests in `tests/` so the gated
+# module is reachable without requiring `--features test-support` on the CLI.
+partiql-tools = { path = ".", features = ["test-support"] }

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,13 +1,16 @@
 use partiql_tools::common;
 
 use common::{create_table_fn_catalog, lower_statement, parse};
+use partiql_common::catalog::CatalogId;
 use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
-use partiql_eval::{CompilationContext, ExecutionContext, PlanCompiler};
+use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanCompiler};
 use partiql_logical::LogicalStatement;
+use partiql_tools::catalog::{HeedCompilationCatalog, HeedExecutionCatalog};
 use partiql_tools::storage::{HeedDB, StorageError};
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
@@ -16,11 +19,9 @@ use reedline::{
     ValidationResult, Validator,
 };
 
-/// Maximum number of lines retained in the REPL history file.
 const HISTORY_CAPACITY: usize = 1000;
 
-/// Version string shared by the `--version` flag and the REPL startup banner:
-/// the crate version joined with the git commit SHA captured in build.rs.
+/// Crate version joined with the git commit SHA captured in build.rs.
 const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "@", env!("PQLITE_GIT_SHA"));
 
 /// Pqlite: An interactive PartiQL database engine and REPL.
@@ -35,8 +36,7 @@ struct Cli {
     #[arg(long, global = true, value_delimiter = ',')]
     debug: Vec<String>,
 
-    /// Path to the database file (required for the interactive REPL). The
-    /// parent directory must already exist; it is not created for you.
+    /// Path to the database file. The parent directory must already exist.
     #[arg(long, global = true)]
     db: Option<std::path::PathBuf>,
 
@@ -70,21 +70,6 @@ enum Commands {
     },
 }
 
-/// How `execute_query` obtains a database when a statement needs one.
-///
-/// Only `CREATE TABLE AS` needs storage. The REPL opens one handle for the
-/// whole session and passes it as `Open`; `exec` passes `Lazy` so the database
-/// is opened only if a write statement actually requires it — a plain query via
-/// `exec` never opens or creates a file.
-#[derive(Clone, Copy)]
-enum DbSource<'a> {
-    /// An already-open handle (the REPL session database).
-    Open(&'a HeedDB),
-    /// A `--db` path to open on demand (the `exec` subcommand); `None` if no
-    /// `--db` was given.
-    Lazy(Option<&'a std::path::Path>),
-}
-
 fn main() {
     let cli = Cli::parse();
     let debug = DebugFlags::from_args(&cli.debug);
@@ -96,55 +81,41 @@ fn main() {
                 eprintln!("Error: empty query");
                 std::process::exit(1);
             }
-            if let Err(e) = execute_query(query, &debug, DbSource::Lazy(cli.db.as_deref())) {
+            let db = match cli.db.as_deref() {
+                Some(p) => match HeedDB::open(p) {
+                    Ok(db) => Some(Arc::new(db)),
+                    Err(e) => {
+                        eprintln!("Error: could not open database at {}: {}", p.display(), e);
+                        std::process::exit(1);
+                    }
+                },
+                None => None,
+            };
+            if let Err(e) = execute_query(query, &debug, db) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
         }
         None => {
-            // The REPL needs a database. We require an explicit --db rather
-            // than inventing a default path: like standard UNIX tools, we don't
-            // create files or directories on the user's behalf.
+            // Require explicit --db rather than inventing a default path.
             let db_path = cli.db.clone().unwrap_or_else(|| {
                 eprintln!("Error: The `--db <PATH>` option is required to open the database.");
                 std::process::exit(1);
             });
 
-            // Open the database up front. Hard-fail rather than fall back (a
-            // silently-non-persisting db is worse than one that refuses to
-            // start). The parent directory must already exist.
-            let db = match HeedDB::open(&db_path) {
-                Ok(db) => db,
-                Err(e) => {
-                    eprintln!(
-                        "Error: could not open database at {}: {}",
-                        db_path.display(),
-                        e
-                    );
-                    std::process::exit(1);
-                }
-            };
-
-            run_repl(&debug, &db);
+            run_repl(&debug, &db_path);
         }
     }
 }
 
-/// Normalize a query string before handing it to the engine: trim outer
-/// whitespace and strip a single trailing `;` statement terminator, while
-/// preserving any internal newlines. The `;` is accepted as a convenience
-/// terminator (and is what the REPL validator uses to detect a complete
-/// entry) but is not part of the PartiQL grammar, so it must be removed.
-///
-/// TODO: support the trailing `;` statement terminator natively in the
-/// PartiQL grammar/parser so semicolons are a first-class part of the
-/// language, and remove this stripping workaround once that lands.
+/// Trim outer whitespace and strip a single trailing `;` so the REPL can use
+/// `;` as a completion signal without it leaking into the PartiQL grammar.
+/// TODO: drop this once the parser accepts `;` natively.
 fn normalize_query(input: &str) -> &str {
     let trimmed = input.trim();
     trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end()
 }
 
-/// Minimal REPL prompt that renders a fixed `pqlite> ` indicator.
 struct PqlitePrompt;
 
 impl Prompt for PqlitePrompt {
@@ -172,15 +143,8 @@ impl Prompt for PqlitePrompt {
     }
 }
 
-/// Validator that decides when a multi-line REPL entry is complete.
-///
-/// An input is considered complete when, after trimming trailing whitespace,
-/// it either:
-///   * ends with a semicolon (`;`) — a finished PartiQL statement, or
-///   * is a meta-command starting with a dot (`.`).
-///
-/// Anything else is treated as `Incomplete`, so pressing Enter inserts a
-/// newline and lets the user keep typing on the following line.
+/// Marks a REPL entry as complete when it ends with `;` or is a `.`-prefixed
+/// meta-command; anything else keeps reading on the next line.
 struct PqliteValidator;
 
 impl Validator for PqliteValidator {
@@ -194,10 +158,8 @@ impl Validator for PqliteValidator {
     }
 }
 
-/// Build a persistent, file-backed history at `~/.pqlite_history`.
-///
-/// Falls back to in-memory history (never crashing) if the home directory
-/// cannot be resolved or the history file cannot be opened.
+/// File-backed history at `~/.pqlite_history`; falls back to in-memory on
+/// resolution or open failure.
 fn build_history() -> Box<dyn History> {
     let history_path = home_dir().map(|mut p| {
         p.push(".pqlite_history");
@@ -219,22 +181,18 @@ fn build_history() -> Box<dyn History> {
         eprintln!("Warning: could not resolve home directory (using in-memory history)");
     }
 
-    // Fallback: in-memory history. If even this fails, run without history.
     match FileBackedHistory::new(HISTORY_CAPACITY) {
         Ok(history) => Box::new(history),
         Err(_) => Box::new(FileBackedHistory::default()),
     }
 }
 
-/// Resolve the user's home directory across platforms.
 fn home_dir() -> Option<std::path::PathBuf> {
-    // `std::env::home_dir` was un-deprecated in Rust 1.85 and is correct on
-    // all supported platforms, so no extra crate is needed here.
+    // `std::env::home_dir` was un-deprecated in Rust 1.85.
     #[allow(deprecated)]
     std::env::home_dir()
 }
 
-/// Print the REPL help menu listing meta-commands and query usage.
 fn print_help() {
     println!("PartiQL REPL — available commands:");
     println!("  .help     Show this help message");
@@ -250,15 +208,11 @@ fn print_help() {
     println!("Example: SELECT t.a, t.b FROM mem(100, 2) t LIMIT 5;");
 }
 
-/// Outcome of handling a REPL meta-command (a line starting with `.`).
 enum MetaOutcome {
-    /// The command was handled; continue the loop.
     Handled,
-    /// The user requested to quit; break the loop.
     Quit,
 }
 
-/// Handle a dot-prefixed meta-command. `input` must be the trimmed buffer.
 fn handle_meta_command(input: &str) -> MetaOutcome {
     match input {
         ".quit" | ".exit" => MetaOutcome::Quit,
@@ -273,24 +227,30 @@ fn handle_meta_command(input: &str) -> MetaOutcome {
     }
 }
 
-/// Print the REPL startup banner: the crate version, the git commit it was
-/// built from, the active database path, and a pointer to the help command.
-///
-/// Written to stderr, not stdout: the banner is startup chrome, and stdout is
-/// reserved for the query result stream so it can be piped/redirected cleanly.
+/// Written to stderr to keep stdout reserved for query output.
 fn print_startup_banner(db_path: &std::path::Path) {
-    // Reuse the same VERSION string that backs the `--version` flag so the two
-    // can never drift (crate version + git SHA captured in build.rs).
     eprintln!("pqlite version {VERSION}");
     eprintln!("database: {}", db_path.display());
     eprintln!("For usage information, enter \".help\".");
 }
 
-/// Run the interactive REPL: read a line, execute it as a query, and loop.
-///
-/// Errors from `execute_query` are reported but never terminate the session.
-fn run_repl(debug: &DebugFlags, db: &HeedDB) {
-    print_startup_banner(db.path());
+/// `execute_query` errors are reported but never terminate the session.
+fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
+    // Hard-fail rather than fall back to in-memory: a silently non-persisting
+    // db is worse than refusing to start.
+    let db = match HeedDB::open(db_path) {
+        Ok(db) => Arc::new(db),
+        Err(e) => {
+            eprintln!(
+                "Error: could not open database at {}: {}",
+                db_path.display(),
+                e
+            );
+            std::process::exit(1);
+        }
+    };
+
+    print_startup_banner(db_path);
 
     let mut line_editor = Reedline::create()
         .with_history(build_history())
@@ -305,7 +265,6 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
                     continue;
                 }
 
-                // Meta-commands start with a dot and are handled locally.
                 if trimmed.starts_with('.') {
                     match handle_meta_command(trimmed) {
                         MetaOutcome::Handled => continue,
@@ -315,12 +274,12 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
 
                 let query = normalize_query(trimmed);
 
-                // A lone `;` strips to empty — skip rather than parse "".
+                // A lone `;` normalizes to empty — skip rather than parse "".
                 if query.is_empty() {
                     continue;
                 }
 
-                if let Err(e) = execute_query(query, debug, DbSource::Open(db)) {
+                if let Err(e) = execute_query(query, debug, Some(Arc::clone(&db))) {
                     eprintln!("{}", e);
                 }
             }
@@ -331,9 +290,7 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
                 println!("Exiting...");
                 break;
             }
-            Ok(_) => {
-                // Other signals (HostCommand / ExternalBreak) are not used here.
-            }
+            Ok(_) => {}
             Err(e) => {
                 eprintln!("REPL error: {}", e);
                 break;
@@ -342,11 +299,7 @@ fn run_repl(debug: &DebugFlags, db: &HeedDB) {
     }
 }
 
-/// Render a `BindingsName` the SQL-idiomatic way, so the printed form round-trips
-/// the case-sensitivity the user typed (instead of the `CaseInsensitive("t")` Debug
-/// wrapper, which both leaks internals and reads identically for quoted vs bare):
-///   - case-sensitive (originally quoted) -> re-quoted, e.g. `"My_Table"`
-///   - case-insensitive (originally bare) -> bare, e.g. `my_table`
+/// SQL-idiomatic rendering: quoted identifiers re-quoted, bare ones bare.
 fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
     match name {
         partiql_value::BindingsName::CaseSensitive(s) => format!("\"{}\"", s),
@@ -354,16 +307,11 @@ fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
     }
 }
 
-/// Derive the canonical catalog key for a table name. Bare (case-insensitive)
-/// identifiers fold to lowercase so `foo`, `FOO`, and `Foo` collide as one
-/// table; quoted (case-sensitive) identifiers are kept verbatim. This is
-/// ASCII-equivalent to the engine's `UniCase` fold; full Unicode-consistent
-/// folding is a later-PR refinement.
+/// Bare identifiers fold to ASCII lowercase; quoted identifiers are verbatim.
+/// `HeedDB::create_table` rejects interior NULs that would panic heed.
 ///
-/// NOTE: `name` may contain arbitrary bytes from a quoted identifier. An
-/// interior NUL byte would otherwise panic heed's internal
-/// `CString::new(name).unwrap()`; `HeedDB::create_table` guards against that
-/// up front and returns `StorageError::InvalidName` instead.
+/// ASCII-only — full Unicode-consistent folding (matching the engine's UniCase
+/// fold for non-ASCII identifiers) is a later-PR refinement.
 fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
     match name {
         partiql_value::BindingsName::CaseInsensitive(s) => s.to_lowercase(),
@@ -371,7 +319,6 @@ fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
     }
 }
 
-/// Shared stderr footer for a planning-only DDL statement.
 fn print_ddl_planned_footer(elapsed: std::time::Duration) {
     eprintln!(
         "(planned in {:.1}ms — execution not yet implemented)",
@@ -379,76 +326,129 @@ fn print_ddl_planned_footer(elapsed: std::time::Duration) {
     );
 }
 
-/// Compile a lowered query plan into an executable program, applying the
-/// `plan`/`program` debug dumps. Shared by the `Query` and `CreateTableAs`
-/// paths so their compilation setup cannot drift.
-///
-/// Note: when a debug flag is set, the `[Plan]`/`[Program]` dumps are written
-/// inside this call, so the caller's reported `compile:` time includes their
-/// cost. That only affects the diagnostic timing line under `--debug`; normal
-/// output is unaffected.
+/// Bundles `HeedCompilationCatalog` with the existing `TableFnCompilationCatalog`
+/// under `PlanCompiler`'s single `"default"` catalog name. Also records the
+/// first unresolved bare table name so `build_compiled` can fail fast with
+/// "Table not found" instead of letting Permissive mode yield a MISSING row.
+struct CombinedCatalog {
+    table_fns: common::TableFnCompilationCatalog,
+    heed: Option<HeedCompilationCatalog>,
+    unresolved_table_name: Arc<Mutex<Option<String>>>,
+}
+
+impl partiql_eval::CompilationCatalog for CombinedCatalog {
+    fn get_table(
+        &self,
+        path: &[partiql_value::BindingsName<'_>],
+    ) -> Option<partiql_eval::source::DataSourceHandle> {
+        if let Some(handle) = self.heed.as_ref().and_then(|h| h.get_table(path)) {
+            return Some(handle);
+        }
+        // Only record bare single-element bindings — schema-qualified paths
+        // never match anything here and aren't useful to surface as table names.
+        // The compiler may probe a name multiple times; keep the first.
+        if path.len() == 1 {
+            if let Ok(mut guard) = self.unresolved_table_name.lock() {
+                if guard.is_none() {
+                    let name = match &path[0] {
+                        partiql_value::BindingsName::CaseSensitive(s) => s.to_string(),
+                        partiql_value::BindingsName::CaseInsensitive(s) => s.to_string(),
+                    };
+                    *guard = Some(name);
+                }
+            }
+        }
+        None
+    }
+
+    fn get_table_function(&self, name: &str) -> Option<partiql_eval::source::TableFunctionHandle> {
+        self.table_fns.get_table_function(name)
+    }
+}
+
+/// CatalogId is reused by the matching ExecutionCatalog.
 fn build_compiled(
     logical: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
     debug: &DebugFlags,
-) -> Result<partiql_eval::CompiledPlan, Box<dyn std::error::Error>> {
+    db: Option<Arc<HeedDB>>,
+) -> Result<(partiql_eval::CompiledPlan, CatalogId), Box<dyn std::error::Error>> {
     if debug.plan {
         eprintln!("[Plan] {:?}", logical);
     }
 
     let mut context = CompilationContext::new();
+
     let column_names = vec!["a".to_string(), "b".to_string()];
-    let comp_catalog: std::sync::Arc<dyn partiql_eval::CompilationCatalog> =
-        std::sync::Arc::new(common::TableFnCompilationCatalog::new(column_names));
-    let _catalog_id = context.add_catalog("default", comp_catalog);
+    let unresolved_table_name: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let combined = CombinedCatalog {
+        table_fns: common::TableFnCompilationCatalog::new(column_names),
+        heed: db.map(HeedCompilationCatalog::new),
+        unresolved_table_name: Arc::clone(&unresolved_table_name),
+    };
+    let catalog: Arc<dyn partiql_eval::CompilationCatalog> = Arc::new(combined);
+    let catalog_id = context.add_catalog("default", catalog);
 
     let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
     let compiled = compiler
         .compile(logical)
         .map_err(|e| format!("Compile error: {:?}", e))?;
 
+    let first_unresolved = unresolved_table_name
+        .lock()
+        .map(|mut g| g.take())
+        .unwrap_or(None);
+    if let Some(name) = first_unresolved {
+        return Err(format!("Error: Table '{}' not found", name).into());
+    }
+
     if debug.program {
         eprintln!("[Program]\n{}", compiled);
     }
 
-    Ok(compiled)
+    Ok((compiled, catalog_id))
 }
 
-/// Build the execution context with pqlite's table functions registered.
-/// Shared by the `Query` and `CreateTableAs` paths.
-fn build_exec_context() -> ExecutionContext {
+/// The Heed catalog is `prepare()`-d from `compiled` before being boxed so
+/// `ScanId → table-name` mappings are populated before the VM calls `create()`.
+fn build_exec_context(
+    db: Option<Arc<HeedDB>>,
+    catalog_id: CatalogId,
+    compiled: &partiql_eval::CompiledPlan,
+) -> ExecutionContext {
     let mut exec_context = ExecutionContext::new();
-    exec_context.register_table_function("rand", std::sync::Arc::new(common::RandTableFunction));
-    exec_context.register_table_function("mem", std::sync::Arc::new(common::MemTableFunction));
-    exec_context.register_table_function(
-        "scan_ion",
-        std::sync::Arc::new(common::ScanIonTableFunction),
-    );
+    exec_context.register_table_function("rand", Arc::new(common::RandTableFunction));
+    exec_context.register_table_function("mem", Arc::new(common::MemTableFunction));
+    exec_context.register_table_function("scan_ion", Arc::new(common::ScanIonTableFunction));
+
+    if let Some(db) = db {
+        let mut heed_exec = HeedExecutionCatalog::new(db);
+        let scans = compiled.scans_for_catalog(catalog_id);
+        heed_exec.prepare(&scans);
+        exec_context.add_catalog(catalog_id, Box::new(heed_exec));
+    }
+
     exec_context
 }
 
 fn execute_query(
     query_str: &str,
     debug: &DebugFlags,
-    db_source: DbSource,
+    db: Option<Arc<HeedDB>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let query = query_str.to_string();
-
     let catalog = create_table_fn_catalog();
 
     let parse_start = Instant::now();
-    let parsed = parse(&query).map_err(|e| format!("Parse error: {:?}", e))?;
+    let parsed = parse(query_str).map_err(|e| format!("Parse error: {:?}", e))?;
     let parse_time = parse_start.elapsed();
 
     if debug.ast {
         eprintln!("[AST] {:?}", parsed);
     }
 
-    // pqlite runs exactly one statement per submission; reject anything else here,
-    // since lowering operates on a single statement.
+    // Lowering operates on a single statement.
     let stmt = match parsed.statements.as_slice() {
         [stmt] => stmt,
-        // Match the planner's wording for this condition so the failure reads the
-        // same whether it surfaces here or via `LogicalPlanner::lower`.
+        // Wording matches `LogicalPlanner::lower` for parity across error sites.
         _ => return Err("Lower error: multi-statement input".into()),
     };
     let lower_start = Instant::now();
@@ -461,55 +461,33 @@ fn execute_query(
         LogicalStatement::CreateTableAs { table_name, query } => {
             let key = canonical_table_key(&table_name);
 
-            // Resolve --db before compile + VM setup so a missing --db on a
-            // CTAS path is a clean CLI error before any expensive work.
-            let db_path: Option<&std::path::Path> = match db_source {
-                DbSource::Open(_) => None,
-                DbSource::Lazy(path) => Some(
-                    path.ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?,
-                ),
-            };
+            // Resolve --db before compile + VM setup so a missing flag fails
+            // cleanly before any expensive work.
+            let db = db
+                .as_ref()
+                .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?;
 
             let compile_start = Instant::now();
-            let compiled = build_compiled(&query, debug)?;
+            let (compiled, catalog_id) = build_compiled(&query, debug, Some(Arc::clone(db)))?;
             let compile_time = compile_start.elapsed();
 
             let exec_start = Instant::now();
-            let exec_context = build_exec_context();
+            let exec_context = build_exec_context(Some(Arc::clone(db)), catalog_id, &compiled);
             let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
                 .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
-            // Capture RowShape before vm.execute() borrows the VM mutably.
+            // Snapshot RowShape before vm.execute() borrows the VM mutably.
             let row_shape = vm.shape().row_shape().clone();
 
-            // 4 KiB scratch: matches LMDB's typical page size; reused per row.
+            // 4 KiB scratch matches LMDB's typical page size; reused per row.
             let mut scratch_buf: Vec<u8> = Vec::with_capacity(4096);
-
-            // Open the env up front. Mid-stream rejection rolls back the wtxn
-            // (no catalog entry, no row bytes), but the env file itself may
-            // remain on disk.
-            let lazily_opened;
-            let db: &HeedDB = match db_source {
-                DbSource::Open(db) => db,
-                DbSource::Lazy(_) => {
-                    let path = db_path.expect("Lazy implies a path");
-                    lazily_opened = HeedDB::open(path).map_err(|e| {
-                        format!(
-                            "Error: could not open database at {}: {}",
-                            path.display(),
-                            e
-                        )
-                    })?;
-                    &lazily_opened
-                }
-            };
 
             let n = match vm.execute() {
                 Ok(partiql_eval::ExecutionResult::Query(iter)) => {
                     let mut writer = db.create_table(&key).map_err(|e| format!("Error: {}", e))?;
-                    // SAFETY: QueryIterator::next uses unsafe lifetime extension
-                    // on its RegisterReader. Aliasing across iter.next() is UB.
-                    // Consume `row` synchronously, drop it, then push the bytes.
+                    // SAFETY: QueryIterator::next uses unsafe lifetime extension on its
+                    // RegisterReader. Aliasing across iter.next() is UB. Consume `row`
+                    // synchronously, drop it, then push the bytes.
                     for r in iter {
                         let row = r.map_err(|e| {
                             format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
@@ -555,11 +533,11 @@ fn execute_query(
     };
 
     let compile_start = Instant::now();
-    let compiled = build_compiled(&logical, debug)?;
+    let (compiled, catalog_id) = build_compiled(&logical, debug, db.clone())?;
     let compile_time = compile_start.elapsed();
 
     let exec_start = Instant::now();
-    let exec_context = build_exec_context();
+    let exec_context = build_exec_context(db, catalog_id, &compiled);
     let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
         .map_err(|e| format!("Execution setup error: {:?}", e))?;
 
@@ -629,35 +607,28 @@ fn row_to_value(
 
     match shape.row_shape() {
         RowShape::Struct(fields) => {
-            // Construct tuple with all fields (including single field case)
             let mut tuple = Tuple::new();
             for field in fields.iter() {
-                let name = match &field.name {
-                    FieldName::Static(s) => s.clone(),
-                    FieldName::Register(reg) => {
-                        // Dynamic name - get from register as string
-                        row.get_str(*reg).unwrap_or("?").to_string()
-                    }
+                let name: &str = match &field.name {
+                    FieldName::Static(s) => s,
+                    FieldName::Register(reg) => row.get_str(*reg).unwrap_or("?"),
                 };
-                // Get register index from the field's value shape
                 let reg_idx = match &field.value {
                     RowShape::Register(idx, _) => *idx,
                     _ => continue, // nested structs not yet supported here
                 };
                 let mut view = row.get_value_view(reg_idx).expect("register should exist");
-                tuple.insert(&name, value_view_to_value(&mut view));
+                tuple.insert(name, value_view_to_value(&mut view));
             }
             Value::Tuple(Box::new(tuple))
         }
         RowShape::Register(idx, _) => {
-            // Scalar - return value directly
             let mut view = row.get_value_view(*idx).expect("register should exist");
             value_view_to_value(&mut view)
         }
     }
 }
 
-/// Convert a ValueView cursor to a Value
 fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
     use partiql_eval::value::ValueType;
 
@@ -671,15 +642,12 @@ fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
         ValueType::String => Value::String(Box::new(view.get_str().unwrap().to_string())),
         ValueType::Bytes => Value::Blob(Box::new(view.get_bytes().unwrap().to_vec())),
         ValueType::Tuple => {
-            // Navigate tuple fields with support for nested tuples
             let mut tuple = Tuple::new();
             if view.step_in().is_ok() {
                 loop {
                     let field_name = view.get_field_name().unwrap().to_string();
                     let field_value = value_view_to_value(view);
                     tuple.insert(&field_name, field_value);
-
-                    // Move to next field
                     if !view.advance().unwrap_or(false) {
                         break;
                     }
@@ -689,13 +657,10 @@ fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
             Value::Tuple(Box::new(tuple))
         }
         ValueType::List => {
-            // Navigate list elements
             let mut items = Vec::new();
             if view.step_in().is_ok() {
                 loop {
-                    let item_value = value_view_to_value(view);
-                    items.push(item_value);
-
+                    items.push(value_view_to_value(view));
                     if !view.advance().unwrap_or(false) {
                         break;
                     }
@@ -705,13 +670,10 @@ fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
             Value::List(Box::new(items.into()))
         }
         ValueType::Bag => {
-            // Navigate bag elements
             let mut items = Vec::new();
             if view.step_in().is_ok() {
                 loop {
-                    let item_value = value_view_to_value(view);
-                    items.push(item_value);
-
+                    items.push(value_view_to_value(view));
                     if !view.advance().unwrap_or(false) {
                         break;
                     }

--- a/partiql-tools/src/catalog.rs
+++ b/partiql-tools/src/catalog.rs
@@ -1,0 +1,297 @@
+//! Heed-backed CompilationCatalog, ExecutionCatalog, and DataSource for pqlite.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use partiql_common::catalog::EntryId;
+use partiql_eval::source::{
+    BufferStability, CatalogScans, DataSource, DataSourceHandle, DataSourceMetadata,
+    RegisterWriter, ScanId, ScanSource,
+};
+use partiql_eval::{CompilationCatalog, EngineError, ExecutionCatalog};
+use partiql_value::BindingsName;
+
+use crate::row_codec::{deserialize_row_into, DeserializeError};
+use crate::storage::{HeedDB, StorageError};
+
+type EvalResult<T> = std::result::Result<T, EngineError>;
+
+/// Table identifiers are hashed to a `u64` EntryId at `get_table` time; the
+/// execution-side catalog rebuilds the reverse map by re-hashing every name
+/// in `_tables`. Hash collision on a `u64` is structurally possible but
+/// astronomically unlikely at realistic table counts. On collision,
+/// `HeedExecutionCatalog::prepare` returns `StorageError::HashCollision` and
+/// the per-query `prepare_error` stash surfaces it through `create()` — the
+/// colliding table is NOT silently hidden.
+pub struct HeedCompilationCatalog {
+    db: Arc<HeedDB>,
+}
+
+impl HeedCompilationCatalog {
+    pub fn new(db: Arc<HeedDB>) -> Self {
+        Self { db }
+    }
+}
+
+impl CompilationCatalog for HeedCompilationCatalog {
+    fn get_table(&self, path: &[BindingsName<'_>]) -> Option<DataSourceHandle> {
+        // pqlite has no schemas or databases — only bare table names.
+        if path.len() != 1 {
+            return None;
+        }
+        // Bare identifiers (case-insensitive) fold to ASCII lowercase; quoted
+        // identifiers (case-sensitive) are taken verbatim. This is the standard
+        // SQL identifier canonicalization rule.
+        let canonical = match &path[0] {
+            BindingsName::CaseInsensitive(s) => s.to_lowercase(),
+            BindingsName::CaseSensitive(s) => s.to_string(),
+        };
+        let entry_id = hash_to_entry_id(&canonical);
+
+        // Scope the read txn so it drops before the handle is returned.
+        {
+            let rtxn = self.db.read_txn().ok()?;
+            if self.db.open_table(&rtxn, &canonical).is_err() {
+                return None;
+            }
+        }
+
+        let metadata: Arc<dyn DataSourceMetadata> = Arc::new(HeedTableMetadata);
+        Some(DataSourceHandle::new(entry_id, metadata))
+    }
+}
+
+/// `resolve` returns `None` for every field, forcing the compiler down the
+/// `WholeValue` branch — the row is decoded as a tuple by `deserialize_row_into`.
+struct HeedTableMetadata;
+
+impl DataSourceMetadata for HeedTableMetadata {
+    fn buffer_stability(&self) -> BufferStability {
+        BufferStability::UntilNext
+    }
+
+    fn resolve(&self, _field_name: &str) -> Option<ScanSource> {
+        None
+    }
+}
+
+pub struct HeedExecutionCatalog {
+    db: Arc<HeedDB>,
+    scans: HashMap<ScanId, EntryId>,
+    entry_to_name: HashMap<EntryId, String>,
+    /// `prepare` returns `()`, so storage errors during index rebuild must be
+    /// stashed and surfaced from the next `create()` call.
+    prepare_error: Option<String>,
+}
+
+impl HeedExecutionCatalog {
+    pub fn new(db: Arc<HeedDB>) -> Self {
+        Self {
+            db,
+            scans: HashMap::new(),
+            entry_to_name: HashMap::new(),
+            prepare_error: None,
+        }
+    }
+
+    fn rebuild_entry_index(&mut self) -> Result<(), StorageError> {
+        self.entry_to_name.clear();
+        let rtxn = self.db.read_txn()?;
+        let tables = self.db.list_table_names(&rtxn)?;
+        for name in tables {
+            let entry_id = hash_to_entry_id(&name);
+            if let Some(existing) = self.entry_to_name.insert(entry_id, name.clone()) {
+                return Err(StorageError::HashCollision {
+                    existing,
+                    new: name,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ExecutionCatalog for HeedExecutionCatalog {
+    fn prepare(&mut self, scans: &CatalogScans) {
+        self.scans.clear();
+        self.prepare_error = None;
+        if let Err(e) = self.rebuild_entry_index() {
+            self.prepare_error = Some(format!("catalog index rebuild failed: {e}"));
+            return;
+        }
+        for (scan_id, entry_id, _layout) in scans.iter() {
+            if self.entry_to_name.contains_key(&entry_id) {
+                self.scans.insert(scan_id, entry_id);
+            }
+        }
+    }
+
+    fn create(&self, scan_id: ScanId) -> EvalResult<Box<dyn DataSource>> {
+        if let Some(msg) = &self.prepare_error {
+            return Err(EngineError::ReaderError(msg.clone()));
+        }
+        let entry_id = *self.scans.get(&scan_id).ok_or_else(|| {
+            EngineError::IllegalState(format!(
+                "scan_id {:?} not registered; prepare() must run first",
+                scan_id
+            ))
+        })?;
+        let name = self.entry_to_name.get(&entry_id).ok_or_else(|| {
+            EngineError::IllegalState(format!(
+                "entry_id {:?} missing from index; prepare() must run first",
+                entry_id
+            ))
+        })?;
+
+        let (bytes, rows) = read_all_rows(&self.db, name)
+            .map_err(|e| EngineError::ReaderError(format!("table scan failed: {e}")))?;
+
+        Ok(Box::new(HeedTableSource {
+            bytes,
+            rows,
+            cursor: 0,
+        }))
+    }
+}
+
+#[inline]
+fn hash_to_entry_id(name: &str) -> EntryId {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::hash::Hash::hash(name, &mut hasher);
+    EntryId::from(std::hash::Hasher::finish(&hasher))
+}
+
+/// Pack the entire scan into one byte buffer with per-row `u32` offsets.
+/// One `Vec<u8>` (geometric growth) replaces one allocation per row.
+/// Fails with `ScanTooLarge` if the packed size exceeds `u32::MAX`.
+fn read_all_rows(
+    db: &HeedDB,
+    table_name: &str,
+) -> Result<(Vec<u8>, Vec<std::ops::Range<u32>>), StorageError> {
+    let rtxn = db.read_txn()?;
+    let tbl = db.open_table(&rtxn, table_name)?;
+    let row_count = tbl.len(&rtxn).map_err(StorageError::Heed)? as usize;
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut rows: Vec<std::ops::Range<u32>> = Vec::with_capacity(row_count);
+    let mut prev_end: u32 = 0;
+    for result in tbl.iter(&rtxn).map_err(StorageError::Heed)? {
+        let (_k, v) = result.map_err(StorageError::Heed)?;
+        bytes.extend_from_slice(v);
+        // Only the cumulative end is checked; the start equals the prior
+        // iteration's end (or 0), which already fit in u32 by induction.
+        let end = u32::try_from(bytes.len()).map_err(|_| StorageError::ScanTooLarge {
+            table: table_name.to_string(),
+            observed_bytes: bytes.len(),
+        })?;
+        rows.push(prev_end..end);
+        prev_end = end;
+    }
+    Ok((bytes, rows))
+}
+
+pub(crate) struct HeedTableSource {
+    bytes: Vec<u8>,
+    rows: Vec<std::ops::Range<u32>>,
+    cursor: usize,
+}
+
+impl DataSource for HeedTableSource {
+    fn open(&mut self) -> EvalResult<()> {
+        self.cursor = 0;
+        Ok(())
+    }
+
+    fn next_row(&mut self, writer: &mut RegisterWriter<'_, '_>) -> EvalResult<bool> {
+        if self.cursor >= self.rows.len() {
+            return Ok(false);
+        }
+        let r = &self.rows[self.cursor];
+        let row = &self.bytes[r.start as usize..r.end as usize];
+        // Safety: HeedTableSource owns self.bytes for the entire scan; the
+        // borrowed slice outlives every per-row arena reset the writer performs.
+        unsafe { deserialize_row_into(row, writer, 0) }.map_err(|e: DeserializeError| {
+            EngineError::ReaderError(format!("row {} decode failed: {e}", self.cursor))
+        })?;
+        self.cursor += 1;
+        Ok(true)
+    }
+
+    fn close(&mut self) -> EvalResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 0x06 (TAG_NULL): parseable single-byte row; only used to confirm catalog plumbing.
+    const TAG_NULL_PLACEHOLDER: u8 = 0x06;
+
+    #[test]
+    fn metadata_resolve_returns_none() {
+        let m = HeedTableMetadata;
+        assert!(m.resolve("anything").is_none());
+        assert!(matches!(m.buffer_stability(), BufferStability::UntilNext));
+    }
+
+    #[test]
+    fn compilation_catalog_returns_none_for_missing_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cat.pqlite");
+        let db = Arc::new(HeedDB::open(&path).unwrap());
+        let cat = HeedCompilationCatalog::new(db);
+        let bindings = [BindingsName::CaseInsensitive(std::borrow::Cow::Borrowed(
+            "nope",
+        ))];
+        assert!(cat.get_table(&bindings).is_none());
+    }
+
+    #[test]
+    fn read_all_rows_packs_rows_into_flat_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("flat.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let mut w = db.create_table("t").unwrap();
+        w.push_row(&[0xAA, 0xBB]).unwrap();
+        w.push_row(&[0xCC]).unwrap();
+        w.push_row(&[0xDD, 0xEE, 0xFF]).unwrap();
+        w.commit().unwrap();
+
+        let (bytes, rows) = read_all_rows(&db, "t").unwrap();
+        assert_eq!(bytes, vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        assert_eq!(rows, vec![0u32..2, 2..3, 3..6]);
+    }
+
+    #[test]
+    fn read_all_rows_handles_empty_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty_flat.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+        db.create_table("t").unwrap().commit().unwrap();
+
+        let (bytes, rows) = read_all_rows(&db, "t").unwrap();
+        assert!(bytes.is_empty());
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn compilation_catalog_returns_handle_for_existing_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cat.pqlite");
+        let db = Arc::new(HeedDB::open(&path).unwrap());
+        let mut w = db.create_table("widgets").unwrap();
+        w.push_row(&[TAG_NULL_PLACEHOLDER]).unwrap();
+        w.commit().unwrap();
+
+        let cat = HeedCompilationCatalog::new(Arc::clone(&db));
+        let bindings = [BindingsName::CaseInsensitive(std::borrow::Cow::Borrowed(
+            "widgets",
+        ))];
+        assert!(
+            cat.get_table(&bindings).is_some(),
+            "expected a handle for 'widgets'"
+        );
+    }
+}

--- a/partiql-tools/src/catalog.rs
+++ b/partiql-tools/src/catalog.rs
@@ -161,6 +161,7 @@ fn hash_to_entry_id(name: &str) -> EntryId {
     EntryId::from(std::hash::Hasher::finish(&hasher))
 }
 
+// Eagerly materialized because Box<dyn DataSource + 'static> cannot hold a borrowed RoTxn.
 /// Pack the entire scan into one byte buffer with per-row `u32` offsets.
 /// One `Vec<u8>` (geometric growth) replaces one allocation per row.
 /// Fails with `ScanTooLarge` if the packed size exceeds `u32::MAX`.

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,3 +1,21 @@
+pub mod catalog;
 pub mod common;
 pub mod row_codec;
 pub mod storage;
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+pub mod test_support {
+    use crate::storage::HeedDB;
+
+    /// Inject a raw row bypassing the encoder so tests can construct malformed
+    /// wire bytes without leaking heed types into the public API.
+    pub fn inject_row(db: &HeedDB, table: &str, row_id: u64, payload: &[u8]) {
+        HeedDB::inject_row_for_tests(db, table, row_id, payload);
+    }
+
+    /// Read the raw bytes the encoder wrote at `row_id`.
+    pub fn read_row(db: &HeedDB, table: &str, row_id: u64) -> Vec<u8> {
+        db.read_row_for_tests(table, row_id)
+    }
+}

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -1,9 +1,4 @@
-//! Custom tagged-union row serialization for the CTAS write path.
-//!
-//! Operates on the VM's RegisterReader + RowShape surface, no `partiql_value::Value`
-//! materialization. The CTAS arm in `pqlite.rs` calls `serialize_row` and passes
-//! the encoded bytes to `TableWriter::push_row` — zero per-row allocations after
-//! warmup.
+//! Tagged-union row serialization and deserialization for pqlite.
 //!
 //! Wire format:
 //!   ROW          = tagged_value
@@ -11,23 +6,17 @@
 //!   payload(TAG_TUPLE) = field_count(u32 LE) (name_len(u32 LE) name_utf8 tagged_value){N}
 //!
 //! All multi-byte VALUE bytes are little-endian. Row-id KEYS in LMDB stay
-//! big-endian: storage encodes them as `row_id.to_be_bytes()` under a
-//! `heed::types::Bytes` key codec so the B+tree's lexicographic key order
-//! matches numeric order with zero per-row key allocations.
+//! big-endian (encoded as `row_id.to_be_bytes()` under `heed::types::Bytes`)
+//! so the B+tree's lexicographic order matches numeric order.
 
 use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
 
-/// Sanity cap on `field_count` consumed by the reader. Real CTAS rows top
-/// out at hundreds; 1024 is ample headroom while catching a flipped byte
-/// producing a huge u32 before `Vec::with_capacity` allocates gigabytes.
+/// Cap on `field_count` to bound `Vec::with_capacity` against a flipped byte.
 pub const MAX_FIELDS_PER_ROW: u32 = 1024;
 
-/// Sanity cap on `name_len` consumed by the reader. PartiQL identifiers are
-/// typically <100 bytes; 1 MiB catches corruption while staying well above
-/// any real-world name. UTF-8 byte length, not char count.
+/// Cap on `name_len` (UTF-8 byte length) to bound allocations on corruption.
 pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 
-// Tag constants. `pub` so the reader and encoder share one source of truth.
 pub const TAG_INTEGER: u8 = 0x00;
 pub const TAG_DECIMAL: u8 = 0x01;
 pub const TAG_FLOAT: u8 = 0x02;
@@ -39,13 +28,11 @@ pub const TAG_NULL: u8 = 0x06;
 // 0x08 = TAG_BOOL    — reserved; rejected.
 // 0x09 = TAG_BYTES   — reserved; rejected.
 
-/// Errors raised by [`serialize_row`]. `pub` because the binary in `src/bin/`
-/// is a separate crate from this library.
 #[derive(Debug)]
 pub enum SerializeError {
-    /// An unsupported type or shape encountered mid-stream: containers,
-    /// dynamic field names, MISSING, BOOL, BYTES. The string identifies
-    /// the offending tuple field or top-level value.
+    /// Unsupported type or shape: containers, dynamic field names, MISSING,
+    /// BOOL, BYTES, or top-level scalar rows (must be wrapped in a tuple).
+    /// The string identifies the offending field or top-level value.
     Unsupported(String),
 }
 
@@ -59,22 +46,13 @@ impl std::fmt::Display for SerializeError {
 
 impl std::error::Error for SerializeError {}
 
-/// Serialize one VM row into `buf` as a tagged-union byte sequence.
-///
-/// `buf` is cleared on entry. On success, `buf` contains a single
-/// `tagged_value`: one tag byte followed by its payload. A top-level tuple
-/// is TAG_TUPLE + struct body; a top-level scalar is its scalar tag +
-/// value bytes.
-///
-/// All integer fields are little-endian. The row-id key in LMDB stays
-/// big-endian under `heed::types::Bytes`. Only VALUE bytes are LE.
+/// Serialize one VM row into `buf` as a tagged-union byte sequence. `buf`
+/// is cleared on entry.
 ///
 /// # Endianness invariant
 ///
-/// Every multi-byte field is written `to_le_bytes()`. The test parser in
-/// `partiql-tools/tests/pqlite_cli.rs::parse_row` uses `from_le_bytes()` to
-/// match. If you add a new tag, write it `to_le_bytes()` here AND read it
-/// `from_le_bytes()` there — an LE/BE asymmetry compiles cleanly and
+/// Every multi-byte VALUE field is written `to_le_bytes()` and the symmetric
+/// decoder reads `from_le_bytes()`. An LE/BE asymmetry compiles cleanly and
 /// silently corrupts every persisted row.
 pub fn serialize_row(
     row: &RegisterReader<'_>,
@@ -84,7 +62,12 @@ pub fn serialize_row(
     buf.clear();
     match row_shape {
         RowShape::Struct(fields) => write_tuple(row, fields, buf),
-        RowShape::Register(slot, _) => write_value(row, *slot, None, buf),
+        // A bare scalar tag with no tuple frame round-trips on write but
+        // fails on read: the decoder's `vw.put_scalar` requires a
+        // non-empty frame stack. Refuse at encode time.
+        RowShape::Register(_, _) => Err(SerializeError::Unsupported(
+            "top-level scalar rows are not yet supported; wrap in a tuple".to_string(),
+        )),
     }
 }
 
@@ -132,8 +115,6 @@ fn write_tuple(
     Ok(())
 }
 
-/// Write `tag + payload` for the value at register `slot`. Unsupported types
-/// return `Err`; the caller propagates and the in-flight wtxn rolls back.
 fn write_value(
     row: &RegisterReader<'_>,
     slot: usize,
@@ -185,4 +166,270 @@ fn write_value(
         }
     }
     Ok(())
+}
+
+#[derive(Debug)]
+pub enum DeserializeError {
+    Truncated,
+    UnknownTag(u8),
+    InvalidUtf8,
+    NameTooLong(u32),
+    FieldCountTooLarge(u32),
+    /// Reserved tag or `ValueWriter` failure; symmetric to encoder rejection.
+    Unsupported(String),
+}
+
+impl std::fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeserializeError::Truncated => write!(f, "truncated row payload"),
+            DeserializeError::UnknownTag(t) => write!(f, "unknown tag byte: 0x{t:02x}"),
+            DeserializeError::InvalidUtf8 => write!(f, "field name is not valid UTF-8"),
+            DeserializeError::NameTooLong(n) => {
+                write!(f, "field name length {n} exceeds {MAX_NAME_LEN_BYTES}")
+            }
+            DeserializeError::FieldCountTooLarge(n) => {
+                write!(f, "tuple field count {n} exceeds {MAX_FIELDS_PER_ROW}")
+            }
+            DeserializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for DeserializeError {}
+
+/// Decode one row of the tagged-union wire format into `writer`'s `target_slot`.
+///
+/// # Safety
+///
+/// `bytes` must outlive every arena reset that touches `target_slot`'s
+/// register. In practice the caller (a `DataSource::next_row`
+/// implementation) must hold the backing row buffer for the duration
+/// of the scan. Violating this precondition causes use-after-free of
+/// the string slices written into the engine's arena via the
+/// lifetime extensions inside `decode_tagged_into`.
+///
+/// String UTF-8 validity is checked inline by `take_str` as each
+/// string is read; no pre-pass is required.
+pub unsafe fn deserialize_row_into(
+    bytes: &[u8],
+    writer: &mut partiql_eval::source::RegisterWriter<'_, '_>,
+    target_slot: u16,
+) -> Result<(), DeserializeError> {
+    let mut cursor = 0usize;
+    let mut vw = writer
+        .value_writer(target_slot)
+        .map_err(|e| DeserializeError::Unsupported(format!("value_writer({target_slot}): {e}")))?;
+    decode_tagged_into(&mut vw, bytes, &mut cursor)?;
+    vw.finish()
+        .map_err(|e| DeserializeError::Unsupported(format!("finish: {e}")))?;
+    Ok(())
+}
+
+fn decode_tagged_into(
+    vw: &mut partiql_eval::source::ValueWriter<'_, '_>,
+    bytes: &[u8],
+    cursor: &mut usize,
+) -> Result<(), DeserializeError> {
+    let tag = take_byte(bytes, cursor)?;
+    match tag {
+        TAG_INTEGER => {
+            let v = i64::from_le_bytes(take_array::<8>(bytes, cursor)?);
+            vw.put_i64(v).map_err(io_err)?;
+        }
+        TAG_FLOAT => {
+            let v = f64::from_le_bytes(take_array::<8>(bytes, cursor)?);
+            vw.put_f64(v).map_err(io_err)?;
+        }
+        TAG_DECIMAL => {
+            let scale = i32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            let mantissa = i128::from_le_bytes(take_array::<16>(bytes, cursor)?);
+            let scale_u32 = u32::try_from(scale).map_err(|_| {
+                DeserializeError::Unsupported(format!("negative decimal scale {scale}"))
+            })?;
+            let d = rust_decimal::Decimal::try_from_i128_with_scale(mantissa, scale_u32)
+                .map_err(|e| DeserializeError::Unsupported(format!("invalid decimal: {e}")))?;
+            vw.put_decimal(d).map_err(io_err)?;
+        }
+        TAG_STRING => {
+            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            let s = take_str(bytes, cursor, len)?;
+            // Safety: see `deserialize_row_into`'s # Safety block.
+            let s_ext: &str = unsafe { extend_to_arena_lifetime(s) };
+            vw.put_str(s_ext).map_err(io_err)?;
+        }
+        TAG_NULL => {
+            vw.put_null().map_err(io_err)?;
+        }
+        TAG_TUPLE => {
+            let field_count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if field_count > MAX_FIELDS_PER_ROW {
+                return Err(DeserializeError::FieldCountTooLarge(field_count));
+            }
+            vw.step_in_tuple().map_err(io_err)?;
+            for _ in 0..field_count {
+                let name_len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+                if name_len > MAX_NAME_LEN_BYTES {
+                    return Err(DeserializeError::NameTooLong(name_len));
+                }
+                let name = take_str(bytes, cursor, name_len)?;
+                // Safety: see `deserialize_row_into`'s # Safety block.
+                let name_ext: &str = unsafe { extend_to_arena_lifetime(name) };
+                vw.put_field_name(name_ext).map_err(io_err)?;
+                decode_tagged_into(vw, bytes, cursor)?;
+            }
+            vw.step_out().map_err(io_err)?;
+        }
+        t => return Err(DeserializeError::UnknownTag(t)),
+    }
+    Ok(())
+}
+
+#[inline]
+fn take_byte(bytes: &[u8], cursor: &mut usize) -> Result<u8, DeserializeError> {
+    let b = *bytes.get(*cursor).ok_or(DeserializeError::Truncated)?;
+    *cursor += 1;
+    Ok(b)
+}
+
+#[inline]
+fn take_array<const N: usize>(
+    bytes: &[u8],
+    cursor: &mut usize,
+) -> Result<[u8; N], DeserializeError> {
+    let end = cursor.checked_add(N).ok_or(DeserializeError::Truncated)?;
+    let slice = bytes.get(*cursor..end).ok_or(DeserializeError::Truncated)?;
+    let arr = <[u8; N]>::try_from(slice).expect("slice is exactly N bytes");
+    *cursor = end;
+    Ok(arr)
+}
+
+#[inline]
+fn take_str<'b>(
+    bytes: &'b [u8],
+    cursor: &mut usize,
+    len: u32,
+) -> Result<&'b str, DeserializeError> {
+    let len = len as usize;
+    let end = cursor.checked_add(len).ok_or(DeserializeError::Truncated)?;
+    let slice = bytes.get(*cursor..end).ok_or(DeserializeError::Truncated)?;
+    let s = std::str::from_utf8(slice).map_err(|_| DeserializeError::InvalidUtf8)?;
+    *cursor = end;
+    Ok(s)
+}
+
+/// Extends `s`'s lifetime to match the arena's. Caller must ensure the
+/// backing buffer outlives every arena reset that touches the register
+/// the string is written into — see [`deserialize_row_into`]'s
+/// `# Safety` contract for the call-site invariant.
+///
+/// The output lifetime `'out` is unrelated to the input lifetime to
+/// permit the arena-lifetime borrow `put_str` / `put_field_name` require.
+///
+/// # Safety
+///
+/// See [`deserialize_row_into`].
+#[inline]
+unsafe fn extend_to_arena_lifetime<'out>(s: &str) -> &'out str {
+    // SAFETY: caller upholds the precondition documented on
+    // deserialize_row_into.
+    unsafe { &*(s as *const str) }
+}
+
+#[inline]
+fn io_err(e: partiql_eval::EngineError) -> DeserializeError {
+    DeserializeError::Unsupported(format!("writer error: {e}"))
+}
+
+// `RegisterWriter::new` and `ValueRef` are `pub(crate)` in `partiql-eval`, so
+// round-trip unit tests must run as integration tests. Tests below cover the
+// byte-reader helpers and the `DeserializeError` surface.
+#[cfg(test)]
+mod deserialize_tests {
+    use super::*;
+
+    #[test]
+    fn take_byte_advances_cursor_on_success() {
+        let mut cursor = 0usize;
+        let b = take_byte(&[0x42, 0xAA], &mut cursor).unwrap();
+        assert_eq!(b, 0x42);
+        assert_eq!(cursor, 1);
+    }
+
+    #[test]
+    fn take_byte_truncated_on_empty() {
+        let mut cursor = 0usize;
+        let res = take_byte(&[], &mut cursor);
+        assert!(matches!(res, Err(DeserializeError::Truncated)));
+        assert_eq!(cursor, 0, "cursor must not advance on error");
+    }
+
+    #[test]
+    fn take_array_reads_le_i64() {
+        // 42 as little-endian i64
+        let bytes = 42i64.to_le_bytes();
+        let mut cursor = 0usize;
+        let arr = take_array::<8>(&bytes, &mut cursor).unwrap();
+        assert_eq!(i64::from_le_bytes(arr), 42);
+        assert_eq!(cursor, 8);
+    }
+
+    #[test]
+    fn take_array_truncated_when_short() {
+        let bytes = [0x01, 0x02, 0x03];
+        let mut cursor = 0usize;
+        let res = take_array::<8>(&bytes, &mut cursor);
+        assert!(matches!(res, Err(DeserializeError::Truncated)));
+    }
+
+    #[test]
+    fn take_str_returns_utf8_slice() {
+        let bytes = b"hello";
+        let mut cursor = 0usize;
+        let s = take_str(bytes, &mut cursor, 5).unwrap();
+        assert_eq!(s, "hello");
+        assert_eq!(cursor, 5);
+    }
+
+    #[test]
+    fn take_str_invalid_utf8_returns_invalid_utf8() {
+        // 0xFF is not valid UTF-8 leading byte.
+        let bytes = [0xFFu8];
+        let mut cursor = 0usize;
+        let res = take_str(&bytes, &mut cursor, 1);
+        assert!(matches!(res, Err(DeserializeError::InvalidUtf8)));
+    }
+
+    #[test]
+    fn take_str_truncated_when_shorter_than_len() {
+        let bytes = b"hi";
+        let mut cursor = 0usize;
+        let res = take_str(bytes, &mut cursor, 10);
+        assert!(matches!(res, Err(DeserializeError::Truncated)));
+    }
+
+    #[test]
+    fn display_renders_each_variant() {
+        assert_eq!(
+            format!("{}", DeserializeError::Truncated),
+            "truncated row payload"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::UnknownTag(0xFE)),
+            "unknown tag byte: 0xfe"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::InvalidUtf8),
+            "field name is not valid UTF-8"
+        );
+        assert!(
+            format!("{}", DeserializeError::NameTooLong(99)).starts_with("field name length 99")
+        );
+        assert!(format!("{}", DeserializeError::FieldCountTooLarge(2048))
+            .starts_with("tuple field count 2048"));
+        assert_eq!(
+            format!("{}", DeserializeError::Unsupported("x".to_string())),
+            "unsupported: x"
+        );
+    }
 }

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -221,6 +221,13 @@ pub unsafe fn deserialize_row_into(
         .value_writer(target_slot)
         .map_err(|e| DeserializeError::Unsupported(format!("value_writer({target_slot}): {e}")))?;
     decode_tagged_into(&mut vw, bytes, &mut cursor)?;
+    if cursor != bytes.len() {
+        return Err(DeserializeError::Unsupported(format!(
+            "trailing bytes after row decode: {} of {} consumed",
+            cursor,
+            bytes.len()
+        )));
+    }
     vw.finish()
         .map_err(|e| DeserializeError::Unsupported(format!("finish: {e}")))?;
     Ok(())

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-/// Virtual address space reserved for the LMDB map. Sparse on disk.
+/// Virtual address space reserved for the LMDB map; sparse on disk.
 const DEFAULT_MAP_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
 
 /// One catalog plus headroom for one named db per user table.
@@ -12,17 +12,15 @@ const TABLES_DB: &str = "_tables";
 
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
-/// Row-store keys are an 8-byte big-endian `u64` row id passed as raw bytes.
-/// `Bytes` (not `U64<BigEndian>`) so the caller can pass a stack-local
-/// `[u8; 8]` — zero allocations per put. BE keeps lexicographic key order
-/// matching numeric order.
+/// Row-store keys are 8-byte big-endian `u64` row ids passed as raw bytes.
+/// `Bytes` (not `U64<BigEndian>`) lets the caller pass a stack-local `[u8; 8]`
+/// for zero per-put allocations. BE keeps lexicographic key order matching
+/// numeric order.
 type RowKey = heed::types::Bytes;
 
 type RowDb = heed::Database<RowKey, heed::types::Bytes>;
 
-/// Write-side handle for a single CTAS operation. Drop without `commit`
-/// triggers `wtxn`'s rollback. `key_buf` is reused across pushes for a
-/// zero-alloc key path.
+/// Drop without `commit` rolls back. `key_buf` is reused across pushes.
 pub struct TableWriter<'env> {
     wtxn: heed::RwTxn<'env>,
     table: RowDb,
@@ -30,7 +28,7 @@ pub struct TableWriter<'env> {
     key_buf: [u8; 8],
 }
 
-// Hand-rolled `Debug` because `heed::RwTxn` does not implement it.
+// `heed::RwTxn` is not `Debug`, so derive can't be used.
 impl<'env> std::fmt::Debug for TableWriter<'env> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TableWriter")
@@ -40,8 +38,7 @@ impl<'env> std::fmt::Debug for TableWriter<'env> {
 }
 
 impl<'env> TableWriter<'env> {
-    /// Encode the next row. `bytes` is the caller-encoded row payload —
-    /// storage adds no framing.
+    /// Append the next row. Storage adds no framing.
     pub fn push_row(&mut self, bytes: &[u8]) -> Result<(), StorageError> {
         self.key_buf = self.row_id.to_be_bytes();
         self.table.put(&mut self.wtxn, &self.key_buf[..], bytes)?;
@@ -49,7 +46,7 @@ impl<'env> TableWriter<'env> {
         Ok(())
     }
 
-    /// Commit the write txn and return the number of rows persisted.
+    /// Commit the write txn and return the row count.
     pub fn commit(self) -> Result<u64, StorageError> {
         self.wtxn.commit()?;
         Ok(self.row_id)
@@ -63,10 +60,24 @@ pub enum StorageError {
     TableExists(String),
     /// `_`-prefixed name; the namespace is reserved.
     ReservedName(String),
-    /// Name contains an interior NUL byte (heed would panic).
+    /// Interior NUL byte (heed would otherwise panic).
     InvalidName(String),
+    TableMissing(String),
     Execution(String),
     Codec(String),
+    /// Table scan exceeded 4 GiB; row offsets do not fit in `u32`.
+    /// Carries the offending table name and the byte count observed so far.
+    ScanTooLarge {
+        table: String,
+        observed_bytes: usize,
+    },
+    /// Two table names hashed to the same EntryId. Astronomically unlikely
+    /// at u64 widths but craftable against the fixed-seed DefaultHasher; this
+    /// would silently make one of the tables unreachable, so we fail hard.
+    HashCollision {
+        existing: String,
+        new: String,
+    },
 }
 
 impl std::fmt::Display for StorageError {
@@ -82,8 +93,20 @@ impl std::fmt::Display for StorageError {
             StorageError::InvalidName(name) => {
                 write!(f, "invalid table name {name:?}: contains a NUL byte")
             }
+            StorageError::TableMissing(name) => write!(f, "table not found: {name}"),
             StorageError::Execution(msg) => write!(f, "execution error: {msg}"),
             StorageError::Codec(msg) => write!(f, "{msg}"),
+            StorageError::ScanTooLarge {
+                table,
+                observed_bytes,
+            } => write!(
+                f,
+                "table scan too large for {table:?}: {observed_bytes} bytes exceeds 4 GiB u32 offset limit"
+            ),
+            StorageError::HashCollision { existing, new } => write!(
+                f,
+                "table name hash collision: '{existing}' and '{new}' share an EntryId; rename one to break the tie"
+            ),
         }
     }
 }
@@ -96,8 +119,11 @@ impl std::error::Error for StorageError {
             StorageError::TableExists(_)
             | StorageError::ReservedName(_)
             | StorageError::InvalidName(_)
+            | StorageError::TableMissing(_)
             | StorageError::Execution(_)
-            | StorageError::Codec(_) => None,
+            | StorageError::Codec(_)
+            | StorageError::ScanTooLarge { .. }
+            | StorageError::HashCollision { .. } => None,
         }
     }
 }
@@ -115,9 +141,9 @@ impl From<heed::Error> for StorageError {
 }
 
 /// Prefix a bare filename with `./` so heed can canonicalize its parent.
-/// Without this, `--db foo.pqlite` fails ENOENT because `parent()` of a
-/// bare name is the empty path. Paths with a real directory component are
-/// returned unchanged, so a genuinely missing parent still errors.
+/// Without this, `--db foo.pqlite` fails ENOENT because `parent()` of a bare
+/// name is the empty path. Paths with a real directory component are returned
+/// unchanged, so a genuinely missing parent still errors.
 fn normalize_db_path(path: &Path) -> PathBuf {
     if path.parent() == Some(Path::new("")) {
         Path::new(".").join(path)
@@ -126,8 +152,8 @@ fn normalize_db_path(path: &Path) -> PathBuf {
     }
 }
 
-/// Owns the LMDB environment and the `_tables` catalog handle. The catalog
-/// handle is valid only while the env is alive, so both live together.
+/// The `_tables` catalog handle is valid only while the env is alive, so
+/// both live together.
 #[derive(Debug)]
 pub struct HeedDB {
     env: heed::Env,
@@ -152,8 +178,8 @@ impl HeedDB {
                 .open(&normalized)?
         };
 
-        // `create_database` is idempotent.
         let mut wtxn = env.write_txn()?;
+        // `create_database` is idempotent.
         let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
         wtxn.commit()?;
 
@@ -164,13 +190,9 @@ impl HeedDB {
         })
     }
 
-    /// Open a write handle for a new table named `name`.
-    ///
-    /// Runs all up-front catalog work (reserved-name guard, NUL guard, dup
-    /// check, catalog registration) and opens a write transaction. The
-    /// returned `TableWriter` lives until `commit` (success) or drop
-    /// (rollback). `name` must already be canonicalized by the caller —
-    /// bare identifiers folded to lowercase, quoted identifiers verbatim.
+    /// Open a write handle for a new table. `name` must already be
+    /// canonicalized by the caller (lowercase for bare identifiers, verbatim
+    /// for quoted).
     pub fn create_table(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
         if name.starts_with('_') {
             return Err(StorageError::ReservedName(name.to_string()));
@@ -183,8 +205,7 @@ impl HeedDB {
             return Err(StorageError::TableExists(name.to_string()));
         }
         let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
-        // Catalog value is empty: the cell records existence only. Table-
-        // level metadata (schema, etc.) lands in a future PR.
+        // Catalog cell records existence only.
         self.tables.put(&mut wtxn, name, &[])?;
         Ok(TableWriter {
             wtxn,
@@ -194,14 +215,36 @@ impl HeedDB {
         })
     }
 
-    /// The live LMDB environment. Test-only; heed types do not leak across
-    /// the module boundary.
+    /// Drop the returned txn to release the read snapshot.
+    pub fn read_txn(&self) -> Result<heed::RoTxn<'_>, StorageError> {
+        Ok(self.env.read_txn()?)
+    }
+
+    /// Open the named table for read. Returns `TableMissing` if no named
+    /// database called `name` exists in the env (i.e., the table was never
+    /// created or was dropped).
+    pub fn open_table(&self, txn: &heed::RoTxn<'_>, name: &str) -> Result<RowDb, StorageError> {
+        self.env
+            .open_database(txn, Some(name))?
+            .ok_or_else(|| StorageError::TableMissing(name.to_string()))
+    }
+
+    /// Enumerate every table name in `_tables`, in lexicographic key order.
+    pub fn list_table_names(&self, txn: &heed::RoTxn<'_>) -> Result<Vec<String>, StorageError> {
+        let mut out =
+            Vec::with_capacity(self.tables.len(txn).map_err(StorageError::Heed)? as usize);
+        for result in self.tables.iter(txn).map_err(StorageError::Heed)? {
+            let (k, _v) = result.map_err(StorageError::Heed)?;
+            out.push(k.to_string());
+        }
+        Ok(out)
+    }
+
     #[cfg(test)]
     pub(crate) fn env(&self) -> &heed::Env {
         &self.env
     }
 
-    /// The `_tables` system catalog handle. Test-only.
     #[cfg(test)]
     pub(crate) fn tables(&self) -> &TablesDb {
         &self.tables
@@ -209,6 +252,39 @@ impl HeedDB {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
+impl HeedDB {
+    /// Test-only: write `payload` at `row_id` bypassing the encoder, so tests
+    /// can inject malformed rows.
+    pub fn inject_row_for_tests(&self, table: &str, row_id: u64, payload: &[u8]) {
+        let mut wtxn = self.env.write_txn().unwrap();
+        let tbl: heed::Database<heed::types::Bytes, heed::types::Bytes> = self
+            .env
+            .open_database(&wtxn, Some(table))
+            .unwrap()
+            .expect("row db must exist");
+        let key = row_id.to_be_bytes();
+        tbl.put(&mut wtxn, &key[..], payload).unwrap();
+        wtxn.commit().unwrap();
+    }
+
+    /// Test-only: read raw payload at `row_id`. Row keys are 8-byte BE `u64`.
+    pub fn read_row_for_tests(&self, table: &str, row_id: u64) -> Vec<u8> {
+        let rtxn = self.env.read_txn().unwrap();
+        let tbl: heed::Database<heed::types::Bytes, heed::types::Bytes> = self
+            .env
+            .open_database(&rtxn, Some(table))
+            .unwrap()
+            .expect("row db must exist");
+        let key = row_id.to_be_bytes();
+        tbl.get(&rtxn, &key[..])
+            .unwrap()
+            .expect("row must exist")
+            .to_vec()
     }
 }
 
@@ -240,8 +316,6 @@ mod tests {
 
     #[test]
     fn create_table_writes_bytes_verbatim_and_registers_catalog() {
-        // Bit-perfect roundtrip: storage's contract is "persist whatever bytes
-        // the caller pushes." A concrete sentinel sequence proves it.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ctas.pqlite");
         let db = HeedDB::open(&path).unwrap();
@@ -334,7 +408,6 @@ mod tests {
             );
         }
 
-        // Guard runs before any transaction, so the catalog is untouched.
         let rtxn = db.env().read_txn().unwrap();
         assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
     }
@@ -345,8 +418,7 @@ mod tests {
         let path = dir.path().join("nul.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        // An interior NUL would otherwise panic heed's CString::new; the guard
-        // turns it into a clean error and never opens a transaction.
+        // Interior NUL would otherwise panic heed's CString::new.
         let res = db.create_table("a\0b");
         assert!(
             matches!(res, Err(StorageError::InvalidName(_))),
@@ -366,7 +438,7 @@ mod tests {
         {
             let mut w = db.create_table("partial").unwrap();
             w.push_row(&[0x42]).unwrap();
-            // Drop w without commit — wtxn rolls back.
+            // Drop without commit — wtxn rolls back.
         }
         let rtxn = db.env().read_txn().unwrap();
         assert!(
@@ -403,6 +475,20 @@ mod tests {
 
         let ex = StorageError::Execution("boom".to_string());
         assert!(ex.to_string().contains("boom"), "got: {ex}");
+
+        let tm = StorageError::TableMissing("ghost".to_string());
+        let s = tm.to_string();
+        assert!(s.contains("table not found"), "got: {s}");
+        assert!(s.contains("ghost"), "got: {s}");
+
+        let stl = StorageError::ScanTooLarge {
+            table: "widgets".to_string(),
+            observed_bytes: 5_000_000_000,
+        };
+        let s = stl.to_string();
+        assert!(s.contains("4 GiB"), "got: {s}");
+        assert!(s.contains("widgets"), "got: {s}");
+        assert!(s.contains("5000000000"), "got: {s}");
     }
 
     #[test]
@@ -411,15 +497,12 @@ mod tests {
         let path = dir.path().join("cat.pqlite");
         let db = HeedDB::open(&path).unwrap();
 
-        // NO_SUB_DIR mode stores the environment as a single file, not a dir.
+        // NO_SUB_DIR stores the environment as a single file.
         assert!(path.is_file(), "db should be a single file (NO_SUB_DIR)");
 
         let rtxn = db.env().read_txn().unwrap();
 
-        // Assert the named `_tables` database specifically exists: look it up by
-        // the literal on-disk name (not the TABLES_DB constant, so renaming the
-        // constant can't make this pass spuriously). `open_database` returns
-        // `None` when no database of that name exists.
+        // Look up by literal name so renaming the TABLES_DB constant can't pass spuriously.
         let named = db
             .env()
             .open_database::<heed::types::Str, heed::types::Bytes>(&rtxn, Some("_tables"))
@@ -429,7 +512,6 @@ mod tests {
             "the `_tables` catalog should exist by name"
         );
 
-        // And it starts empty.
         assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
     }
 
@@ -439,15 +521,50 @@ mod tests {
         let path = dir.path().join("reopen.pqlite");
         {
             let _db = HeedDB::open(&path).unwrap();
-        } // first handle dropped, env closed
+        }
         let reopened = HeedDB::open(&path);
         assert!(reopened.is_ok(), "reopening an existing db must succeed");
     }
 
     #[test]
+    fn open_table_yields_pushed_rows_in_insertion_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("read.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+
+        let mut w = db.create_table("t").unwrap();
+        w.push_row(&[0x01, 0x02]).unwrap();
+        w.push_row(&[0x03, 0x04, 0x05]).unwrap();
+        w.commit().unwrap();
+
+        let rtxn = db.read_txn().unwrap();
+        let tbl = db.open_table(&rtxn, "t").unwrap();
+
+        let rows: Vec<Vec<u8>> = tbl
+            .iter(&rtxn)
+            .unwrap()
+            .map(|res| res.unwrap().1.to_vec())
+            .collect();
+
+        assert_eq!(rows, vec![vec![0x01, 0x02], vec![0x03, 0x04, 0x05]]);
+    }
+
+    #[test]
+    fn open_table_returns_table_missing_for_unknown_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.pqlite");
+        let db = HeedDB::open(&path).unwrap();
+        let rtxn = db.read_txn().unwrap();
+        let res = db.open_table(&rtxn, "no_such_table");
+        assert!(
+            matches!(res, Err(StorageError::TableMissing(ref n)) if n == "no_such_table"),
+            "expected TableMissing; got {:?}",
+            res
+        );
+    }
+
+    #[test]
     fn normalize_db_path_prefixes_bare_filename_with_dot() {
-        // A bare filename (empty parent) gets an explicit `.` parent so heed can
-        // canonicalize it; anything with a real directory component is untouched.
         assert_eq!(
             normalize_db_path(Path::new("foo.pqlite")),
             Path::new("./foo.pqlite")

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -224,6 +224,9 @@ impl HeedDB {
     /// database called `name` exists in the env (i.e., the table was never
     /// created or was dropped).
     pub fn open_table(&self, txn: &heed::RoTxn<'_>, name: &str) -> Result<RowDb, StorageError> {
+        if self.tables.get(txn, name)?.is_none() {
+            return Err(StorageError::TableMissing(name.to_string()));
+        }
         self.env
             .open_database(txn, Some(name))?
             .ok_or_else(|| StorageError::TableMissing(name.to_string()))
@@ -231,10 +234,9 @@ impl HeedDB {
 
     /// Enumerate every table name in `_tables`, in lexicographic key order.
     pub fn list_table_names(&self, txn: &heed::RoTxn<'_>) -> Result<Vec<String>, StorageError> {
-        let mut out =
-            Vec::with_capacity(self.tables.len(txn).map_err(StorageError::Heed)? as usize);
-        for result in self.tables.iter(txn).map_err(StorageError::Heed)? {
-            let (k, _v) = result.map_err(StorageError::Heed)?;
+        let mut out = Vec::with_capacity(self.tables.len(txn)? as usize);
+        for result in self.tables.iter(txn)? {
+            let (k, _v) = result?;
             out.push(k.to_string());
         }
         Ok(out)

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -87,6 +87,66 @@ fn ctas_without_db_errors_cleanly() {
 }
 
 #[test]
+fn select_from_unknown_table_errors_cleanly() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("unknown.pqlite");
+
+    // CTAS one table so the .pqlite env exists.
+    let (ok, _stdout, _stderr) = run_exec(
+        "CREATE TABLE real_table AS (SELECT m.a FROM mem(1, 1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS setup must succeed");
+
+    // SELECT from a DIFFERENT, non-existent table.
+    let (ok, _stdout, stderr) = run_exec("SELECT * FROM ghost_table", Some(&dbp));
+    assert!(
+        !ok,
+        "SELECT from unknown table must fail with non-zero exit"
+    );
+    assert!(
+        stderr.contains("Table 'ghost_table' not found"),
+        "stderr should name the missing table; got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn select_from_unknown_table_without_db_errors_cleanly() {
+    // No --db, so `self.heed` is None inside the catalog. The recorder still
+    // captures "ghost" from the bare-name probe and fail-fast fires before
+    // VM construction. Exercises the lazy-open path with an unknown table.
+    let dir = tempfile::tempdir().unwrap();
+    let out = Command::new(PQLITE)
+        .arg("exec")
+        .arg("SELECT * FROM ghost")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn pqlite");
+
+    assert!(
+        !out.status.success(),
+        "SELECT from unknown table (no --db) must fail with non-zero exit"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Table 'ghost' not found"),
+        "stderr should name the missing table; got: {stderr}"
+    );
+
+    // Lazy-open contract still holds: no db file created.
+    let stray: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "a failed unknown-table SELECT must create no files, but found: {stray:?}"
+    );
+}
+
+#[test]
 fn ctas_with_db_creates_table_and_persists_file() {
     let dir = tempfile::tempdir().unwrap();
     let db = dir.path().join("ctas.pqlite");
@@ -178,417 +238,206 @@ fn duplicate_ctas_is_rejected_and_names_the_table() {
     );
 }
 
-// Wire-format parser (hand-written, mirrors row_codec spec).
-
-use partiql_tools::row_codec::{
-    MAX_FIELDS_PER_ROW, MAX_NAME_LEN_BYTES, TAG_DECIMAL, TAG_FLOAT, TAG_INTEGER, TAG_NULL,
-    TAG_STRING, TAG_TUPLE,
-};
-
-#[derive(Debug, PartialEq)]
-enum ParsedValue {
-    Integer(i64),
-    Decimal { scale: i32, mantissa: i128 },
-    Float(f64),
-    String(String),
-    Null,
-    Tuple(Vec<(String, ParsedValue)>),
-}
-
-/// Mirror of the wire-format spec. Returns `ParsedValue` or panics with a
-/// pointed message; this is a test helper, not a production reader.
-///
-/// Imports `TAG_*`, `MAX_FIELDS_PER_ROW`, and `MAX_NAME_LEN_BYTES` from
-/// `partiql_tools::row_codec` so a tag-byte or cap change in the encoder
-/// cannot drift here.
-///
-/// ENDIANNESS INVARIANT: every multi-byte field is little-endian, matching
-/// `row_codec::serialize_row`'s `to_le_bytes()` calls. A new tag must be
-/// written `to_le_bytes()` there AND read `from_le_bytes()` here — an
-/// asymmetry compiles cleanly and silently corrupts every persisted row.
-fn parse_row(bytes: &[u8]) -> ParsedValue {
-    fn take<'a>(i: &mut usize, n: usize, bytes: &'a [u8]) -> &'a [u8] {
-        assert!(
-            *i + n <= bytes.len(),
-            "ran off the end at offset {i} taking {n}"
-        );
-        let s = &bytes[*i..*i + n];
-        *i += n;
-        s
-    }
-    fn take_u32(i: &mut usize, bytes: &[u8]) -> u32 {
-        u32::from_le_bytes(take(i, 4, bytes).try_into().unwrap())
-    }
-    fn take_i32(i: &mut usize, bytes: &[u8]) -> i32 {
-        i32::from_le_bytes(take(i, 4, bytes).try_into().unwrap())
-    }
-    fn take_i64(i: &mut usize, bytes: &[u8]) -> i64 {
-        i64::from_le_bytes(take(i, 8, bytes).try_into().unwrap())
-    }
-    fn take_f64(i: &mut usize, bytes: &[u8]) -> f64 {
-        f64::from_le_bytes(take(i, 8, bytes).try_into().unwrap())
-    }
-    fn take_i128(i: &mut usize, bytes: &[u8]) -> i128 {
-        i128::from_le_bytes(take(i, 16, bytes).try_into().unwrap())
-    }
-    fn take_value(i: &mut usize, bytes: &[u8], tag: u8) -> ParsedValue {
-        match tag {
-            t if t == TAG_INTEGER => ParsedValue::Integer(take_i64(i, bytes)),
-            t if t == TAG_DECIMAL => {
-                let scale = take_i32(i, bytes);
-                let mantissa = take_i128(i, bytes);
-                ParsedValue::Decimal { scale, mantissa }
-            }
-            t if t == TAG_FLOAT => ParsedValue::Float(take_f64(i, bytes)),
-            t if t == TAG_STRING => {
-                let len = take_u32(i, bytes) as usize;
-                ParsedValue::String(
-                    std::str::from_utf8(take(i, len, bytes))
-                        .expect("string must be valid UTF-8")
-                        .to_string(),
-                )
-            }
-            t if t == TAG_NULL => ParsedValue::Null,
-            t if t == TAG_TUPLE => {
-                let field_count = take_u32(i, bytes);
-                assert!(
-                    field_count <= MAX_FIELDS_PER_ROW,
-                    "sanity: field_count={field_count} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
-                );
-                let mut fields = Vec::with_capacity(field_count as usize);
-                for _ in 0..field_count {
-                    let name_len = take_u32(i, bytes);
-                    assert!(
-                        name_len <= MAX_NAME_LEN_BYTES,
-                        "sanity: name_len={name_len} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
-                    );
-                    let name = std::str::from_utf8(take(i, name_len as usize, bytes))
-                        .expect("field name must be valid UTF-8")
-                        .to_string();
-                    let inner_tag = take(i, 1, bytes)[0];
-                    fields.push((name, take_value(i, bytes, inner_tag)));
-                }
-                ParsedValue::Tuple(fields)
-            }
-            other => panic!("unknown tag {other:#04x} at offset {}", *i - 1),
-        }
-    }
-
-    let mut i = 0usize;
-    let top_tag = take(&mut i, 1, bytes)[0];
-    let value = take_value(&mut i, bytes, top_tag);
-    assert_eq!(
-        i,
-        bytes.len(),
-        "parser left {} trailing bytes",
-        bytes.len() - i
-    );
-    value
-}
-
-/// Read every row in table `t` from the .pqlite file at `db_path`, returning
-/// ParsedValue rows in row_id order.
-fn read_all_rows(db_path: &std::path::Path, table: &str) -> Vec<ParsedValue> {
-    let env = unsafe {
-        heed::EnvOpenOptions::new()
-            .map_size(1024 * 1024 * 1024)
-            .max_dbs(128)
-            .flags(heed::EnvFlags::NO_SUB_DIR)
-            .open(db_path)
-            .expect("re-open env")
-    };
-    let rtxn = env.read_txn().expect("read txn");
-    // Key codec matches storage: BE u64 bytes under `heed::types::Bytes`
-    // (storage switched from `U64<BigEndian>` to `Bytes` to drop the per-put
-    // Vec allocation; BE byte order preserves numeric key ordering).
-    let rowdb: heed::Database<heed::types::Bytes, heed::types::Bytes> = env
-        .open_database(&rtxn, Some(table))
-        .expect("open row db")
-        .expect("row db must exist");
-    let mut out = Vec::new();
-    for entry in rowdb.iter(&rtxn).expect("iter rows") {
-        let (_row_id, payload) = entry.expect("row entry");
-        out.push(parse_row(payload));
-    }
-    out
-}
+// End-to-end CTAS-then-SELECT round-trip tests. Each spins up the binary
+// twice against the same temp .pqlite file: once to write, once to read.
+// Output format expectations (assertion source-of-truth, taken from the
+// binary's actual stdout):
+//   * SELECT results render as `<<\n  { 'a': 0 },\n  { 'a': 1 } ...\n>>`
+//   * String values render single-quoted: `'x'`
+//   * NULL renders uppercase: `NULL`
+//   * Empty bag renders `<<\n\n>>`
 
 #[test]
-#[cfg_attr(windows, ignore)]
-fn ctas_persists_tagged_union_rows() {
-    // mem(3,2) yields i64 rows with column `a` taking 0, 1, 2.
+fn ctas_then_select_single_i64_column() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("rt.pqlite");
-    let (ok, _stdout, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT t.a FROM mem(3,2) t)",
-        Some(&db_path),
-    );
-    assert!(ok, "CTAS should succeed; stderr: {stderr}");
-    assert!(db_path.is_file());
+    let dbp = dir.path().join("e2e.pqlite");
 
-    let rows = read_all_rows(&db_path, "t");
-    assert_eq!(rows.len(), 3, "expected 3 rows; got: {rows:?}");
-    for (idx, row) in rows.iter().enumerate() {
-        let fields = match row {
-            ParsedValue::Tuple(f) => f,
-            other => panic!("row {idx}: expected Tuple, got {other:?}"),
-        };
-        assert_eq!(fields.len(), 1, "row {idx}: expected 1 field");
-        let (name, value) = &fields[0];
-        assert_eq!(name, "a", "row {idx}: field name should be `a`");
-        match value {
-            ParsedValue::Integer(v) => {
-                assert_eq!(*v as usize, idx, "row {idx}: value should equal row index");
-            }
-            other => panic!("row {idx}: expected Integer, got {other:?}"),
-        }
-    }
-}
-
-#[test]
-#[cfg_attr(windows, ignore)]
-fn ctas_oversize_row_round_trips_through_lmdb_overflow_pages() {
-    // Guard the two paths that mem(3,2)'s small rows don't exercise:
-    //   1) the reusable Vec<u8> in pqlite's CTAS arm grows past its 4 KiB
-    //      initial capacity (Vec doubles its allocation)
-    //   2) LMDB routes the value onto overflow pages (heed wraps mdb_put
-    //      which handles this transparently)
-    //
-    // We synthesize the oversize row via a 16 KiB string LITERAL embedded in
-    // the SQL projection, joined with mem(1,2) to satisfy the planner's
-    // FROM-clause requirement. This avoids adding a test-only table
-    // function to the production binary — the literal is materialized once
-    // by the parser and lives only for the duration of this CTAS.
-    const PAYLOAD_SIZE: usize = 16 * 1024;
-    let big_string: String = "x".repeat(PAYLOAD_SIZE);
-    let query = format!(
-        "CREATE TABLE t AS (SELECT '{}' AS s FROM mem(1,2) m)",
-        big_string
-    );
-
-    let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("oversize.pqlite");
-    let (ok, _stdout, stderr) = run_exec(&query, Some(&db_path));
+    let (ok, _, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(3,2) t)", Some(&dbp));
     assert!(ok, "CTAS should succeed; stderr: {stderr}");
 
-    let rows = read_all_rows(&db_path, "t");
-    assert_eq!(rows.len(), 1, "expected exactly 1 row; got: {}", rows.len());
-    let fields = match &rows[0] {
-        ParsedValue::Tuple(f) => f,
-        other => panic!("expected Tuple row, got {other:?}"),
-    };
-    assert_eq!(fields.len(), 1, "row should have exactly one field");
-    let (name, value) = &fields[0];
-    assert_eq!(name, "s", "field name should be `s`");
-    match value {
-        ParsedValue::String(s) => {
-            assert_eq!(
-                s.len(),
-                PAYLOAD_SIZE,
-                "string must be exactly {PAYLOAD_SIZE} bytes; got len={}",
-                s.len()
-            );
-            assert!(
-                s.chars().all(|c| c == 'x'),
-                "every char should be 'x' (corruption check)"
-            );
-        }
-        other => panic!("expected String, got {other:?}"),
-    }
+    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT should succeed; stderr: {stderr}");
+    // mem(3,2) yields a=0,1,2 in insertion order.
+    assert!(stdout.contains("'a': 0"), "got: {stdout}");
+    assert!(stdout.contains("'a': 1"), "got: {stdout}");
+    assert!(stdout.contains("'a': 2"), "got: {stdout}");
 }
 
 #[test]
-fn parser_adversarial_truncation_walk() {
-    // Hand-crafted valid 1-field tuple mirroring row_codec's wire format:
-    //   tuple_tag(0x03),
-    //   field_count(1 u32 LE), name_len(1 u32 LE), name "a",
-    //   tag 0x00 (Integer), value 42 (i64 LE). 19 bytes total.
-    let valid_bytes: [u8; 19] = [
-        TAG_TUPLE,
-        0x01,
-        0x00,
-        0x00,
-        0x00, // field_count = 1
-        0x01,
-        0x00,
-        0x00,
-        0x00, // name_len = 1
-        b'a', // name
-        TAG_INTEGER,
-        0x2a,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00, // i64 LE = 42
-    ];
+fn ctas_then_select_mixed_scalars() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("mixed.pqlite");
 
-    // Sanity: the full payload parses cleanly. If this fails, the loop below
-    // is testing the wrong baseline.
-    let row = parse_row(&valid_bytes);
-    let fields = match &row {
-        ParsedValue::Tuple(f) => f,
-        other => panic!("expected Tuple row, got {other:?}"),
-    };
-    assert_eq!(fields.len(), 1);
-    assert_eq!(fields[0].0, "a");
-    assert_eq!(fields[0].1, ParsedValue::Integer(42));
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a, 2.5 AS b, 'x' AS c, NULL AS d FROM mem(1,2) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
 
-    // Truncate at every offset 0..19. Every truncation MUST panic — never
-    // return a half-parsed value, never read OOB. catch_unwind verifies
-    // the parser exits via a panic, not via a normal return.
-    for len in 0..valid_bytes.len() {
-        let truncated = &valid_bytes[..len];
-        let result = std::panic::catch_unwind(|| parse_row(truncated));
-        assert!(
-            result.is_err(),
-            "parser returned without panicking on truncation len={len}: must never return half-parsed bytes",
+    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT should succeed; stderr: {stderr}");
+    assert!(stdout.contains("'a': 1"), "got: {stdout}");
+    assert!(stdout.contains("'b': 2.5"), "got: {stdout}");
+    assert!(stdout.contains("'c': 'x'"), "got: {stdout}");
+    assert!(stdout.contains("'d': NULL"), "got: {stdout}");
+    // The Missing value would be a regression — distinct from explicit NULL.
+    assert!(!stdout.contains("MISSING"), "got: {stdout}");
+}
+
+#[test]
+fn ctas_then_select_preserves_multi_field_struct_shape() {
+    // Two-column row guards field-name preservation and column ordering
+    // through the encode → LMDB → decode → format pipeline. Nested tuples
+    // (i.e. a column whose VALUE is itself a tuple) are not yet supported
+    // by the encoder — the inline `{ 'k': v }` literal lowers to
+    // ValueType::Tuple, which `write_value` rejects — so the nested case
+    // is intentionally out of scope here. See PR5-deferred-items.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("tuple.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT 99 AS outer_a, 'inner_a' AS outer_b FROM mem(1,2) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+
+    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT should succeed; stderr: {stderr}");
+    // Both field names survive the round trip.
+    assert!(stdout.contains("'outer_a': 99"), "got: {stdout}");
+    assert!(stdout.contains("'outer_b': 'inner_a'"), "got: {stdout}");
+}
+
+#[test]
+fn ctas_zero_rows_then_select_prints_no_rows_no_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("empty.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t WHERE FALSE)",
+        Some(&dbp),
+    );
+    assert!(ok, "zero-row CTAS should succeed; stderr: {stderr}");
+
+    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(
+        ok,
+        "SELECT against empty table should succeed; stderr: {stderr}"
+    );
+    // Empty bag: the `<<` opener and `>>` closer surround a blank line, no rows.
+    assert!(stdout.contains("<<"), "got: {stdout}");
+    assert!(stdout.contains(">>"), "got: {stdout}");
+    assert!(
+        !stdout.contains("'a':"),
+        "expected no row payloads; got: {stdout}"
+    );
+    // Footer reports 0 rows. Anchor to the opening paren to avoid matching
+    // a hypothetical "10 rows" prefix.
+    assert!(stderr.contains("(0 rows "), "stderr: {stderr}");
+}
+
+#[test]
+fn ctas_then_select_10k_rows_completes() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("big.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT t.a FROM mem(10000,2) t)",
+        Some(&dbp),
+    );
+    assert!(ok, "10k-row CTAS should succeed; stderr: {stderr}");
+
+    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "10k-row SELECT should succeed; stderr: {stderr}");
+    // The final row (a=9999) must be visible; this catches premature termination.
+    assert!(
+        stdout.contains("'a': 9999"),
+        "expected final row visible; got tail: {:?}",
+        &stdout[stdout.len().saturating_sub(200)..]
+    );
+    // Footer reports 10000 rows. Anchor to the opening paren for tightness.
+    assert!(stderr.contains("(10000 rows "), "stderr: {stderr}");
+}
+
+#[test]
+fn two_tables_in_one_db_two_selects_in_one_run() {
+    // The pqlite binary does not support multi-statement input (`;`-separated
+    // queries are rejected by the parser). Each statement is issued as a
+    // separate `pqlite exec` invocation against the same `--db` file.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("two.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE alpha AS (SELECT t.a FROM mem(1,2) t)",
+        Some(&dbp),
+    );
+    assert!(ok, "alpha CTAS should succeed; stderr: {stderr}");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE beta AS (SELECT t.a FROM mem(2,2) t)",
+        Some(&dbp),
+    );
+    assert!(ok, "beta CTAS should succeed; stderr: {stderr}");
+
+    let (ok, stdout_alpha, stderr) = run_exec("SELECT * FROM alpha", Some(&dbp));
+    assert!(ok, "SELECT alpha should succeed; stderr: {stderr}");
+    assert!(stdout_alpha.contains("'a': 0"), "alpha got: {stdout_alpha}");
+
+    let (ok, stdout_beta, stderr) = run_exec("SELECT * FROM beta", Some(&dbp));
+    assert!(ok, "SELECT beta should succeed; stderr: {stderr}");
+    assert!(stdout_beta.contains("'a': 0"), "beta got: {stdout_beta}");
+    assert!(stdout_beta.contains("'a': 1"), "beta got: {stdout_beta}");
+}
+
+#[test]
+fn select_surfaces_truncated_row_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("trunc.pqlite");
+
+    // Seed a valid row at row id 0 so the LMDB env + named db exist.
+    let (ok, _, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)", Some(&dbp));
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+
+    // Inject a bad row at id 1: just the TAG_INTEGER byte, no 8-byte payload.
+    // LMDB is single-writer; open the env, inject, and drop before run_exec.
+    {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::inject_row(
+            &db,
+            "t",
+            1,
+            &[partiql_tools::row_codec::TAG_INTEGER],
         );
     }
-}
 
-/// Extract the message string from a `catch_unwind` payload. Panic messages
-/// land as either `&'static str` or `String` depending on whether the panic
-/// site used `panic!("literal")` or formatted via `assert!(..., "msg")`.
-fn panic_message(err: Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = err.downcast_ref::<String>() {
-        return s.clone();
-    }
-    if let Some(s) = err.downcast_ref::<&'static str>() {
-        return (*s).to_string();
-    }
-    String::from("<non-string panic payload>")
-}
-
-#[test]
-fn parser_sanity_cap_field_count_trips_before_allocation() {
-    // tuple_tag + field_count = MAX_FIELDS_PER_ROW + 1 (= 1025, LE: 0x01
-    // 0x04 0x00 0x00). The cap rejects values > MAX_FIELDS_PER_ROW.
-    //
-    // The assertion pins the panic SOURCE to the sanity cap by matching the
-    // message text. A naive `result.is_err()` would silently pass if the cap
-    // were deleted (the downstream `take()` bounds-check would fire instead
-    // on this exact 5-byte payload). Matching `"sanity:"` and `"field_count"`
-    // makes cap removal, cap weakening, and cap-position regressions all
-    // surface a different message ("ran off the end ...") and fail this test.
-    let payload: [u8; 5] = [TAG_TUPLE, 0x01, 0x04, 0x00, 0x00];
-    assert_eq!(
-        u32::from_le_bytes([0x01, 0x04, 0x00, 0x00]),
-        MAX_FIELDS_PER_ROW + 1,
-        "fixture must encode exactly MAX_FIELDS_PER_ROW + 1",
-    );
-    let result = std::panic::catch_unwind(|| parse_row(&payload));
-    let msg =
-        panic_message(result.expect_err("sanity cap must reject field_count > MAX_FIELDS_PER_ROW"));
+    let (ok, _, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "SELECT over a truncated row must fail");
     assert!(
-        msg.contains("sanity:") && msg.contains("field_count"),
-        "expected the field_count sanity-cap panic; got: {msg}",
+        stderr.contains("row 1 decode failed") && stderr.contains("truncated"),
+        "stderr was: {stderr}"
     );
 }
 
 #[test]
-fn parser_sanity_cap_name_len_trips_before_allocation() {
-    // tuple_tag + field_count=1 + name_len = MAX_NAME_LEN_BYTES + 1
-    // (= 1_048_577, LE: 0x01 0x00 0x10 0x00). The cap rejects name_len values
-    // > MAX_NAME_LEN_BYTES before attempting to read the name bytes.
-    //
-    // As with the field_count sibling, the assertion pins the panic SOURCE
-    // to the sanity cap by matching the message. Without this, removing or
-    // weakening the cap would still leave `take()`'s OOB check to fire,
-    // silently passing the test while shipping a real OOM regression.
-    let payload: [u8; 9] = [TAG_TUPLE, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x10, 0x00];
-    assert_eq!(
-        u32::from_le_bytes([0x01, 0x00, 0x10, 0x00]),
-        MAX_NAME_LEN_BYTES + 1,
-        "fixture must encode exactly MAX_NAME_LEN_BYTES + 1",
-    );
-    let result = std::panic::catch_unwind(|| parse_row(&payload));
-    let msg =
-        panic_message(result.expect_err("sanity cap must reject name_len > MAX_NAME_LEN_BYTES"));
-    assert!(
-        msg.contains("sanity:") && msg.contains("name_len"),
-        "expected the name_len sanity-cap panic; got: {msg}",
-    );
-}
-
-#[test]
-#[cfg_attr(windows, ignore)]
-fn ctas_scalar_and_string_boundaries() {
-    // Boundary values that exercise the LE byte-packing edges:
-    //   * i64::MAX (9_223_372_036_854_775_807) — every i64 bit position used
-    //   * negative Float / Decimal literal — sign bit + non-trivial mantissa
-    //   * 0.0000 — zero mantissa with non-zero scale (proves scale survives)
-    //   * empty string — proves length-prefix handles len=0 correctly
-    //
-    // We do NOT include i64::MIN — the PartiQL parser rejects the literal
-    // `-9223372036854775808` because it tokenizes as unary-minus applied to
-    // `9223372036854775808` (= i64::MAX + 1) which overflows i64. That is a
-    // parser-level constraint, not an encoder one; out of scope here.
+fn select_surfaces_unknown_tag_error() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("boundaries.pqlite");
-    let (ok, _stdout, stderr) = run_exec(
-        "CREATE TABLE t AS (            SELECT                 9223372036854775807 AS max_int,                -12345.6789 AS neg_float,                0.0000 AS zero_dec,                '' AS empty_str             FROM mem(1,1) m         )",
-        Some(&db_path),
-    );
-    assert!(ok, "boundary CTAS failed; stderr: {stderr}");
+    let dbp = dir.path().join("badtag.pqlite");
 
-    let rows = read_all_rows(&db_path, "t");
-    assert_eq!(rows.len(), 1);
-    let tuple_fields = match rows.into_iter().next().unwrap() {
-        ParsedValue::Tuple(f) => f,
-        other => panic!("expected Tuple row, got {other:?}"),
-    };
-    let fields: std::collections::HashMap<String, ParsedValue> = tuple_fields.into_iter().collect();
+    let (ok, _, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)", Some(&dbp));
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
 
-    // i64::MAX must round-trip exactly — proves the high bit of the i64 LE
-    // encoding survives the to_le_bytes/from_le_bytes round trip.
-    assert_eq!(
-        fields.get("max_int"),
-        Some(&ParsedValue::Integer(i64::MAX)),
-        "i64::MAX must round-trip exactly",
-    );
-
-    // PartiQL may type `-12345.6789` as either Float or Decimal depending on
-    // planner literal-typing rules. Accept either; the numeric value must
-    // round-trip in both representations.
-    let neg = fields.get("neg_float").expect("neg_float column missing");
-    match neg {
-        ParsedValue::Float(v) => assert!(
-            (*v - (-12345.6789_f64)).abs() < 1e-9,
-            "negative float should round-trip: got {v}",
-        ),
-        ParsedValue::Decimal { scale, mantissa } => {
-            let reconstructed = (*mantissa as f64) / 10f64.powi(*scale);
-            assert!(
-                (reconstructed - (-12345.6789_f64)).abs() < 1e-9,
-                "negative decimal should round-trip: mantissa={mantissa} scale={scale}",
-            );
-        }
-        other => panic!("expected Float or Decimal for -12345.6789, got {other:?}"),
+    // 0xFE is unassigned in the tag space.
+    // LMDB is single-writer; open the env, inject, and drop before run_exec.
+    {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::inject_row(&db, "t", 1, &[0xFE]);
     }
 
-    // 0.0000 must preserve scale even with mantissa=0 — load-bearing
-    // assertion for our 20-byte decimal encoding (4-byte i32 scale +
-    // 16-byte i128 mantissa). A bug that dropped scale would still pass an
-    // `== 0` check but corrupt non-zero decimals.
-    match fields.get("zero_dec").expect("zero_dec column missing") {
-        ParsedValue::Decimal { scale, mantissa } => {
-            assert_eq!(*mantissa, 0, "0.0000 mantissa must be exactly 0");
-            assert!(
-                *scale >= 1,
-                "0.0000 must preserve a non-zero scale, got {scale}"
-            );
-        }
-        other => panic!("expected Decimal for 0.0000, got {other:?}"),
-    }
-
-    // Empty string proves the u32 length prefix handles len=0 cleanly.
-    assert_eq!(
-        fields.get("empty_str"),
-        Some(&ParsedValue::String(String::new())),
-        "empty string must round-trip with len=0 in the u32 length prefix",
+    let (ok, _, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "SELECT over an unknown-tag row must fail");
+    assert!(
+        stderr.contains("row 1 decode failed") && stderr.contains("unknown tag"),
+        "stderr was: {stderr}"
     );
 }
 
@@ -631,25 +480,110 @@ fn ctas_rejects_bool_with_pointed_message() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)]
-fn ctas_persists_bare_scalar_rows() {
-    // Top-level shape is RowShape::Register(_) — a bag of scalars. Encoder
-    // writes TAG_INTEGER + i64 LE per row, no tuple framing.
+fn quoted_table_name_preserves_case_through_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("scalar.pqlite");
+    let dbp = dir.path().join("quoted.pqlite");
+
+    // CTAS with a CASE-SENSITIVE quoted identifier.
     let (ok, _stdout, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT VALUE t.a FROM mem(3,2) t)",
-        Some(&db_path),
+        r#"CREATE TABLE "MyTable" AS (SELECT 42 AS id FROM mem(1, 1) m)"#,
+        Some(&dbp),
     );
-    assert!(ok, "bare-scalar CTAS should succeed; stderr: {stderr}");
-    let rows = read_all_rows(&db_path, "t");
-    assert_eq!(rows.len(), 3, "expected 3 scalar rows; got: {rows:?}");
-    for (idx, row) in rows.iter().enumerate() {
-        match row {
-            ParsedValue::Integer(v) => {
-                assert_eq!(*v as usize, idx, "row {idx}: value should equal row index");
-            }
-            other => panic!("row {idx}: expected Integer, got {other:?}"),
-        }
-    }
+    assert!(
+        ok,
+        "CTAS with quoted name should succeed; stderr: {}",
+        stderr
+    );
+
+    // SELECT with the SAME case-sensitive name should find the table and return the row.
+    let (ok, stdout, stderr) = run_exec(r#"SELECT * FROM "MyTable""#, Some(&dbp));
+    assert!(
+        ok,
+        "SELECT with matching quoted name should succeed; stderr: {}",
+        stderr
+    );
+    assert!(
+        stdout.contains("42"),
+        "expected '42' in output; got stdout: {}",
+        stdout
+    );
+}
+
+#[test]
+fn quoted_table_name_is_not_found_via_different_case() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("case_distinct.pqlite");
+
+    // CTAS with a CASE-SENSITIVE quoted identifier.
+    let (ok, _, stderr) = run_exec(
+        r#"CREATE TABLE "Foo" AS (SELECT 1 AS x FROM mem(1, 1) m)"#,
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {}", stderr);
+
+    // SELECT with a BARE identifier (case-insensitive, lowercased to "foo") should NOT find "Foo".
+    let (ok, _, stderr) = run_exec(r#"SELECT * FROM foo"#, Some(&dbp));
+    assert!(
+        !ok,
+        "bare 'foo' should not find quoted \"Foo\" — case-sensitive identifiers are distinct"
+    );
+    assert!(
+        stderr.contains("Table 'foo' not found"),
+        "expected fail-fast error naming bare 'foo'; got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn wire_format_byte_shape_is_stable() {
+    // Pin the on-disk byte layout for a 2-column row. Round-trip tests can
+    // accidentally compensate for an LE↔BE flip in both encoder and decoder;
+    // a bit-for-bit anchor cannot. If this fails, the byte literal is the
+    // source of truth — investigate `serialize_row`, do not rewrite the test.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("anchor.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a, 'xy' AS b FROM mem(1,2) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+
+    let row0 = {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::read_row(&db, "t", 0)
+    };
+
+    // Expected wire format for {"a": 1i64, "b": "xy"}:
+    //   TAG_TUPLE (0x03)
+    //   field_count = 2 (LE u32: 02 00 00 00)
+    //   field 0:
+    //     name_len = 1 (LE u32: 01 00 00 00)
+    //     name = 'a'   (0x61)
+    //     TAG_INTEGER (0x00)
+    //     i64 value = 1 (LE: 01 00 00 00 00 00 00 00)
+    //   field 1:
+    //     name_len = 1 (LE u32: 01 00 00 00)
+    //     name = 'b'   (0x62)
+    //     TAG_STRING (0x05)
+    //     str_len = 2  (LE u32: 02 00 00 00)
+    //     str bytes = 'x' 'y' (0x78 0x79)
+    // name_len (1) deliberately differs from str_len (2) so a regression that
+    // swapped the two u32 prefixes would not cancel out.
+    let expected: &[u8] = &[
+        0x03, // TAG_TUPLE
+        0x02, 0x00, 0x00, 0x00, // field_count = 2
+        0x01, 0x00, 0x00, 0x00, 0x61, // name "a"
+        0x00, // TAG_INTEGER
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 1 LE
+        0x01, 0x00, 0x00, 0x00, 0x62, // name "b"
+        0x05, // TAG_STRING
+        0x02, 0x00, 0x00, 0x00, // str_len = 2
+        0x78, 0x79, // "xy"
+    ];
+
+    assert_eq!(
+        row0, expected,
+        "wire format byte shape regressed: expected {expected:02x?}, got {row0:02x?}",
+    );
 }


### PR DESCRIPTION
# feat: add read path for pqlite


Hey everyone! This PR adds the read path for pqlite under partiql-tools/. 

In our most recent storage PR (#644), we got the write path working (CREATE TABLE AS). This PR finishes the query loop so that if you save data into a table using CTAS, you can read it right back out with a standard SELECT *. 

This satisfies the milestone exit criteria: CTAS followed by SELECT round-trips end-to-end.

7 files changed: +1248 / -666. Verified: 53 tests total (30 library, 3 binary, 20 integration), clippy clean, and fmt clean. Significant test churn replaces old manual parsing fixtures from #644 with a robust end-to-end integration test suite.

------------------------------------------------------------------------
Verification Example:
------------------------------------------------------------------------
pqlite --db test.pqlite exec "CREATE TABLE t AS (SELECT 'hello' AS status FROM mem(1, 1) m)"
pqlite --db test.pqlite exec "SELECT * FROM t"
Output: << { 'status': 'hello' } >>

------------------------------------------------------------------------
Backstory: Where pqlite Came From
------------------------------------------------------------------------
If you haven't been tracking the recent storage sprints, pqlite is a small embeddable PartiQL engine living at partiql-tools/src/bin/pqlite.rs. Think of it as "SQLite for PartiQL." It persists tables in a single-file LMDB database (via the heed crate) and uses partiql-eval as its execution library.

It's been built up across three previous steps:
- PR1 (#641): Added the basic LMDB environment hook, the --db flag for picking a database file, and the internal _tables system catalog to track which tables exist.
- PR2 (#642): Added parsing and logical planning for CREATE TABLE AS. CTAS lives at a new LogicalStatement layer above LogicalPlan, since DDL acts as a statement category rather than a typical relational query operator.
- PR3 (#644): Shipped the write path. Introduced a custom tagged-union wire format for rows (serialize_row in row_codec.rs) that encodes VM register state directly to bytes with zero allocation per row after warmup. All multi-byte values are little-endian, but the row-id keys in LMDB are big-endian so lexicographic byte order matches numeric sort order.
- This PR (Read Milestone): Adds the read path. Brings the catalog, DataSource implementation, and CLI binary plumbing needed to scan tables back out with a standard SELECT.

Going custom on the wire format (instead of throwing Ion or an off-the-shelf serializer at it) was a deliberate design choice in #644: it gives us total control over the on-disk footprint and cuts out per-row heap overhead. The decoder added in this PR is the direct, symmetric companion to #644's encoder. 

------------------------------------------------------------------------
What I Did:
------------------------------------------------------------------------

 ### 1. Added Read Primitives — `partiql-tools/src/storage.rs`

  Three new methods on `HeedDB` so the query engine can pull rows out:
  - `read_txn()` — opens a read-only LMDB transaction.
  - `open_table(&txn, name)` — gets a handle to a persisted table's row store.
  - `list_table_names(&txn)` — lists every table in our `_tables` catalog.

  Also added `StorageError::ScanTooLarge` as a safety check so a single
  scan can't balloon past 4 GiB without surfacing a clean error.

  ### 2. Built the Symmetric Row Decoder — `partiql-tools/src/row_codec.rs`

  Wrote `deserialize_row_into` to unpack raw disk bytes straight into the
  VM's registers with zero middle-man allocations.

  - Marked `unsafe` because it pulls zero-copy string slices directly
    from the source buffer using lifetime extensions. The caller must
    keep that buffer alive for the duration of the scan.


  ### 3. Wired up Catalog & DataSource — `partiql-tools/src/catalog.rs` (new)

  New module connecting our storage layer to `partiql_eval`'s catalog traits.

  - `HeedTableMetadata::resolve` intentionally returns `None` for every
    field name. This forces the compiler down the `WholeValue` projection
    branch, dropping the whole row tuple into register slot 0 so the VM
    can resolve fields at runtime.
  - `HeedExecutionCatalog` eagerly collects scanned rows into one flat
    `Vec<u8>` buffer plus a `Vec<Range<u32>>` index, replacing the legacy
    per-row allocations with a single amortized-growth pattern.

  ### 4. Cleaned up the REPL Binary — `partiql-tools/src/bin/pqlite.rs`

  Refactored `execute_query` to share a single open `HeedDB` instance
  across statements, eliminating the wtxn-commit + fsync overhead of
  reopening the environment on every query.

  - Added `CombinedCatalog`: since `PlanCompiler` hardcodes the single
    catalog name `"default"`, this wrapper structurally bundles our
    persisted tables alongside built-in table functions (`rand`, `mem`,
    `scan_ion`) under one name.
  - Added a fail-fast check during compilation so a typo in a table
    name surfaces as `Error: Table '<name>' not found` instead of
    letting Permissive mode silently yield a fake MISSING row.

  ### 5. Added Solid Test Coverage — `partiql-tools/tests/pqlite_cli.rs`

  Replaced the old manual parsing fixtures with an end-to-end integration
  suite of 20 tests. The suite covers:

  - End-to-end subprocess round-trips: scalars, mixed types, empty tables,
    multi-field tuples, multi-table databases.
  - Case-sensitive vs bare quoted-identifier behavior.
  - Byte-shape anchor test asserting exact disk layout so LE/BE encoding
    never drifts out of sync.
  - Fail-fast tests for SELECT against unknown tables.
  - Malformed byte-injection tests to confirm corrupt rows surface as
    clean stderr errors instead of panics.

------------------------------------------------------------------------
Commit Structure (Fully Bisectable)
------------------------------------------------------------------------
The history is split into 5 layered commits so that each step makes sense and cargo check passes completely on every single revision:

1. 8607f8d -- Storage primitives: read_txn, open_table, list_table_names
2. d4e0781 -- Row codec: The symmetric decoder 
3. 75a5feb -- Catalog: Hooking up HeedCompilationCatalog and HeedTableSource
4. 985cc2f -- Binary wiring: Open-once database caching, CombinedCatalog, and fail-fast checking
5. d9aea11 -- Tests: Full E2E CLI suite and error surfacing blocks

------------------------------------------------------------------------
Known Upstream Limitations (Pre-existing on dev branch)
------------------------------------------------------------------------
These queries fail or return wrong results because of bugs or missing features inside the upstream partiql-eval or partiql-logical-planner crates--this PR didn't touch those directories:
- Aliased FROM clauses: Writing FROM table alias returns MISSING because of a local rewriting bug in search_locals (Logged with John on Slack to fix in a future planner PR). Workaround: unaliased formats like SELECT col FROM table cover all current tests.
- Arithmetic on persisted columns: Performing operations like m.col * 5 fails with "Type mismatch for add!" because it is a downstream symptom of the alias-MISSING bug.
- Constant SELECTs: Writing SELECT 42 fails compilation with InvalidPlan because the upstream planner requires a relational input source to run a projection.
- Cross Joins: Writing FROM a, b errors out because join operators aren't mapped in the VM bytecode loop yet.

------------------------------------------------------------------------
Deferred to Follow-up PRs
------------------------------------------------------------------------
To hit our exact read/write loop targets for this initial milestone, the following items have been pushed out to our future roadmap:

- Universal Type Support (Our Immediate Next Milestone / Next Storage PR):
  Expanding the row codec to read and write all remaining PartiQL types, including deeply nested data like arrays, bags, and structs.

- INSERT Statement Support:
  Adding the parser, AST, and logical planning plumbing for INSERT statements so callers can append rows to existing tables without re-running CTAS.

- System Table Expansion & Value-Based Keying:
  Building out the rest of our system databases (SCHEMAS, CATALOG, FUNCTIONS) and migrating our storage engine to key tables using serialized PartiQL values instead of direct strings.

- Schema Registry & Real Scan Projections:
  Because we do not store table schemas yet, the catalog defaults to a WholeValue layout fallback. True column projection pushdowns are deferred until the schema catalog layer is implemented.

- Streaming Row Iteration:
  Currently, HeedExecutionCatalog materializes all of a table's rows into memory before delivering the first one. A streaming implementation that co-owns the RoTxn and RoIter is a potential follow-up but out of scope for now. 