### PR TITLE
feat(pqlite): extend row codec to the all current PartiQL values

### DIFF
--- a/partiql-tools/src/catalog.rs
+++ b/partiql-tools/src/catalog.rs
@@ -226,9 +226,6 @@ impl DataSource for HeedTableSource {
 mod tests {
     use super::*;
 
-    // 0x06 (TAG_NULL): parseable single-byte row; only used to confirm catalog plumbing.
-    const TAG_NULL_PLACEHOLDER: u8 = 0x06;
-
     #[test]
     fn metadata_resolve_returns_none() {
         let m = HeedTableMetadata;
@@ -283,7 +280,9 @@ mod tests {
         let path = dir.path().join("cat.pqlite");
         let db = Arc::new(HeedDB::open(&path).unwrap());
         let mut w = db.create_table("widgets").unwrap();
-        w.push_row(&[TAG_NULL_PLACEHOLDER]).unwrap();
+        // TAG_NULL: a complete single-byte NULL row (NULL has no payload);
+        // only used to confirm catalog plumbing.
+        w.push_row(&[crate::row_codec::TAG_NULL]).unwrap();
         w.commit().unwrap();
 
         let cat = HeedCompilationCatalog::new(Arc::clone(&db));

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -17,16 +17,21 @@ pub const MAX_FIELDS_PER_ROW: u32 = 1024;
 /// Cap on `name_len` (UTF-8 byte length) to bound allocations on corruption.
 pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 
-pub const TAG_INTEGER: u8 = 0x00;
-pub const TAG_DECIMAL: u8 = 0x01;
-pub const TAG_FLOAT: u8 = 0x02;
-pub const TAG_TUPLE: u8 = 0x03;
-// 0x04 = TAG_BAG     — reserved; rejected.
-pub const TAG_STRING: u8 = 0x05;
-pub const TAG_NULL: u8 = 0x06;
-// 0x07 = TAG_MISSING — reserved; rejected.
-// 0x08 = TAG_BOOL    — reserved; rejected.
-// 0x09 = TAG_BYTES   — reserved; rejected.
+// Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
+// load-bearing: a later commit tells a container-rooted row from a
+// scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
+// tag may sit at or above TAG_TUPLE.
+pub const TAG_NULL: u8 = 0x00;
+pub const TAG_MISSING: u8 = 0x01;
+pub const TAG_BOOL: u8 = 0x02;
+pub const TAG_INTEGER: u8 = 0x03;
+pub const TAG_FLOAT: u8 = 0x04;
+pub const TAG_DECIMAL: u8 = 0x05;
+pub const TAG_STRING: u8 = 0x06;
+pub const TAG_BYTES: u8 = 0x07;
+pub const TAG_TUPLE: u8 = 0x08;
+pub const TAG_LIST: u8 = 0x09;
+pub const TAG_BAG: u8 = 0x0A;
 
 #[derive(Debug)]
 pub enum SerializeError {

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -17,6 +17,9 @@ pub const MAX_FIELDS_PER_ROW: u32 = 1024;
 /// Cap on `name_len` (UTF-8 byte length) to bound allocations on corruption.
 pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 
+/// Cap on `bytes` payload length to bound allocations on corruption.
+pub const MAX_BYTES_LEN: u32 = 1024 * 1024;
+
 // Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
 // load-bearing: a later commit tells a container-rooted row from a
 // scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
@@ -35,8 +38,8 @@ pub const TAG_BAG: u8 = 0x0A;
 
 #[derive(Debug)]
 pub enum SerializeError {
-    /// Unsupported type or shape: containers, dynamic field names, MISSING,
-    /// BOOL, BYTES, or top-level scalar rows (must be wrapped in a tuple).
+    /// Unsupported type or shape: containers (Tuple/List/Bag), dynamic field
+    /// names, or top-level scalar rows (must be wrapped in a tuple).
     /// The string identifies the offending field or top-level value.
     Unsupported(String),
 }
@@ -155,12 +158,34 @@ fn write_value(
             buf.extend_from_slice(&str_len.to_le_bytes());
             buf.extend_from_slice(sb);
         }
-        ty @ (ValueType::Bool
-        | ValueType::Bytes
-        | ValueType::Missing
-        | ValueType::Tuple
-        | ValueType::List
-        | ValueType::Bag) => {
+        ValueType::Bool => {
+            buf.push(TAG_BOOL);
+            let b = view.get_bool().expect("bool view");
+            buf.push(if b { 0x01 } else { 0x00 });
+        }
+        ValueType::Missing => {
+            buf.push(TAG_MISSING);
+        }
+        ValueType::Bytes => {
+            buf.push(TAG_BYTES);
+            let b = view.get_bytes().expect("bytes view");
+            if b.len() > MAX_BYTES_LEN as usize {
+                let prefix = match field_name {
+                    Some(name) => format!("field '{name}'"),
+                    None => "top-level value".to_string(),
+                };
+                return Err(SerializeError::Unsupported(format!(
+                    "{prefix}: bytes length {} exceeds MAX_BYTES_LEN ({})",
+                    b.len(),
+                    MAX_BYTES_LEN
+                )));
+            }
+            // Safe: the cap above bounds b.len() to MAX_BYTES_LEN (u32).
+            let byte_len: u32 = b.len() as u32;
+            buf.extend_from_slice(&byte_len.to_le_bytes());
+            buf.extend_from_slice(b);
+        }
+        ty @ (ValueType::Tuple | ValueType::List | ValueType::Bag) => {
             let prefix = match field_name {
                 Some(name) => format!("field '{name}'"),
                 None => "top-level value".to_string(),
@@ -180,6 +205,8 @@ pub enum DeserializeError {
     InvalidUtf8,
     NameTooLong(u32),
     FieldCountTooLarge(u32),
+    InvalidBool(u8),
+    BytesTooLong(u32),
     /// Reserved tag or `ValueWriter` failure; symmetric to encoder rejection.
     Unsupported(String),
 }
@@ -196,6 +223,10 @@ impl std::fmt::Display for DeserializeError {
             DeserializeError::FieldCountTooLarge(n) => {
                 write!(f, "tuple field count {n} exceeds {MAX_FIELDS_PER_ROW}")
             }
+            DeserializeError::InvalidBool(b) => write!(f, "invalid bool payload: 0x{b:02x}"),
+            DeserializeError::BytesTooLong(len) => {
+                write!(f, "bytes length {len} exceeds MAX_BYTES_LEN")
+            }
             DeserializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
         }
     }
@@ -211,7 +242,7 @@ impl std::error::Error for DeserializeError {}
 /// register. In practice the caller (a `DataSource::next_row`
 /// implementation) must hold the backing row buffer for the duration
 /// of the scan. Violating this precondition causes use-after-free of
-/// the string slices written into the engine's arena via the
+/// the string and byte slices written into the engine's arena via the
 /// lifetime extensions inside `decode_tagged_into`.
 ///
 /// String UTF-8 validity is checked inline by `take_str` as each
@@ -292,6 +323,31 @@ fn decode_tagged_into(
             }
             vw.step_out().map_err(io_err)?;
         }
+        TAG_BOOL => {
+            let b = take_byte(bytes, cursor)?;
+            match b {
+                0x00 => vw.put_bool(false).map_err(io_err)?,
+                0x01 => vw.put_bool(true).map_err(io_err)?,
+                _ => return Err(DeserializeError::InvalidBool(b)),
+            }
+        }
+        TAG_MISSING => {
+            vw.put_missing().map_err(io_err)?;
+        }
+        TAG_BYTES => {
+            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if len > MAX_BYTES_LEN {
+                return Err(DeserializeError::BytesTooLong(len));
+            }
+            let end = cursor
+                .checked_add(len as usize)
+                .ok_or(DeserializeError::Truncated)?;
+            let slice = bytes.get(*cursor..end).ok_or(DeserializeError::Truncated)?;
+            *cursor = end;
+            // Safety: see `deserialize_row_into`'s # Safety block.
+            let b_ext: &[u8] = unsafe { extend_bytes_to_arena_lifetime(slice) };
+            vw.put_bytes(b_ext).map_err(io_err)?;
+        }
         t => return Err(DeserializeError::UnknownTag(t)),
     }
     Ok(())
@@ -346,6 +402,23 @@ unsafe fn extend_to_arena_lifetime<'out>(s: &str) -> &'out str {
     // SAFETY: caller upholds the precondition documented on
     // deserialize_row_into.
     unsafe { &*(s as *const str) }
+}
+
+/// Extends `b`'s lifetime to match the arena's. Sibling of
+/// [`extend_to_arena_lifetime`] for `&[u8]`: the caller must uphold the same
+/// backing-buffer-outlives-arena-reset invariant.
+///
+/// The output lifetime `'out` is unrelated to the input lifetime to permit
+/// the arena-lifetime borrow `put_bytes` requires.
+///
+/// # Safety
+///
+/// See [`deserialize_row_into`].
+#[inline]
+unsafe fn extend_bytes_to_arena_lifetime<'out>(b: &[u8]) -> &'out [u8] {
+    // SAFETY: caller upholds the precondition documented on
+    // deserialize_row_into.
+    unsafe { &*(b as *const [u8]) }
 }
 
 #[inline]

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -23,6 +23,14 @@ pub const MAX_BYTES_LEN: u32 = 1024 * 1024;
 /// Cap on `string` payload length (UTF-8 bytes) to bound allocations on corruption.
 pub const MAX_STRING_LEN: u32 = 1024 * 1024;
 
+/// Cap on container nesting depth to bound stack use when decoding a
+/// deeply nested (possibly adversarial) on-disk payload.
+///
+/// Safety invariant: the encoder rejects at a depth no deeper than the decoder
+/// on every path (encode is the stricter side), so any row the encoder produces
+/// is always decodable.
+pub const MAX_RECURSION_DEPTH: u32 = 128;
+
 // Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
 // load-bearing: deserialize_row_into tells a container-rooted row from a
 // scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
@@ -72,7 +80,7 @@ pub fn serialize_row(
 ) -> Result<(), SerializeError> {
     buf.clear();
     match row_shape {
-        RowShape::Struct(fields) => write_tuple(row, fields, buf),
+        RowShape::Struct(fields) => write_tuple(row, fields, 0, buf),
         RowShape::Register(slot, _) => write_value_at_root(row, *slot, buf),
     }
 }
@@ -90,8 +98,14 @@ fn write_value_at_root(
 fn write_tuple(
     row: &RegisterReader<'_>,
     fields: &[partiql_eval::value::FieldShape],
+    depth: u32,
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
+    if depth > MAX_RECURSION_DEPTH {
+        return Err(SerializeError::Unsupported(format!(
+            "nesting depth {depth} exceeds MAX_RECURSION_DEPTH ({MAX_RECURSION_DEPTH})"
+        )));
+    }
     if fields.len() > MAX_FIELDS_PER_ROW as usize {
         return Err(SerializeError::Unsupported(format!(
             "tuple has {} fields, exceeds MAX_FIELDS_PER_ROW ({})",
@@ -125,7 +139,7 @@ fn write_tuple(
         buf.extend_from_slice(name.as_bytes());
         match &field.value {
             RowShape::Register(idx, _) => write_value(row, *idx, Some(name), buf)?,
-            RowShape::Struct(nested_fields) => write_tuple(row, nested_fields, buf)?,
+            RowShape::Struct(nested_fields) => write_tuple(row, nested_fields, depth + 1, buf)?,
         }
     }
     Ok(())
@@ -228,6 +242,7 @@ pub enum DeserializeError {
     InvalidBool(u8),
     BytesTooLong(u32),
     StringTooLong(u32),
+    DepthExceeded(u32),
     /// Reserved tag or `ValueWriter` failure; symmetric to encoder rejection.
     Unsupported(String),
 }
@@ -250,6 +265,9 @@ impl std::fmt::Display for DeserializeError {
             }
             DeserializeError::StringTooLong(len) => {
                 write!(f, "string length {len} exceeds MAX_STRING_LEN")
+            }
+            DeserializeError::DepthExceeded(d) => {
+                write!(f, "nesting depth {d} exceeds MAX_RECURSION_DEPTH")
             }
             DeserializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
         }
@@ -324,7 +342,7 @@ pub unsafe fn deserialize_row_into(
         let mut vw = writer.value_writer(target_slot).map_err(|e| {
             DeserializeError::Unsupported(format!("value_writer({target_slot}): {e}"))
         })?;
-        decode_tagged_into(&mut vw, bytes, &mut cursor)?;
+        decode_tagged_into(&mut vw, bytes, &mut cursor, 0)?;
         if cursor != bytes.len() {
             return Err(DeserializeError::Unsupported(format!(
                 "trailing bytes after row decode: {} of {} consumed",
@@ -423,7 +441,11 @@ fn decode_tagged_into(
     vw: &mut partiql_eval::source::ValueWriter<'_, '_>,
     bytes: &[u8],
     cursor: &mut usize,
+    depth: u32,
 ) -> Result<(), DeserializeError> {
+    if depth > MAX_RECURSION_DEPTH {
+        return Err(DeserializeError::DepthExceeded(depth));
+    }
     let tag = take_byte(bytes, cursor)?;
     match tag {
         TAG_TUPLE => {
@@ -441,7 +463,7 @@ fn decode_tagged_into(
                 // Safety: see `deserialize_row_into`'s # Safety block.
                 let name_ext: &str = unsafe { extend_to_arena_lifetime(name) };
                 vw.put_field_name(name_ext).map_err(io_err)?;
-                decode_tagged_into(vw, bytes, cursor)?;
+                decode_tagged_into(vw, bytes, cursor, depth + 1)?;
             }
             vw.step_out().map_err(io_err)?;
         }

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -24,7 +24,7 @@ pub const MAX_BYTES_LEN: u32 = 1024 * 1024;
 pub const MAX_STRING_LEN: u32 = 1024 * 1024;
 
 // Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
-// load-bearing: a later commit tells a container-rooted row from a
+// load-bearing: deserialize_row_into tells a container-rooted row from a
 // scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
 // tag may sit at or above TAG_TUPLE.
 pub const TAG_NULL: u8 = 0x00;
@@ -41,9 +41,9 @@ pub const TAG_BAG: u8 = 0x0A;
 
 #[derive(Debug)]
 pub enum SerializeError {
-    /// Unsupported type or shape: containers (Tuple/List/Bag), dynamic field
-    /// names, or top-level scalar rows (must be wrapped in a tuple).
-    /// The string identifies the offending field or top-level value.
+    /// Unsupported type or shape: containers (Tuple/List/Bag) or dynamic
+    /// field names. The string identifies the offending field or top-level
+    /// value.
     Unsupported(String),
 }
 
@@ -73,13 +73,18 @@ pub fn serialize_row(
     buf.clear();
     match row_shape {
         RowShape::Struct(fields) => write_tuple(row, fields, buf),
-        // A bare scalar tag with no tuple frame round-trips on write but
-        // fails on read: the decoder's `vw.put_scalar` requires a
-        // non-empty frame stack. Refuse at encode time.
-        RowShape::Register(_, _) => Err(SerializeError::Unsupported(
-            "top-level scalar rows are not yet supported; wrap in a tuple".to_string(),
-        )),
+        RowShape::Register(slot, _) => write_value_at_root(row, *slot, buf),
     }
+}
+
+fn write_value_at_root(
+    row: &RegisterReader<'_>,
+    slot: usize,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    // Top-level scalar rows land as a bare tag + payload with no tuple frame.
+    // `field_name = None` selects the "top-level value" error prefix.
+    write_value(row, slot, None, buf)
 }
 
 fn write_tuple(
@@ -253,6 +258,43 @@ impl std::fmt::Display for DeserializeError {
 
 impl std::error::Error for DeserializeError {}
 
+/// Decode a scalar-rooted row directly into `target_slot` via `RegisterWriter`.
+///
+/// # Safety
+///
+/// Same contract as [`deserialize_row_into`]: `bytes` must outlive every
+/// arena reset that touches `target_slot`. Reachable only when the row's
+/// first byte is a scalar tag (`< TAG_TUPLE`); container roots use the
+/// `ValueWriter` frame-stack path in `deserialize_row_into`.
+unsafe fn decode_top_scalar_into(
+    bytes: &[u8],
+    writer: &mut partiql_eval::source::RegisterWriter<'_, '_>,
+    target_slot: u16,
+) -> Result<(), DeserializeError> {
+    let mut cursor = 0usize;
+    let tag = take_byte(bytes, &mut cursor)?;
+    // Safety: see this fn's # Safety block; contract is delegated to the helper.
+    let scalar = unsafe { decode_scalar_payload(tag, bytes, &mut cursor)? };
+    match scalar {
+        Scalar::Null => writer.write_null(target_slot).map_err(io_err)?,
+        Scalar::Missing => writer.write_missing(target_slot).map_err(io_err)?,
+        Scalar::Bool(v) => writer.write_bool(target_slot, v).map_err(io_err)?,
+        Scalar::I64(v) => writer.write_i64(target_slot, v).map_err(io_err)?,
+        Scalar::F64(v) => writer.write_f64(target_slot, v).map_err(io_err)?,
+        Scalar::Decimal(d) => writer.write_decimal(target_slot, d).map_err(io_err)?,
+        Scalar::Str(s) => writer.write_str(target_slot, s).map_err(io_err)?,
+        Scalar::Bytes(b) => writer.write_bytes(target_slot, b).map_err(io_err)?,
+    }
+    if cursor != bytes.len() {
+        return Err(DeserializeError::Unsupported(format!(
+            "trailing bytes after scalar-root row: {} of {} consumed",
+            cursor,
+            bytes.len()
+        )));
+    }
+    Ok(())
+}
+
 /// Decode one row of the tagged-union wire format into `writer`'s `target_slot`.
 ///
 /// # Safety
@@ -262,7 +304,7 @@ impl std::error::Error for DeserializeError {}
 /// implementation) must hold the backing row buffer for the duration
 /// of the scan. Violating this precondition causes use-after-free of
 /// the string and byte slices written into the engine's arena via the
-/// lifetime extensions inside `decode_tagged_into`.
+/// lifetime extensions inside `decode_scalar_payload` and `decode_tagged_into`.
 ///
 /// String UTF-8 validity is checked inline by `take_str` as each
 /// string is read; no pre-pass is required.
@@ -271,21 +313,110 @@ pub unsafe fn deserialize_row_into(
     writer: &mut partiql_eval::source::RegisterWriter<'_, '_>,
     target_slot: u16,
 ) -> Result<(), DeserializeError> {
-    let mut cursor = 0usize;
-    let mut vw = writer
-        .value_writer(target_slot)
-        .map_err(|e| DeserializeError::Unsupported(format!("value_writer({target_slot}): {e}")))?;
-    decode_tagged_into(&mut vw, bytes, &mut cursor)?;
-    if cursor != bytes.len() {
-        return Err(DeserializeError::Unsupported(format!(
-            "trailing bytes after row decode: {} of {} consumed",
-            cursor,
-            bytes.len()
-        )));
+    if bytes.is_empty() {
+        return Err(DeserializeError::Truncated);
     }
-    vw.finish()
-        .map_err(|e| DeserializeError::Unsupported(format!("finish: {e}")))?;
+    // Container-rooted rows start with a tag >= TAG_TUPLE (0x08) and use the
+    // ValueWriter frame-stack path. Scalar-rooted rows write straight to the
+    // register (a bare scalar has no frame for ValueWriter::put_*).
+    if bytes[0] >= TAG_TUPLE {
+        let mut cursor = 0usize;
+        let mut vw = writer.value_writer(target_slot).map_err(|e| {
+            DeserializeError::Unsupported(format!("value_writer({target_slot}): {e}"))
+        })?;
+        decode_tagged_into(&mut vw, bytes, &mut cursor)?;
+        if cursor != bytes.len() {
+            return Err(DeserializeError::Unsupported(format!(
+                "trailing bytes after row decode: {} of {} consumed",
+                cursor,
+                bytes.len()
+            )));
+        }
+        vw.finish()
+            .map_err(|e| DeserializeError::Unsupported(format!("finish: {e}")))?;
+    } else {
+        // Safety: same contract as this function's # Safety block.
+        unsafe { decode_top_scalar_into(bytes, writer, target_slot)? };
+    }
     Ok(())
+}
+
+/// A decoded scalar value. `Str`/`Bytes` carry arena-lifetime borrows
+/// laundered from the source buffer.
+enum Scalar<'a> {
+    Null,
+    Missing,
+    Bool(bool),
+    I64(i64),
+    F64(f64),
+    Decimal(rust_decimal::Decimal),
+    Str(&'a str),
+    Bytes(&'a [u8]),
+}
+
+/// Decode the payload for a single scalar `tag`, advancing `cursor`. The
+/// single source of truth for scalar reads shared by the register-root path
+/// (`decode_top_scalar_into`) and the `ValueWriter` frame path
+/// (`decode_tagged_into`): the two must decode byte-identically forever, so
+/// the reads live here once. An unknown scalar tag yields `UnknownTag`.
+///
+/// # Safety
+///
+/// The `Str`/`Bytes` variants carry borrows extended to an unbounded arena
+/// lifetime. See [`deserialize_row_into`]'s `# Safety` block: `bytes` must
+/// outlive every arena reset that touches the register the value is written
+/// into.
+unsafe fn decode_scalar_payload<'a>(
+    tag: u8,
+    bytes: &[u8],
+    cursor: &mut usize,
+) -> Result<Scalar<'a>, DeserializeError> {
+    let scalar = match tag {
+        TAG_NULL => Scalar::Null,
+        TAG_MISSING => Scalar::Missing,
+        TAG_BOOL => {
+            let b = take_byte(bytes, cursor)?;
+            match b {
+                0x00 => Scalar::Bool(false),
+                0x01 => Scalar::Bool(true),
+                _ => return Err(DeserializeError::InvalidBool(b)),
+            }
+        }
+        TAG_INTEGER => Scalar::I64(i64::from_le_bytes(take_array::<8>(bytes, cursor)?)),
+        TAG_FLOAT => Scalar::F64(f64::from_le_bytes(take_array::<8>(bytes, cursor)?)),
+        TAG_DECIMAL => {
+            let scale = i32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            let mantissa = i128::from_le_bytes(take_array::<16>(bytes, cursor)?);
+            let scale_u32 = u32::try_from(scale).map_err(|_| {
+                DeserializeError::Unsupported(format!("negative decimal scale {scale}"))
+            })?;
+            let d = rust_decimal::Decimal::try_from_i128_with_scale(mantissa, scale_u32)
+                .map_err(|e| DeserializeError::Unsupported(format!("invalid decimal: {e}")))?;
+            Scalar::Decimal(d)
+        }
+        TAG_STRING => {
+            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if len > MAX_STRING_LEN {
+                return Err(DeserializeError::StringTooLong(len));
+            }
+            let s = take_str(bytes, cursor, len)?;
+            // Safety: see `deserialize_row_into`'s # Safety block.
+            let s_ext: &'a str = unsafe { extend_to_arena_lifetime(s) };
+            Scalar::Str(s_ext)
+        }
+        TAG_BYTES => {
+            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if len > MAX_BYTES_LEN {
+                return Err(DeserializeError::BytesTooLong(len));
+            }
+            let slice = take_bytes(bytes, cursor, len)?;
+            // Safety: see `deserialize_row_into`'s # Safety block.
+            let b_ext: &'a [u8] = unsafe { extend_bytes_to_arena_lifetime(slice) };
+            Scalar::Bytes(b_ext)
+        }
+        t => return Err(DeserializeError::UnknownTag(t)),
+    };
+    Ok(scalar)
 }
 
 fn decode_tagged_into(
@@ -295,37 +426,6 @@ fn decode_tagged_into(
 ) -> Result<(), DeserializeError> {
     let tag = take_byte(bytes, cursor)?;
     match tag {
-        TAG_INTEGER => {
-            let v = i64::from_le_bytes(take_array::<8>(bytes, cursor)?);
-            vw.put_i64(v).map_err(io_err)?;
-        }
-        TAG_FLOAT => {
-            let v = f64::from_le_bytes(take_array::<8>(bytes, cursor)?);
-            vw.put_f64(v).map_err(io_err)?;
-        }
-        TAG_DECIMAL => {
-            let scale = i32::from_le_bytes(take_array::<4>(bytes, cursor)?);
-            let mantissa = i128::from_le_bytes(take_array::<16>(bytes, cursor)?);
-            let scale_u32 = u32::try_from(scale).map_err(|_| {
-                DeserializeError::Unsupported(format!("negative decimal scale {scale}"))
-            })?;
-            let d = rust_decimal::Decimal::try_from_i128_with_scale(mantissa, scale_u32)
-                .map_err(|e| DeserializeError::Unsupported(format!("invalid decimal: {e}")))?;
-            vw.put_decimal(d).map_err(io_err)?;
-        }
-        TAG_STRING => {
-            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
-            if len > MAX_STRING_LEN {
-                return Err(DeserializeError::StringTooLong(len));
-            }
-            let s = take_str(bytes, cursor, len)?;
-            // Safety: see `deserialize_row_into`'s # Safety block.
-            let s_ext: &str = unsafe { extend_to_arena_lifetime(s) };
-            vw.put_str(s_ext).map_err(io_err)?;
-        }
-        TAG_NULL => {
-            vw.put_null().map_err(io_err)?;
-        }
         TAG_TUPLE => {
             let field_count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
             if field_count > MAX_FIELDS_PER_ROW {
@@ -345,32 +445,21 @@ fn decode_tagged_into(
             }
             vw.step_out().map_err(io_err)?;
         }
-        TAG_BOOL => {
-            let b = take_byte(bytes, cursor)?;
-            match b {
-                0x00 => vw.put_bool(false).map_err(io_err)?,
-                0x01 => vw.put_bool(true).map_err(io_err)?,
-                _ => return Err(DeserializeError::InvalidBool(b)),
+        _ => {
+            // Safety: decode_tagged_into is only reached from deserialize_row_into,
+            // which upholds the # Safety contract; delegated to the helper.
+            let scalar = unsafe { decode_scalar_payload(tag, bytes, cursor)? };
+            match scalar {
+                Scalar::Null => vw.put_null().map_err(io_err)?,
+                Scalar::Missing => vw.put_missing().map_err(io_err)?,
+                Scalar::Bool(v) => vw.put_bool(v).map_err(io_err)?,
+                Scalar::I64(v) => vw.put_i64(v).map_err(io_err)?,
+                Scalar::F64(v) => vw.put_f64(v).map_err(io_err)?,
+                Scalar::Decimal(d) => vw.put_decimal(d).map_err(io_err)?,
+                Scalar::Str(s) => vw.put_str(s).map_err(io_err)?,
+                Scalar::Bytes(b) => vw.put_bytes(b).map_err(io_err)?,
             }
         }
-        TAG_MISSING => {
-            vw.put_missing().map_err(io_err)?;
-        }
-        TAG_BYTES => {
-            let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
-            if len > MAX_BYTES_LEN {
-                return Err(DeserializeError::BytesTooLong(len));
-            }
-            let end = cursor
-                .checked_add(len as usize)
-                .ok_or(DeserializeError::Truncated)?;
-            let slice = bytes.get(*cursor..end).ok_or(DeserializeError::Truncated)?;
-            *cursor = end;
-            // Safety: see `deserialize_row_into`'s # Safety block.
-            let b_ext: &[u8] = unsafe { extend_bytes_to_arena_lifetime(slice) };
-            vw.put_bytes(b_ext).map_err(io_err)?;
-        }
-        t => return Err(DeserializeError::UnknownTag(t)),
     }
     Ok(())
 }
@@ -406,6 +495,20 @@ fn take_str<'b>(
     let s = std::str::from_utf8(slice).map_err(|_| DeserializeError::InvalidUtf8)?;
     *cursor = end;
     Ok(s)
+}
+
+#[inline]
+fn take_bytes<'b>(
+    bytes: &'b [u8],
+    cursor: &mut usize,
+    len: u32,
+) -> Result<&'b [u8], DeserializeError> {
+    let end = cursor
+        .checked_add(len as usize)
+        .ok_or(DeserializeError::Truncated)?;
+    let slice = bytes.get(*cursor..end).ok_or(DeserializeError::Truncated)?;
+    *cursor = end;
+    Ok(slice)
 }
 
 /// Extends `s`'s lifetime to match the arena's. Caller must ensure the

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -152,9 +152,10 @@ fn write_tuple(
         buf.extend_from_slice(&name_len.to_le_bytes());
         buf.extend_from_slice(name.as_bytes());
         match &field.value {
-            // Pass the CURRENT depth: the field lives at the tuple's depth, and
-            // write_value_from_view will +1 itself when it steps into a container.
-            RowShape::Register(idx, _) => write_value(row, *idx, Some(name), depth, buf)?,
+            // depth + 1: the field value is one frame below this tuple. This keeps
+            // the encoder at or ahead of the decoder's per-frame count (encoder is
+            // the stricter side), so any row the encoder accepts is decodable.
+            RowShape::Register(idx, _) => write_value(row, *idx, Some(name), depth + 1, buf)?,
             RowShape::Struct(nested_fields) => write_tuple(row, nested_fields, depth + 1, buf)?,
         }
     }
@@ -265,8 +266,11 @@ fn write_value_from_view(
 /// Encode a runtime tuple (`{...}` literal) reached as `ValueType::Tuple` in a
 /// view — distinct from the static `RowShape::Struct` path in [`write_tuple`].
 ///
-/// The count is backpatched after writing the fields: `ValueView` gives no
-/// pre-`step_in` length, and deferring the count avoids a scratch allocation.
+/// The count is backpatched after writing the fields: one uniform strategy
+/// across all three container kinds, deferring the count to avoid a scratch
+/// allocation. A pre-`step_in` count is not reliably available here — a nested
+/// tuple's view carries the parent's context, and List/Bag expose no length
+/// before stepping in — so we count while writing rather than special-case.
 fn write_tuple_via_view(
     view: &mut ValueView<'_>,
     depth: u32,
@@ -383,26 +387,41 @@ impl std::fmt::Display for DeserializeError {
             DeserializeError::UnknownTag(t) => write!(f, "unknown tag byte: 0x{t:02x}"),
             DeserializeError::InvalidUtf8 => write!(f, "field name is not valid UTF-8"),
             DeserializeError::NameTooLong(n) => {
-                write!(f, "field name length {n} exceeds {MAX_NAME_LEN_BYTES}")
+                write!(
+                    f,
+                    "field name length {n} exceeds MAX_NAME_LEN_BYTES ({MAX_NAME_LEN_BYTES})"
+                )
             }
             DeserializeError::FieldCountTooLarge(n) => {
-                write!(f, "tuple field count {n} exceeds {MAX_FIELDS_PER_ROW}")
+                write!(
+                    f,
+                    "tuple field count {n} exceeds MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW})"
+                )
             }
             DeserializeError::InvalidBool(b) => write!(f, "invalid bool payload: 0x{b:02x}"),
             DeserializeError::BytesTooLong(len) => {
-                write!(f, "bytes length {len} exceeds MAX_BYTES_LEN")
+                write!(
+                    f,
+                    "bytes length {len} exceeds MAX_BYTES_LEN ({MAX_BYTES_LEN})"
+                )
             }
             DeserializeError::StringTooLong(len) => {
-                write!(f, "string length {len} exceeds MAX_STRING_LEN")
+                write!(
+                    f,
+                    "string length {len} exceeds MAX_STRING_LEN ({MAX_STRING_LEN})"
+                )
             }
             DeserializeError::ElementCountTooLarge(n) => {
                 write!(
                     f,
-                    "container element count {n} exceeds {MAX_CONTAINER_ELEMENTS}"
+                    "container element count {n} exceeds MAX_CONTAINER_ELEMENTS ({MAX_CONTAINER_ELEMENTS})"
                 )
             }
             DeserializeError::DepthExceeded(d) => {
-                write!(f, "nesting depth {d} exceeds MAX_RECURSION_DEPTH")
+                write!(
+                    f,
+                    "nesting depth {d} exceeds MAX_RECURSION_DEPTH ({MAX_RECURSION_DEPTH})"
+                )
             }
             DeserializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
         }
@@ -602,23 +621,19 @@ fn decode_tagged_into(
             }
             vw.step_out().map_err(io_err)?;
         }
-        TAG_LIST => {
+        // List and bag share an identical wire layout and decode loop; only the
+        // frame kind differs, mirroring the unified `write_list_or_bag_via_view`
+        // on the encode side.
+        TAG_LIST | TAG_BAG => {
             let count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
             if count > MAX_CONTAINER_ELEMENTS {
                 return Err(DeserializeError::ElementCountTooLarge(count));
             }
-            vw.step_in_list().map_err(io_err)?;
-            for _ in 0..count {
-                decode_tagged_into(vw, bytes, cursor, depth + 1)?;
+            if tag == TAG_LIST {
+                vw.step_in_list().map_err(io_err)?;
+            } else {
+                vw.step_in_bag().map_err(io_err)?;
             }
-            vw.step_out().map_err(io_err)?;
-        }
-        TAG_BAG => {
-            let count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
-            if count > MAX_CONTAINER_ELEMENTS {
-                return Err(DeserializeError::ElementCountTooLarge(count));
-            }
-            vw.step_in_bag().map_err(io_err)?;
             for _ in 0..count {
                 decode_tagged_into(vw, bytes, cursor, depth + 1)?;
             }
@@ -822,19 +837,19 @@ mod deserialize_tests {
         );
         assert_eq!(
             format!("{}", DeserializeError::BytesTooLong(3000)),
-            "bytes length 3000 exceeds MAX_BYTES_LEN"
+            "bytes length 3000 exceeds MAX_BYTES_LEN (1048576)"
         );
         assert_eq!(
             format!("{}", DeserializeError::StringTooLong(4096)),
-            "string length 4096 exceeds MAX_STRING_LEN"
+            "string length 4096 exceeds MAX_STRING_LEN (1048576)"
         );
         assert_eq!(
             format!("{}", DeserializeError::ElementCountTooLarge(99999)),
-            "container element count 99999 exceeds 65536"
+            "container element count 99999 exceeds MAX_CONTAINER_ELEMENTS (65536)"
         );
         assert_eq!(
             format!("{}", DeserializeError::DepthExceeded(200)),
-            "nesting depth 200 exceeds MAX_RECURSION_DEPTH"
+            "nesting depth 200 exceeds MAX_RECURSION_DEPTH (128)"
         );
         assert_eq!(
             format!("{}", DeserializeError::Unsupported("x".to_string())),

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -20,6 +20,9 @@ pub const MAX_NAME_LEN_BYTES: u32 = 1024 * 1024;
 /// Cap on `bytes` payload length to bound allocations on corruption.
 pub const MAX_BYTES_LEN: u32 = 1024 * 1024;
 
+/// Cap on `string` payload length (UTF-8 bytes) to bound allocations on corruption.
+pub const MAX_STRING_LEN: u32 = 1024 * 1024;
+
 // Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
 // load-bearing: a later commit tells a container-rooted row from a
 // scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
@@ -154,7 +157,19 @@ fn write_value(
             buf.push(TAG_STRING);
             let s = view.get_str().expect("string view");
             let sb = s.as_bytes();
-            let str_len: u32 = sb.len().try_into().expect("str_len exceeds u32::MAX");
+            if sb.len() > MAX_STRING_LEN as usize {
+                let prefix = match field_name {
+                    Some(name) => format!("field '{name}'"),
+                    None => "top-level value".to_string(),
+                };
+                return Err(SerializeError::Unsupported(format!(
+                    "{prefix}: string length {} bytes exceeds MAX_STRING_LEN ({})",
+                    sb.len(),
+                    MAX_STRING_LEN
+                )));
+            }
+            // Safe: the cap above bounds sb.len() to MAX_STRING_LEN (u32).
+            let str_len: u32 = sb.len() as u32;
             buf.extend_from_slice(&str_len.to_le_bytes());
             buf.extend_from_slice(sb);
         }
@@ -207,6 +222,7 @@ pub enum DeserializeError {
     FieldCountTooLarge(u32),
     InvalidBool(u8),
     BytesTooLong(u32),
+    StringTooLong(u32),
     /// Reserved tag or `ValueWriter` failure; symmetric to encoder rejection.
     Unsupported(String),
 }
@@ -226,6 +242,9 @@ impl std::fmt::Display for DeserializeError {
             DeserializeError::InvalidBool(b) => write!(f, "invalid bool payload: 0x{b:02x}"),
             DeserializeError::BytesTooLong(len) => {
                 write!(f, "bytes length {len} exceeds MAX_BYTES_LEN")
+            }
+            DeserializeError::StringTooLong(len) => {
+                write!(f, "string length {len} exceeds MAX_STRING_LEN")
             }
             DeserializeError::Unsupported(m) => write!(f, "unsupported: {m}"),
         }
@@ -296,6 +315,9 @@ fn decode_tagged_into(
         }
         TAG_STRING => {
             let len = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if len > MAX_STRING_LEN {
+                return Err(DeserializeError::StringTooLong(len));
+            }
             let s = take_str(bytes, cursor, len)?;
             // Safety: see `deserialize_row_into`'s # Safety block.
             let s_ext: &str = unsafe { extend_to_arena_lifetime(s) };

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -4,12 +4,13 @@
 //!   ROW          = tagged_value
 //!   tagged_value = tag(u8) payload
 //!   payload(TAG_TUPLE) = field_count(u32 LE) (name_len(u32 LE) name_utf8 tagged_value){N}
+//!   payload(TAG_LIST | TAG_BAG) = count(u32 LE) tagged_value{N}
 //!
 //! All multi-byte VALUE bytes are little-endian. Row-id KEYS in LMDB stay
 //! big-endian (encoded as `row_id.to_be_bytes()` under `heed::types::Bytes`)
 //! so the B+tree's lexicographic order matches numeric order.
 
-use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType};
+use partiql_eval::value::{FieldName, RegisterReader, RowShape, ValueType, ValueView};
 
 /// Cap on `field_count` to bound `Vec::with_capacity` against a flipped byte.
 pub const MAX_FIELDS_PER_ROW: u32 = 1024;
@@ -31,6 +32,10 @@ pub const MAX_STRING_LEN: u32 = 1024 * 1024;
 /// is always decodable.
 pub const MAX_RECURSION_DEPTH: u32 = 128;
 
+/// Cap on List/Bag element count to bound work when decoding a
+/// (possibly adversarial) on-disk container payload.
+pub const MAX_CONTAINER_ELEMENTS: u32 = 65_536;
+
 // Tag taxonomy: scalars 0x00-0x07, containers 0x08-0x0A. This split is
 // load-bearing: deserialize_row_into tells a container-rooted row from a
 // scalar-rooted one with a single `tag >= TAG_TUPLE` test, so no scalar
@@ -49,9 +54,8 @@ pub const TAG_BAG: u8 = 0x0A;
 
 #[derive(Debug)]
 pub enum SerializeError {
-    /// Unsupported type or shape: containers (Tuple/List/Bag) or dynamic
-    /// field names. The string identifies the offending field or top-level
-    /// value.
+    /// Unsupported shape (dynamic field names) or a size/depth cap violation.
+    /// The string identifies the offending field or top-level value.
     Unsupported(String),
 }
 
@@ -92,7 +96,21 @@ fn write_value_at_root(
 ) -> Result<(), SerializeError> {
     // Top-level scalar rows land as a bare tag + payload with no tuple frame.
     // `field_name = None` selects the "top-level value" error prefix.
-    write_value(row, slot, None, buf)
+    write_value(row, slot, None, 0, buf)
+}
+
+/// Reject once container nesting would exceed the stack-bounding cap. Called at
+/// each encoder entry that can recurse; the callee runs at `depth + 1`, so an
+/// empty over-deep container (whose element loop never fires) is still caught by
+/// the callee's own check.
+#[inline]
+fn check_encode_depth(depth: u32) -> Result<(), SerializeError> {
+    if depth > MAX_RECURSION_DEPTH {
+        return Err(SerializeError::Unsupported(format!(
+            "nesting depth {depth} exceeds MAX_RECURSION_DEPTH ({MAX_RECURSION_DEPTH})"
+        )));
+    }
+    Ok(())
 }
 
 fn write_tuple(
@@ -101,11 +119,7 @@ fn write_tuple(
     depth: u32,
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
-    if depth > MAX_RECURSION_DEPTH {
-        return Err(SerializeError::Unsupported(format!(
-            "nesting depth {depth} exceeds MAX_RECURSION_DEPTH ({MAX_RECURSION_DEPTH})"
-        )));
-    }
+    check_encode_depth(depth)?;
     if fields.len() > MAX_FIELDS_PER_ROW as usize {
         return Err(SerializeError::Unsupported(format!(
             "tuple has {} fields, exceeds MAX_FIELDS_PER_ROW ({})",
@@ -138,23 +152,53 @@ fn write_tuple(
         buf.extend_from_slice(&name_len.to_le_bytes());
         buf.extend_from_slice(name.as_bytes());
         match &field.value {
-            RowShape::Register(idx, _) => write_value(row, *idx, Some(name), buf)?,
+            // Pass the CURRENT depth: the field lives at the tuple's depth, and
+            // write_value_from_view will +1 itself when it steps into a container.
+            RowShape::Register(idx, _) => write_value(row, *idx, Some(name), depth, buf)?,
             RowShape::Struct(nested_fields) => write_tuple(row, nested_fields, depth + 1, buf)?,
         }
     }
     Ok(())
 }
 
+/// Thin wrapper over the recursive core: fetch the register's view and
+/// delegate. Every value — scalar or container — reached through a
+/// register/view flows through [`write_value_from_view`], the sole encoder
+/// path for such values (static `RowShape::Struct` tuples are emitted by
+/// [`write_tuple`] instead).
 fn write_value(
     row: &RegisterReader<'_>,
     slot: usize,
     field_name: Option<&str>,
+    depth: u32,
     buf: &mut Vec<u8>,
 ) -> Result<(), SerializeError> {
-    let view = row.get_value_view(slot).expect("register slot from shape");
+    let mut view = row.get_value_view(slot).expect("register slot from shape");
+    write_value_from_view(&mut view, field_name, depth, buf)
+}
+
+/// Encode the value the cursor currently points at, recursing into containers.
+/// This is the ONE recursive core: scalars, runtime tuples (`{...}` literals),
+/// lists, and bags all pass through here. `field_name` is used only to build an
+/// error-message prefix on a cap violation.
+fn write_value_from_view(
+    view: &mut ValueView<'_>,
+    field_name: Option<&str>,
+    depth: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    check_encode_depth(depth)?;
     match view.get_type() {
         ValueType::Null => {
             buf.push(TAG_NULL);
+        }
+        ValueType::Missing => {
+            buf.push(TAG_MISSING);
+        }
+        ValueType::Bool => {
+            buf.push(TAG_BOOL);
+            let b = view.get_bool().expect("bool view");
+            buf.push(if b { 0x01 } else { 0x00 });
         }
         ValueType::Integer => {
             buf.push(TAG_INTEGER);
@@ -192,14 +236,6 @@ fn write_value(
             buf.extend_from_slice(&str_len.to_le_bytes());
             buf.extend_from_slice(sb);
         }
-        ValueType::Bool => {
-            buf.push(TAG_BOOL);
-            let b = view.get_bool().expect("bool view");
-            buf.push(if b { 0x01 } else { 0x00 });
-        }
-        ValueType::Missing => {
-            buf.push(TAG_MISSING);
-        }
         ValueType::Bytes => {
             buf.push(TAG_BYTES);
             let b = view.get_bytes().expect("bytes view");
@@ -219,16 +255,108 @@ fn write_value(
             buf.extend_from_slice(&byte_len.to_le_bytes());
             buf.extend_from_slice(b);
         }
-        ty @ (ValueType::Tuple | ValueType::List | ValueType::Bag) => {
-            let prefix = match field_name {
-                Some(name) => format!("field '{name}'"),
-                None => "top-level value".to_string(),
-            };
-            return Err(SerializeError::Unsupported(format!(
-                "{prefix}: {ty:?} is not yet supported"
-            )));
-        }
+        ValueType::Tuple => write_tuple_via_view(view, depth + 1, buf)?,
+        ValueType::List => write_list_or_bag_via_view(view, TAG_LIST, "list", depth + 1, buf)?,
+        ValueType::Bag => write_list_or_bag_via_view(view, TAG_BAG, "bag", depth + 1, buf)?,
     }
+    Ok(())
+}
+
+/// Encode a runtime tuple (`{...}` literal) reached as `ValueType::Tuple` in a
+/// view — distinct from the static `RowShape::Struct` path in [`write_tuple`].
+///
+/// The count is backpatched after writing the fields: `ValueView` gives no
+/// pre-`step_in` length, and deferring the count avoids a scratch allocation.
+fn write_tuple_via_view(
+    view: &mut ValueView<'_>,
+    depth: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    check_encode_depth(depth)?;
+    buf.push(TAG_TUPLE);
+    // Reserve the field-count slot; backpatched after the fields are written.
+    let count_pos = buf.len();
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    let mut count: u32 = 0;
+    // `step_in` fails on an empty tuple; the empty case leaves count 0 with no
+    // fields, matching the wire format for a static empty struct.
+    if view.step_in().is_ok() {
+        loop {
+            if count >= MAX_FIELDS_PER_ROW {
+                return Err(SerializeError::Unsupported(format!(
+                    "tuple has more than MAX_FIELDS_PER_ROW ({MAX_FIELDS_PER_ROW}) fields"
+                )));
+            }
+            let name: &str = view
+                .get_field_name()
+                .map_err(|e| SerializeError::Unsupported(format!("tuple get_field_name: {e}")))?;
+            if name.len() > MAX_NAME_LEN_BYTES as usize {
+                return Err(SerializeError::Unsupported(format!(
+                    "field '{name}': name length {} bytes exceeds MAX_NAME_LEN_BYTES ({})",
+                    name.len(),
+                    MAX_NAME_LEN_BYTES
+                )));
+            }
+            // Safe: cap above bounds name length to u32.
+            buf.extend_from_slice(&(name.len() as u32).to_le_bytes());
+            buf.extend_from_slice(name.as_bytes());
+            write_value_from_view(view, Some(name), depth, buf)?;
+            count += 1;
+            let has_next = view
+                .advance()
+                .map_err(|e| SerializeError::Unsupported(format!("tuple advance: {e}")))?;
+            if !has_next {
+                break;
+            }
+        }
+        view.step_out()
+            .map_err(|e| SerializeError::Unsupported(format!("tuple step_out: {e}")))?;
+    }
+    buf[count_pos..count_pos + 4].copy_from_slice(&count.to_le_bytes());
+    Ok(())
+}
+
+/// Encode a List or Bag reached in a view. `tag` and `kind` differentiate the
+/// two; the body is identical (ordered elements, no field names).
+///
+/// The count is backpatched after writing the elements: `ValueView` gives no
+/// pre-`step_in` length for List/Bag, and deferring avoids a scratch allocation.
+fn write_list_or_bag_via_view(
+    view: &mut ValueView<'_>,
+    tag: u8,
+    kind: &'static str,
+    depth: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), SerializeError> {
+    check_encode_depth(depth)?;
+    buf.push(tag);
+    // Reserve the element-count slot; backpatched after the elements are
+    // written so we never allocate a scratch buffer to pre-count.
+    let count_pos = buf.len();
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    let mut count: u32 = 0;
+    // `step_in` errors on an empty container; an empty list/bag is legal and
+    // simply has count 0.
+    if view.step_in().is_ok() {
+        loop {
+            if count >= MAX_CONTAINER_ELEMENTS {
+                return Err(SerializeError::Unsupported(format!(
+                    "{kind} has more than MAX_CONTAINER_ELEMENTS ({MAX_CONTAINER_ELEMENTS}) elements"
+                )));
+            }
+            write_value_from_view(view, None, depth, buf)?;
+            count += 1;
+            let has_next = view
+                .advance()
+                .map_err(|e| SerializeError::Unsupported(format!("{kind} advance: {e}")))?;
+            if !has_next {
+                break;
+            }
+        }
+        view.step_out()
+            .map_err(|e| SerializeError::Unsupported(format!("{kind} step_out: {e}")))?;
+    }
+    buf[count_pos..count_pos + 4].copy_from_slice(&count.to_le_bytes());
     Ok(())
 }
 
@@ -242,6 +370,7 @@ pub enum DeserializeError {
     InvalidBool(u8),
     BytesTooLong(u32),
     StringTooLong(u32),
+    ElementCountTooLarge(u32),
     DepthExceeded(u32),
     /// Reserved tag or `ValueWriter` failure; symmetric to encoder rejection.
     Unsupported(String),
@@ -265,6 +394,12 @@ impl std::fmt::Display for DeserializeError {
             }
             DeserializeError::StringTooLong(len) => {
                 write!(f, "string length {len} exceeds MAX_STRING_LEN")
+            }
+            DeserializeError::ElementCountTooLarge(n) => {
+                write!(
+                    f,
+                    "container element count {n} exceeds {MAX_CONTAINER_ELEMENTS}"
+                )
             }
             DeserializeError::DepthExceeded(d) => {
                 write!(f, "nesting depth {d} exceeds MAX_RECURSION_DEPTH")
@@ -467,6 +602,28 @@ fn decode_tagged_into(
             }
             vw.step_out().map_err(io_err)?;
         }
+        TAG_LIST => {
+            let count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if count > MAX_CONTAINER_ELEMENTS {
+                return Err(DeserializeError::ElementCountTooLarge(count));
+            }
+            vw.step_in_list().map_err(io_err)?;
+            for _ in 0..count {
+                decode_tagged_into(vw, bytes, cursor, depth + 1)?;
+            }
+            vw.step_out().map_err(io_err)?;
+        }
+        TAG_BAG => {
+            let count = u32::from_le_bytes(take_array::<4>(bytes, cursor)?);
+            if count > MAX_CONTAINER_ELEMENTS {
+                return Err(DeserializeError::ElementCountTooLarge(count));
+            }
+            vw.step_in_bag().map_err(io_err)?;
+            for _ in 0..count {
+                decode_tagged_into(vw, bytes, cursor, depth + 1)?;
+            }
+            vw.step_out().map_err(io_err)?;
+        }
         _ => {
             // Safety: decode_tagged_into is only reached from deserialize_row_into,
             // which upholds the # Safety contract; delegated to the helper.
@@ -659,6 +816,26 @@ mod deserialize_tests {
         );
         assert!(format!("{}", DeserializeError::FieldCountTooLarge(2048))
             .starts_with("tuple field count 2048"));
+        assert_eq!(
+            format!("{}", DeserializeError::InvalidBool(0x7F)),
+            "invalid bool payload: 0x7f"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::BytesTooLong(3000)),
+            "bytes length 3000 exceeds MAX_BYTES_LEN"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::StringTooLong(4096)),
+            "string length 4096 exceeds MAX_STRING_LEN"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::ElementCountTooLarge(99999)),
+            "container element count 99999 exceeds 65536"
+        );
+        assert_eq!(
+            format!("{}", DeserializeError::DepthExceeded(200)),
+            "nesting depth 200 exceeds MAX_RECURSION_DEPTH"
+        );
         assert_eq!(
             format!("{}", DeserializeError::Unsupported("x".to_string())),
             "unsupported: x"

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -670,3 +670,48 @@ fn ctas_rejects_container_rolls_back_wtxn() {
         "row-0 rejection must leave catalog clean even if env file persists"
     );
 }
+
+#[test]
+fn string_at_1kb_encodes_and_round_trips() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("kb_str.pqlite");
+    let query = format!(
+        "CREATE TABLE t AS (SELECT '{}' AS s FROM mem(1,1) m)",
+        "x".repeat(1024)
+    );
+    let (ok, _out, err) = run_exec(&query, Some(&dbp));
+    assert!(ok, "1KB string CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(
+        out.contains(&"x".repeat(1024)),
+        "1KB string did not round-trip"
+    );
+}
+
+#[test]
+fn oversize_string_payload_surfaces_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bad_str.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT 'ok' AS s FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS setup failed: {err}");
+    // Craft a tuple row whose string field claims a payload 1 byte over the cap.
+    let mut payload = Vec::new();
+    payload.push(partiql_tools::row_codec::TAG_TUPLE);
+    payload.extend_from_slice(&1u32.to_le_bytes()); // field_count = 1
+    payload.extend_from_slice(&1u32.to_le_bytes()); // name_len = 1
+    payload.push(b's');
+    payload.push(partiql_tools::row_codec::TAG_STRING);
+    let bad_len: u32 = partiql_tools::row_codec::MAX_STRING_LEN + 1;
+    payload.extend_from_slice(&bad_len.to_le_bytes());
+    // Intentionally NO actual string bytes — the cap check must trip before the read.
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    drop(db);
+    let (ok, _out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "expected SELECT to fail on oversize string");
+    assert!(err.contains("string length"), "got: {err}");
+}

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -442,44 +442,6 @@ fn select_surfaces_unknown_tag_error() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore)]
-fn ctas_rejects_bool_with_pointed_message() {
-    // The encoder must reject a Bool column mid-stream. Err propagates so
-    // the wtxn rolls back; the env file may persist but the catalog stays
-    // clean.
-    let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("bool.pqlite");
-    let (ok, _stdout, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT true AS b FROM mem(1,1) m)",
-        Some(&db_path),
-    );
-    assert!(!ok, "Bool column must be rejected; stderr: {stderr}");
-    assert!(
-        stderr.contains("field 'b'") && stderr.contains("Bool"),
-        "error must name the column and the rejected type; got: {stderr}",
-    );
-    // Verify wtxn rollback by re-opening: the env file may persist on disk,
-    // but the catalog must not register `t`.
-    let env = unsafe {
-        heed::EnvOpenOptions::new()
-            .map_size(1024 * 1024 * 1024)
-            .max_dbs(128)
-            .flags(heed::EnvFlags::NO_SUB_DIR)
-            .open(&db_path)
-            .expect("re-open env")
-    };
-    let rtxn = env.read_txn().expect("read txn");
-    let catalog: heed::Database<heed::types::Str, heed::types::Bytes> = env
-        .open_database(&rtxn, Some("_tables"))
-        .expect("open catalog")
-        .expect("catalog must exist");
-    assert!(
-        catalog.get(&rtxn, "t").expect("catalog get").is_none(),
-        "row-0 rejection must leave catalog clean even if env file persists"
-    );
-}
-
-#[test]
 fn quoted_table_name_preserves_case_through_roundtrip() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("quoted.pqlite");
@@ -585,5 +547,126 @@ fn wire_format_byte_shape_is_stable() {
     assert_eq!(
         row0, expected,
         "wire format byte shape regressed: expected {expected:02x?}, got {row0:02x?}",
+    );
+}
+
+#[test]
+fn ctas_then_select_bool_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bool_rt.pqlite");
+    // mem's arg order is (rows, cols): mem(2,1) yields two rows a=0,a=1,
+    // so `m.a = 0` produces true then false. (Not mem(1,2), which is one row.)
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT (m.a = 0) AS b FROM mem(2,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(
+        out.contains("true"),
+        "expected 'true' in output; got: {out}"
+    );
+    assert!(
+        out.contains("false"),
+        "expected 'false' in output; got: {out}"
+    );
+}
+
+#[test]
+fn ctas_then_select_missing_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("missing_rt.pqlite");
+    // mem's arg order is (rows, cols); mem(2,1) yields two rows.
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT m.nonexistent AS x FROM mem(2,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(
+        out.contains("MISSING"),
+        "expected MISSING in output; got: {out}"
+    );
+}
+
+#[test]
+fn invalid_bool_payload_surfaces_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bad_bool.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT (m.a = 0) AS b FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS setup failed: {err}");
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    partiql_tools::test_support::inject_row(
+        &db,
+        "t",
+        1,
+        &[
+            partiql_tools::row_codec::TAG_TUPLE,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            b'b',
+            partiql_tools::row_codec::TAG_BOOL,
+            0x7F,
+        ],
+    );
+    drop(db);
+    let (ok, _out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "expected SELECT to fail on invalid bool payload");
+    assert!(
+        err.contains("invalid bool") && err.contains("0x7f"),
+        "expected the specific bad byte 0x7f to propagate; got: {err}"
+    );
+}
+
+#[test]
+#[cfg_attr(windows, ignore)]
+fn ctas_rejects_container_rolls_back_wtxn() {
+    // Repoint target: migrate this to a cap-violation trigger (oversize
+    // string/bytes or too-many-elements) once List/Bag are supported, since the
+    // container triggers used here become valid then.
+    //
+    // The encoder must reject a still-unsupported container column mid-stream.
+    // Err propagates so the wtxn rolls back; the env file may persist but the
+    // catalog stays clean.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("list.pqlite");
+    let (ok, _stdout, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT [1, 2] AS xs FROM mem(1,1) m)",
+        Some(&db_path),
+    );
+    assert!(!ok, "List column must be rejected; stderr: {stderr}");
+    assert!(
+        stderr.contains("List") && stderr.contains("not yet supported"),
+        "error must name the rejected container type; got: {stderr}",
+    );
+    // Verify wtxn rollback by re-opening: the env file may persist on disk,
+    // but the catalog must not register `t`.
+    let env = unsafe {
+        heed::EnvOpenOptions::new()
+            .map_size(1024 * 1024 * 1024)
+            .max_dbs(128)
+            .flags(heed::EnvFlags::NO_SUB_DIR)
+            .open(&db_path)
+            .expect("re-open env")
+    };
+    let rtxn = env.read_txn().expect("read txn");
+    let catalog: heed::Database<heed::types::Str, heed::types::Bytes> = env
+        .open_database(&rtxn, Some("_tables"))
+        .expect("open catalog")
+        .expect("catalog must exist");
+    assert!(
+        catalog.get(&rtxn, "t").expect("catalog get").is_none(),
+        "row-0 rejection must leave catalog clean even if env file persists"
     );
 }

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -762,6 +762,87 @@ fn top_level_scalar_row_is_bare_tag_on_disk() {
 }
 
 #[test]
+fn deeply_nested_tuple_payload_within_cap_round_trips() {
+    // A tuple nested a few levels deep, crafted as raw bytes, must decode
+    // cleanly (well within MAX_RECURSION_DEPTH). This directly exercises the
+    // decode_tagged_into recursion without needing the planner to produce a
+    // nested static struct (which it does not yet do).
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("nest_ok.pqlite");
+    // Seed a real table so the table + catalog exist.
+    let (ok, _o, e) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {e}");
+
+    // Build a payload: 4 nested single-field tuples, innermost value = i64 42.
+    // Each tuple frame: TAG_TUPLE, field_count=1(LE u32), name_len=1(LE u32), 'n', <value>.
+    fn wrap(inner: Vec<u8>) -> Vec<u8> {
+        let mut v = vec![partiql_tools::row_codec::TAG_TUPLE];
+        v.extend_from_slice(&1u32.to_le_bytes()); // field_count
+        v.extend_from_slice(&1u32.to_le_bytes()); // name_len
+        v.push(b'n');
+        v.extend_from_slice(&inner);
+        v
+    }
+    let mut payload = vec![partiql_tools::row_codec::TAG_INTEGER];
+    payload.extend_from_slice(&42i64.to_le_bytes());
+    for _ in 0..4 {
+        payload = wrap(payload);
+    }
+
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    drop(db);
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over nested tuple failed: {err}");
+    assert!(
+        out.contains("42"),
+        "nested value 42 must survive round-trip; got: {out}"
+    );
+}
+
+#[test]
+fn over_deep_nested_tuple_payload_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("nest_deep.pqlite");
+    let (ok, _o, e) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {e}");
+
+    fn wrap(inner: Vec<u8>) -> Vec<u8> {
+        let mut v = vec![partiql_tools::row_codec::TAG_TUPLE];
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.extend_from_slice(&1u32.to_le_bytes());
+        v.push(b'n');
+        v.extend_from_slice(&inner);
+        v
+    }
+    let mut payload = vec![partiql_tools::row_codec::TAG_INTEGER];
+    payload.extend_from_slice(&0i64.to_le_bytes());
+    // Nest deeper than the cap. MAX_RECURSION_DEPTH + 5 levels guarantees rejection.
+    let levels = partiql_tools::row_codec::MAX_RECURSION_DEPTH + 5;
+    for _ in 0..levels {
+        payload = wrap(payload);
+    }
+
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    drop(db);
+
+    let (ok, _out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "over-deep nesting must be rejected");
+    assert!(
+        err.contains("nesting depth") || err.contains("depth"),
+        "error must mention depth; got: {err}"
+    );
+}
+
+#[test]
 fn oversize_string_payload_surfaces_error() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("bad_str.pqlite");

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -932,8 +932,8 @@ fn ctas_then_select_runtime_tuple() {
 
 #[test]
 fn encode_accepts_implies_decode_accepts_at_depth_boundary() {
-    // End-to-end depth coverage for the VIEW encode path: a runtime tuple
-    // nested three levels deep must round-trip. The injected-bytes depth tests
+    // End-to-end depth coverage for the VIEW encode path: a shallow runtime
+    // tuple must round-trip. The injected-bytes depth tests
     // (deeply_nested_tuple_payload_within_cap_round_trips /
     // over_deep_nested_tuple_payload_is_rejected) anchor the DECODE boundary;
     // this one proves write_tuple_via_view's own depth accounting produces a
@@ -955,6 +955,53 @@ fn encode_accepts_implies_decode_accepts_at_depth_boundary() {
     assert!(
         out.contains("{ 'r': { 'a': { 'b': { 'c': 42 } } } }"),
         "expected the full 3-level nesting to render; got: {out}"
+    );
+}
+
+#[test]
+fn static_root_deep_runtime_tuple_never_writes_unreadable_row() {
+    // Regression: a runtime container nested under a static-struct root
+    // (`... AS r`) is charged at a depth no shallower than the decoder (the
+    // encoder is the stricter side), so the codec's safety invariant holds — the
+    // encoder must NEVER persist a row the decoder then refuses (write-but-can't-
+    // read = data loss). Sweep depths straddling MAX_RECURSION_DEPTH (128) and
+    // assert the invariant directly: for every depth, we never observe
+    // `CTAS ok && SELECT fails`.
+    let mut any_round_tripped = false;
+    for n in [126usize, 127, 128, 129, 130] {
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join(format!("depth_{n}.pqlite"));
+
+        // Build an n-deep runtime tuple `{ 'a': { 'a': ... 42 ... } }` under a
+        // static-struct root named `r`.
+        let mut inner = String::from("42");
+        for _ in 0..n {
+            inner = format!("{{ 'a': {inner} }}");
+        }
+        let query = format!("CREATE TABLE t AS (SELECT {inner} AS r FROM mem(1,1) m)");
+
+        let (ctas_ok, _o, ctas_err) = run_exec(&query, Some(&dbp));
+        let (select_ok, _so, _se) = if ctas_ok {
+            run_exec("SELECT * FROM t", Some(&dbp))
+        } else {
+            (true, String::new(), String::new()) // no row written, nothing to read
+        };
+
+        // The invariant: a persisted row must always be readable back.
+        let wrote_unreadable_row = ctas_ok && !select_ok;
+        assert!(
+            !wrote_unreadable_row,
+            "depth {n}: encoder persisted a row the decoder cannot read \
+             (write-but-can't-read). CTAS err: {ctas_err}"
+        );
+        any_round_tripped |= ctas_ok && select_ok;
+    }
+    // Guard against a vacuous pass: the sweep must include at least one depth
+    // the encoder accepts and the decoder reads back, or the invariant above is
+    // trivially satisfied by an encoder that rejects everything.
+    assert!(
+        any_round_tripped,
+        "sweep never achieved a write+read round-trip; boundary coverage evaporated"
     );
 }
 

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -555,29 +555,29 @@ fn wire_format_byte_shape_is_stable() {
     };
 
     // Expected wire format for {"a": 1i64, "b": "xy"}:
-    //   TAG_TUPLE (0x03)
+    //   TAG_TUPLE (0x08)
     //   field_count = 2 (LE u32: 02 00 00 00)
     //   field 0:
     //     name_len = 1 (LE u32: 01 00 00 00)
     //     name = 'a'   (0x61)
-    //     TAG_INTEGER (0x00)
+    //     TAG_INTEGER (0x03)
     //     i64 value = 1 (LE: 01 00 00 00 00 00 00 00)
     //   field 1:
     //     name_len = 1 (LE u32: 01 00 00 00)
     //     name = 'b'   (0x62)
-    //     TAG_STRING (0x05)
+    //     TAG_STRING (0x06)
     //     str_len = 2  (LE u32: 02 00 00 00)
     //     str bytes = 'x' 'y' (0x78 0x79)
     // name_len (1) deliberately differs from str_len (2) so a regression that
     // swapped the two u32 prefixes would not cancel out.
     let expected: &[u8] = &[
-        0x03, // TAG_TUPLE
+        0x08, // TAG_TUPLE
         0x02, 0x00, 0x00, 0x00, // field_count = 2
         0x01, 0x00, 0x00, 0x00, 0x61, // name "a"
-        0x00, // TAG_INTEGER
+        0x03, // TAG_INTEGER
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 1 LE
         0x01, 0x00, 0x00, 0x00, 0x62, // name "b"
-        0x05, // TAG_STRING
+        0x06, // TAG_STRING
         0x02, 0x00, 0x00, 0x00, // str_len = 2
         0x78, 0x79, // "xy"
     ];

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -287,11 +287,9 @@ fn ctas_then_select_mixed_scalars() {
 #[test]
 fn ctas_then_select_preserves_multi_field_struct_shape() {
     // Two-column row guards field-name preservation and column ordering
-    // through the encode → LMDB → decode → format pipeline. Nested tuples
-    // (i.e. a column whose VALUE is itself a tuple) are not yet supported
-    // by the encoder — the inline `{ 'k': v }` literal lowers to
-    // ValueType::Tuple, which `write_value` rejects — so the nested case
-    // is intentionally out of scope here. See PR5-deferred-items.
+    // through the encode → LMDB → decode → format pipeline. The nested-tuple
+    // case (a column whose VALUE is itself a tuple) is covered separately by
+    // ctas_then_select_runtime_tuple and ctas_then_select_nested_tuple_in_list.
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("tuple.pqlite");
 
@@ -631,24 +629,26 @@ fn invalid_bool_payload_surfaces_error() {
 
 #[test]
 #[cfg_attr(windows, ignore)]
-fn ctas_rejects_container_rolls_back_wtxn() {
-    // Repoint target: migrate this to a cap-violation trigger (oversize
-    // string/bytes or too-many-elements) once List/Bag are supported, since the
-    // container triggers used here become valid then.
-    //
-    // The encoder must reject a still-unsupported container column mid-stream.
-    // Err propagates so the wtxn rolls back; the env file may persist but the
-    // catalog stays clean.
+fn ctas_rejects_oversize_tuple_rolls_back_wtxn() {
+    // A mid-encode rejection must roll back the wtxn, leaving `_tables` clean.
+    // Trigger: a 1025-field runtime tuple trips MAX_FIELDS_PER_ROW. (An oversize
+    // string would exceed the OS arg length limit when passed via the CLI.)
     let dir = tempfile::tempdir().unwrap();
-    let db_path = dir.path().join("list.pqlite");
-    let (ok, _stdout, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT [1, 2] AS xs FROM mem(1,1) m)",
-        Some(&db_path),
-    );
-    assert!(!ok, "List column must be rejected; stderr: {stderr}");
+    let db_path = dir.path().join("oversize.pqlite");
+    let field_count = partiql_tools::row_codec::MAX_FIELDS_PER_ROW + 1;
+    let fields: String = (0..field_count)
+        .map(|i| format!("'k{i}': {i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query = format!("CREATE TABLE t AS (SELECT {{ {fields} }} AS obj FROM mem(1,1) m)");
+    let (ok, _stdout, stderr) = run_exec(&query, Some(&db_path));
     assert!(
-        stderr.contains("List") && stderr.contains("not yet supported"),
-        "error must name the rejected container type; got: {stderr}",
+        !ok,
+        "oversize tuple column must be rejected; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("MAX_FIELDS_PER_ROW"),
+        "error must name the field-count cap; got: {stderr}",
     );
     // Verify wtxn rollback by re-opening: the env file may persist on disk,
     // but the catalog must not register `t`.
@@ -839,6 +839,202 @@ fn over_deep_nested_tuple_payload_is_rejected() {
     assert!(
         err.contains("nesting depth") || err.contains("depth"),
         "error must mention depth; got: {err}"
+    );
+}
+
+#[test]
+fn ctas_then_select_list_of_ints() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("list_ints.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT [10, 20, 30] AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "list CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("10"), "expected 10; got: {out}");
+    assert!(out.contains("20"), "expected 20; got: {out}");
+    assert!(out.contains("30"), "expected 30; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_bag_of_ints() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bag_ints.pqlite");
+    // `<< ... >>` is the PartiQL bag-literal syntax and parses cleanly.
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT << 100, 200 >> AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "bag CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("100"), "expected 100; got: {out}");
+    assert!(out.contains("200"), "expected 200; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_empty_list() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("empty_list.pqlite");
+    // An empty container is legal: count=0, no elements, no step_in.
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT [] AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "empty-list CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over empty list failed: {err}");
+    // Empty list renders as `[]` inside the row tuple.
+    assert!(out.contains("'xs': []"), "expected empty list; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_nested_tuple_in_list() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("nested.pqlite");
+    // A list of runtime tuples exercises the full recursion:
+    // list → tuple → scalar, on both encode and decode.
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT [{ 'a': 1 }, { 'a': 2 }] AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(
+        ok,
+        "nested-tuple-in-list CTAS should succeed; stderr: {err}"
+    );
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("1"), "expected 1; got: {out}");
+    assert!(out.contains("2"), "expected 2; got: {out}");
+    // Both tuples preserve their field name through the round trip.
+    assert!(out.contains("'a': 1"), "expected 'a': 1; got: {out}");
+    assert!(out.contains("'a': 2"), "expected 'a': 2; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_runtime_tuple() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("runtime_tuple.pqlite");
+    // A runtime `{...}` tuple value flows through write_tuple_via_view
+    // (distinct from the static-struct encode path).
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT { 'k': 42 } AS obj FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "runtime-tuple CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("42"), "expected 42; got: {out}");
+    assert!(out.contains("'k': 42"), "expected 'k': 42; got: {out}");
+}
+
+#[test]
+fn encode_accepts_implies_decode_accepts_at_depth_boundary() {
+    // End-to-end depth coverage for the VIEW encode path: a runtime tuple
+    // nested three levels deep must round-trip. The injected-bytes depth tests
+    // (deeply_nested_tuple_payload_within_cap_round_trips /
+    // over_deep_nested_tuple_payload_is_rejected) anchor the DECODE boundary;
+    // this one proves write_tuple_via_view's own depth accounting produces a
+    // decodable row for a query-produced nested tuple.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("depth_e2e.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT { 'a': { 'b': { 'c': 42 } } } AS r FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(
+        ok,
+        "3-level runtime-tuple CTAS should succeed; stderr: {err}"
+    );
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over 3-level nested tuple failed: {err}");
+    // The innermost value and the full nesting survive the round trip.
+    assert!(out.contains("42"), "expected inner value 42; got: {out}");
+    assert!(
+        out.contains("{ 'r': { 'a': { 'b': { 'c': 42 } } } }"),
+        "expected the full 3-level nesting to render; got: {out}"
+    );
+}
+
+#[test]
+fn wire_format_list_byte_shape() {
+    // Pin the on-disk byte layout for a single-element int list. Locks the
+    // TAG_LIST wire format the way `wire_format_byte_shape_is_stable` locks the
+    // tuple/scalar layout. If this fails, the byte literal is the source of
+    // truth — investigate the encoder, do not rewrite the test.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("list_anchor.pqlite");
+
+    let (ok, _, stderr) = run_exec(
+        "CREATE TABLE t AS (SELECT [1] AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS should succeed; stderr: {stderr}");
+
+    let row0 = {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::read_row(&db, "t", 0)
+    };
+
+    // Expected wire format for the row {"xs": [1i64]}:
+    //   TAG_TUPLE (0x08)
+    //   field_count = 1 (LE u32: 01 00 00 00)
+    //   field 0:
+    //     name_len = 2 (LE u32: 02 00 00 00)
+    //     name = 'x' 's' (0x78 0x73)
+    //     TAG_LIST (0x09)
+    //     elem_count = 1 (LE u32: 01 00 00 00)
+    //     element 0:
+    //       TAG_INTEGER (0x03)
+    //       i64 value = 1 (LE: 01 00 00 00 00 00 00 00)
+    let expected: &[u8] = &[
+        0x08, // TAG_TUPLE
+        0x01, 0x00, 0x00, 0x00, // field_count = 1
+        0x02, 0x00, 0x00, 0x00, 0x78, 0x73, // name "xs"
+        0x09, // TAG_LIST
+        0x01, 0x00, 0x00, 0x00, // elem_count = 1
+        0x03, // TAG_INTEGER
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 1 LE
+    ];
+
+    assert_eq!(
+        row0, expected,
+        "list wire format byte shape regressed: expected {expected:02x?}, got {row0:02x?}",
+    );
+}
+
+#[test]
+fn over_many_list_elements_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("too_many.pqlite");
+    let (ok, _o, e) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {e}");
+
+    // Craft a tuple row whose 'xs' list claims one element more than the cap.
+    // No element bytes are needed — the cap check trips before the read.
+    let mut payload = Vec::new();
+    payload.push(partiql_tools::row_codec::TAG_TUPLE);
+    payload.extend_from_slice(&1u32.to_le_bytes()); // field_count = 1
+    payload.extend_from_slice(&2u32.to_le_bytes()); // name_len = 2
+    payload.extend_from_slice(b"xs");
+    payload.push(partiql_tools::row_codec::TAG_LIST);
+    let bad_count: u32 = partiql_tools::row_codec::MAX_CONTAINER_ELEMENTS + 1;
+    payload.extend_from_slice(&bad_count.to_le_bytes());
+
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    drop(db);
+
+    let (ok, _out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(!ok, "over-cap element count must be rejected");
+    assert!(
+        err.contains("element count"),
+        "error must mention element count; got: {err}"
     );
 }
 

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -690,6 +690,78 @@ fn string_at_1kb_encodes_and_round_trips() {
 }
 
 #[test]
+fn ctas_then_select_value_int_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("sv_int.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE m.a * 1000 + 777 FROM mem(3,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    // m.a = 0,1,2 -> 777, 1777, 2777 : distinctive, won't collide with framing.
+    assert!(out.contains("777"), "expected 777; got: {out}");
+    assert!(out.contains("1777"), "expected 1777; got: {out}");
+    assert!(out.contains("2777"), "expected 2777; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_value_string_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("sv_str.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE 'hello' FROM mem(2,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("hello"), "expected 'hello'; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_value_null_distinct_from_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("sv_null.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE NULL FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(out.contains("NULL"), "expected NULL; got: {out}");
+    assert!(
+        !out.contains("MISSING"),
+        "NULL must not render as MISSING; got: {out}"
+    );
+}
+
+#[test]
+fn top_level_scalar_row_is_bare_tag_on_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bare.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE m.a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "CTAS failed: {err}");
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    let row0 = partiql_tools::test_support::read_row(&db, "t", 0);
+    drop(db);
+    // Bare TAG_INTEGER (0x03) + i64 0 LE — NO tuple wrapper (no 0x08 prefix).
+    let expected: &[u8] = &[
+        0x03, // TAG_INTEGER
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 0 LE
+    ];
+    assert_eq!(
+        row0, expected,
+        "top-level scalar must be a bare tag, not tuple-wrapped"
+    );
+}
+
+#[test]
 fn oversize_string_payload_surfaces_error() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("bad_str.pqlite");

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -1064,3 +1064,400 @@ fn oversize_string_payload_surfaces_error() {
     assert!(!ok, "expected SELECT to fail on oversize string");
     assert!(err.contains("string length"), "got: {err}");
 }
+
+// ---------------------------------------------------------------------------
+// Container-root, decimal/float/bytes, empty-bag, deep-mixed-nesting, and
+// list/bag-parity coverage. These fill gaps the earlier round-trip tests left:
+//   * every prior `SELECT VALUE` test produced a SCALAR root (tag < 0x08);
+//     none exercised the `bytes[0] >= TAG_TUPLE` auto-detect on a CONTAINER
+//     root (a bare List/Bag row);
+//   * no test round-tripped a Decimal, a Float, or a Bytes VALUE;
+//   * the empty *list* was covered, the empty *bag* was not;
+//   * no single row exercised tuple -> list -> bag -> scalar recursion;
+//   * the List byte-anchor existed, the Bag one did not.
+//
+// Rendering facts pinned from the binary's actual stdout (source of truth):
+//   * A SELECT reading a bare container/scalar row (a `RowShape::Register`
+//     row on disk) re-wraps it under a synthetic `'_1'` field, e.g. a bare
+//     List row renders `{ '_1': [11, 22] }`, a bare Float renders
+//     `{ '_1': 2.5 }`.
+//   * List renders `[a, b]`; Bag renders `<<a, b>>`; empty Bag renders `<<>>`.
+//   * A Bytes value renders as an Ion-style hex blob literal: `x'deadbeef'`.
+
+#[test]
+fn ctas_then_select_value_list_root() {
+    // A top-level list row (RowShape::Register holding a List) decodes and
+    // renders its elements. The bare-on-disk shape is pinned by
+    // top_level_list_root_is_bare_list_on_disk.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("list_root.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE [m.a * 100 + 11, m.a * 100 + 22] FROM mem(2,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "list-root CTAS should succeed; stderr: {err}");
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over a list-root table failed: {err}");
+    // m.a = 0 -> [11, 22]; m.a = 1 -> [111, 122]. A read-back of a bare row
+    // re-wraps it under the synthetic '_1' field, so each row renders
+    // `{ '_1': [.., ..] }`.
+    assert!(out.contains("[11, 22]"), "expected [11, 22]; got: {out}");
+    assert!(
+        out.contains("[111, 122]"),
+        "expected [111, 122]; got: {out}"
+    );
+    assert!(
+        out.contains("'_1':"),
+        "a read-back bare row wraps under '_1'; got: {out}"
+    );
+}
+
+#[test]
+fn top_level_list_root_is_bare_list_on_disk() {
+    // Companion byte-anchor to `top_level_scalar_row_is_bare_tag_on_disk`: a
+    // top-level CONTAINER value must persist BARE (starting with TAG_LIST,
+    // 0x09), NOT tuple-wrapped (0x08). Proves the container-root encode path
+    // in `write_value_at_root` does not add a tuple frame.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("list_root_anchor.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT VALUE [m.a + 55] FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "single-element list-root CTAS failed: {err}");
+
+    let row0 = {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::read_row(&db, "t", 0)
+    };
+
+    // Expected wire format for the bare row `[55i64]`:
+    //   TAG_LIST (0x09)
+    //   elem_count = 1 (LE u32: 01 00 00 00)
+    //   element 0:
+    //     TAG_INTEGER (0x03)
+    //     i64 value = 55 (LE: 37 00 00 00 00 00 00 00)
+    // Note the FIRST byte is 0x09, not 0x08 — no tuple wrapper.
+    let expected: &[u8] = &[
+        0x09, // TAG_LIST (container root, bare)
+        0x01, 0x00, 0x00, 0x00, // elem_count = 1
+        0x03, // TAG_INTEGER
+        0x37, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 55 LE
+    ];
+    assert_eq!(
+        row0, expected,
+        "a top-level container must persist bare (TAG_LIST 0x09), not tuple-wrapped: \
+         expected {expected:02x?}, got {row0:02x?}",
+    );
+}
+
+#[test]
+fn ctas_then_select_decimal_column() {
+    // The literal `3.14` is a DECIMAL in this engine (on-disk tag TAG_DECIMAL
+    // 0x05, scale 2, mantissa 314 — confirmed by direct byte inspection), NOT
+    // a float. Decimal is exact, so `3.14` must round-trip as exactly `3.14`,
+    // with no float drift like `3.1400000001`.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("decimal_col.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT 3.14 AS d FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "decimal CTAS failed: {err}");
+
+    // Anchor: the value must land in field 'd' as an exact 3.14.
+    let row0 = {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::read_row(&db, "t", 0)
+    };
+    // {'d': 3.14dec}: TAG_TUPLE, fc=1, name_len=1, 'd', TAG_DECIMAL, scale=2,
+    // mantissa=314 (i128 LE: 3a 01 then 14 zero bytes).
+    let expected: &[u8] = &[
+        0x08, // TAG_TUPLE
+        0x01, 0x00, 0x00, 0x00, // field_count = 1
+        0x01, 0x00, 0x00, 0x00, 0x64, // name "d"
+        0x05, // TAG_DECIMAL
+        0x02, 0x00, 0x00, 0x00, // scale = 2 (i32 LE)
+        0x3a, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mantissa 314 (i128 LE)
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(
+        row0, expected,
+        "decimal 3.14 wire format regressed: expected {expected:02x?}, got {row0:02x?}",
+    );
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT failed: {err}");
+    assert!(
+        out.contains("'d': 3.14"),
+        "decimal must round-trip exactly as 3.14; got: {out}"
+    );
+    // Exactness guard: no float-style drift.
+    assert!(
+        !out.contains("3.13") && !out.contains("3.1400"),
+        "decimal must be exact, not float-drifted; got: {out}"
+    );
+}
+
+#[test]
+fn ctas_then_select_float_roundtrip() {
+    // No SQL literal produces a FLOAT in this engine: `2.5`, `2.5e0`, `25e-1`
+    // and `1.5e10` all parse to DECIMAL (on-disk TAG_DECIMAL 0x05 — verified by
+    // byte inspection). A genuine FLOAT (TAG_FLOAT 0x04) therefore has to be
+    // crafted on disk, then decoded back through SELECT. A bare Float row is a
+    // `RowShape::Register` root, so the read-back wraps it under '_1'.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("float_rt.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {err}");
+
+    // Bare TAG_FLOAT root: 0x04 + f64(2.5) LE. 2.5 is exactly representable in
+    // binary64, so it prints back as `2.5` with no drift.
+    let mut payload = vec![partiql_tools::row_codec::TAG_FLOAT];
+    payload.extend_from_slice(&2.5f64.to_le_bytes());
+    {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    }
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over crafted float failed: {err}");
+    assert!(
+        out.contains("'_1': 2.5"),
+        "crafted float 2.5 must round-trip under '_1'; got: {out}"
+    );
+    assert!(
+        !out.contains("2.50"),
+        "float 2.5 must not render with drift/padding; got: {out}"
+    );
+}
+
+#[test]
+fn ctas_then_select_bytes_roundtrip() {
+    // Bytes (blob) has no SQL literal reachable through this CLI (CAST is an
+    // UnsupportedFunction, and there is no `b'..'` / `{{..}}` literal path
+    // that survives lowering here), so a Bytes VALUE is crafted on disk inside
+    // a tuple field and decoded back through SELECT. A Bytes value renders as
+    // an Ion-style hex blob literal `x'deadbeef'`.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bytes_rt.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {err}");
+
+    // {'b': BYTES 0xDE 0xAD 0xBE 0xEF}
+    let raw: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+    let mut payload = vec![partiql_tools::row_codec::TAG_TUPLE];
+    payload.extend_from_slice(&1u32.to_le_bytes()); // field_count = 1
+    payload.extend_from_slice(&1u32.to_le_bytes()); // name_len = 1
+    payload.push(b'b');
+    payload.push(partiql_tools::row_codec::TAG_BYTES);
+    payload.extend_from_slice(&(raw.len() as u32).to_le_bytes());
+    payload.extend_from_slice(&raw);
+    {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::inject_row(&db, "t", 1, &payload);
+    }
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over crafted bytes failed: {err}");
+    assert!(
+        out.contains("'b': x'deadbeef'"),
+        "crafted bytes must render as an Ion hex blob under 'b'; got: {out}"
+    );
+}
+
+#[test]
+fn ctas_then_select_empty_bag() {
+    // The empty-*list* case is covered; the empty-*bag* is the gap. An empty
+    // container encodes as count=0 with no elements and no step_in, and the
+    // empty bag renders `<<>>` inside the row tuple.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("empty_bag.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT << >> AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "empty-bag CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over empty bag failed: {err}");
+    assert!(out.contains("'xs': <<>>"), "expected empty bag; got: {out}");
+}
+
+#[test]
+fn ctas_then_select_three_level_mixed_nesting() {
+    // A single row that nests all three container kinds:
+    //   tuple 'r' -> tuple 'a' -> list -> bag -> scalar.
+    // Exercises tuple/list/bag recursion together on BOTH encode and decode in
+    // one row. Renders `{ 'r': { 'a': [<<777, 888>>] } }`.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("mixed3.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT { 'a': [ << 777, 888 >> ] } AS r FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "three-level-nesting CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over three-level nesting failed: {err}");
+    assert!(out.contains("777"), "expected 777; got: {out}");
+    assert!(out.contains("888"), "expected 888; got: {out}");
+    // The full structure survives: outer field 'r', inner field 'a', a list of
+    // one bag of two ints.
+    assert!(out.contains("'r':"), "expected outer field 'r'; got: {out}");
+    assert!(out.contains("'a':"), "expected inner field 'a'; got: {out}");
+    assert!(
+        out.contains("[<<777, 888>>]"),
+        "expected list-of-bag structure; got: {out}"
+    );
+}
+
+#[test]
+fn wire_format_bag_byte_shape() {
+    // Companion to `wire_format_list_byte_shape`: pin the single-element Bag
+    // wire format. The bytes must be identical to the LIST anchor EXCEPT the
+    // container tag byte: TAG_BAG (0x0A) where the list has TAG_LIST (0x09).
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("bag_anchor.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT << 1 >> AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "single-element bag CTAS failed: {err}");
+
+    let row0 = {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::read_row(&db, "t", 0)
+    };
+
+    // Expected wire format for the row {"xs": <<1i64>>}:
+    //   TAG_TUPLE (0x08)
+    //   field_count = 1 (LE u32: 01 00 00 00)
+    //   field 0:
+    //     name_len = 2 (LE u32: 02 00 00 00)
+    //     name = 'x' 's' (0x78 0x73)
+    //     TAG_BAG (0x0A)          <-- the ONLY difference from the list anchor
+    //     elem_count = 1 (LE u32: 01 00 00 00)
+    //     element 0:
+    //       TAG_INTEGER (0x03)
+    //       i64 value = 1 (LE: 01 00 00 00 00 00 00 00)
+    let expected: &[u8] = &[
+        0x08, // TAG_TUPLE
+        0x01, 0x00, 0x00, 0x00, // field_count = 1
+        0x02, 0x00, 0x00, 0x00, 0x78, 0x73, // name "xs"
+        0x0A, // TAG_BAG (vs 0x09 TAG_LIST for the identical list anchor)
+        0x01, 0x00, 0x00, 0x00, // elem_count = 1
+        0x03, // TAG_INTEGER
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // i64 1 LE
+    ];
+    assert_eq!(
+        row0, expected,
+        "bag wire format byte shape regressed: expected {expected:02x?}, got {row0:02x?}",
+    );
+    // Cross-check the list/bag-differ-only-by-tag invariant explicitly: the
+    // bag anchor equals the list anchor with byte 11 flipped 0x09 -> 0x0A.
+    let mut as_list = expected.to_vec();
+    assert_eq!(
+        as_list[11],
+        partiql_tools::row_codec::TAG_BAG,
+        "byte 11 is the container tag"
+    );
+    as_list[11] = partiql_tools::row_codec::TAG_LIST;
+    let list_anchor: &[u8] = &[
+        0x08, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x78, 0x73, 0x09, 0x01, 0x00, 0x00,
+        0x00, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(
+        as_list, list_anchor,
+        "bag and list wire formats must differ ONLY at the container tag byte"
+    );
+}
+
+#[test]
+fn list_and_bag_decode_same_elements_modulo_tag() {
+    // Inject two tuple rows whose bytes are byte-identical except the container
+    // tag (TAG_LIST vs TAG_BAG). Both must decode and surface the same
+    // elements (7 and 8), proving the decoder treats the two tags as the same
+    // shape modulo semantics — list renders `[7, 8]`, bag renders `<<7, 8>>`.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("list_bag_parity.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT 1 AS a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "setup CTAS failed: {err}");
+
+    // Build a {"xs": <container>[7, 8]} tuple parametrised by the container tag.
+    fn tuple_container(tag: u8) -> Vec<u8> {
+        let mut p = vec![partiql_tools::row_codec::TAG_TUPLE];
+        p.extend_from_slice(&1u32.to_le_bytes()); // field_count = 1
+        p.extend_from_slice(&2u32.to_le_bytes()); // name_len = 2
+        p.extend_from_slice(b"xs");
+        p.push(tag);
+        p.extend_from_slice(&2u32.to_le_bytes()); // elem_count = 2
+        for v in [7i64, 8i64] {
+            p.push(partiql_tools::row_codec::TAG_INTEGER);
+            p.extend_from_slice(&v.to_le_bytes());
+        }
+        p
+    }
+    let list_bytes = tuple_container(partiql_tools::row_codec::TAG_LIST);
+    let bag_bytes = tuple_container(partiql_tools::row_codec::TAG_BAG);
+    // The two payloads differ at exactly one byte: the container tag at index 11.
+    assert_eq!(list_bytes.len(), bag_bytes.len());
+    let diffs: Vec<usize> = (0..list_bytes.len())
+        .filter(|&i| list_bytes[i] != bag_bytes[i])
+        .collect();
+    assert_eq!(
+        diffs,
+        vec![11],
+        "list and bag payloads must differ only at the container tag byte"
+    );
+
+    {
+        let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+        partiql_tools::test_support::inject_row(&db, "t", 1, &list_bytes);
+        partiql_tools::test_support::inject_row(&db, "t", 2, &bag_bytes);
+    }
+
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over injected list+bag rows failed: {err}");
+    assert!(
+        out.contains("'xs': [7, 8]"),
+        "expected list row; got: {out}"
+    );
+    assert!(
+        out.contains("'xs': <<7, 8>>"),
+        "expected bag row; got: {out}"
+    );
+}
+
+#[test]
+fn ctas_then_select_null_inside_list_distinct_from_missing() {
+    // NULL as a container element (distinct from the existing bare-scalar-root
+    // NULL/MISSING test `ctas_then_select_value_null_distinct_from_missing`):
+    // exercises the null tag inside list recursion. Confirms NULL does not
+    // render as MISSING. Renders `{ 'xs': [NULL, 42] }`.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("null_in_list.pqlite");
+    let (ok, _out, err) = run_exec(
+        "CREATE TABLE t AS (SELECT [NULL, 42] AS xs FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    assert!(ok, "null-in-list CTAS should succeed; stderr: {err}");
+    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok, "SELECT over null-in-list failed: {err}");
+    assert!(
+        out.contains("[NULL, 42]"),
+        "expected [NULL, 42]; got: {out}"
+    );
+    assert!(
+        !out.contains("MISSING"),
+        "an explicit NULL element must not render as MISSING; got: {out}"
+    );
+}


### PR DESCRIPTION
Extends the row_codec to all remaining PartiQL types -> Bool, Bytes, Missing, List, Bag, runtime {...} tuples, and top-level scalar/container rows.



`CREATE TABLE t AS (SELECT [{ 'a': 1 }, { 'a': 2 }] AS xs FROM [0])`

`SELECT * FROM t`  →   `<< { 'xs': [{ 'a': 1 }, { 'a': 2 }] } >>`



-------------

- Reshuffled Tags to scalars from 0x00-0x07 and containers from 0x08-0x0A. Decode can tell the difference between a container-rooted row from a scalar one with one `tag >= TAG_TUPLE` test.
- Top-level scalars stay bare without a wrapper.
- Container counts are backpatched reserving u32. Elements stream straight into the buffer. Zero allocation per container, single pass.
- Inline enforced caps on both paths so that the encoder accepts only rows that the decoder can decode later. 
- 50 integration tests, 8 bisectable commits.

