### PR TITLE
feat(pqlite): parse, lower, and execute INSERT INTO <table> SELECT ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - *BREAKING* partiql-parser: `Parsed`'s `ast` field replaced by `statements: Vec<AstNode<Statement>>`. The `Item` enum is renamed to `Statement` with bare variants (`Statement::Query(TopLevelQuery)`, `Statement::Ddl(DdlOp)`, `Statement::Dml(Dml)`). The single-field `Ddl` wrapper struct is removed; `DdlOp` is held directly. Code that accessed `parsed.ast` must now use `parsed.statements[0]` and match on `Statement` variants.
+- *BREAKING* partiql-parser: `INSERT` and `INTO` are now reserved keywords (per SQL:2003), so they can no longer be used as bare identifiers. A query such as `SELECT x AS into FROM t` must now quote the identifier (`"into"`).
 
 ### Added
 - partiql-parser: Parsing support for `CREATE TABLE <name>` and `CREATE TABLE <name> AS (<query>)` (CTAS). DDL lowering/evaluation is not yet implemented and surfaces a `NotYetImplemented` error.
+- partiql-parser: Parsing support for `INSERT INTO <name> <query>` (INSERT ... SELECT), lowered to `LogicalStatement::InsertInto`. Other DML forms surface a `NotYetImplemented` error.
 
 ### Removed
 

--- a/partiql-logical-planner/src/lib.rs
+++ b/partiql-logical-planner/src/lib.rs
@@ -72,11 +72,47 @@ impl<'c> LogicalPlanner<'c> {
                 }
             }
             ast::Statement::Ddl(_) => Err(ddl_not_yet_implemented()),
-            ast::Statement::Dml(_) => Err(AstTransformationError {
-                errors: vec![AstTransformError::NotYetImplemented(
-                    "DML statement lowering".to_string(),
-                )],
-            }),
+            ast::Statement::Dml(dml) => match &dml.op {
+                ast::DmlOp::Insert(insert) => {
+                    // The spec-general Expr target is narrowed to a bare table-name
+                    // VarRef here; qualified/path targets are spec-legal but not yet
+                    // lowered.
+                    let table_name = match &*insert.target {
+                        ast::Expr::VarRef(v) => AstToLogical::symprim_to_binding(&v.node.name),
+                        _ => {
+                            return Err(AstTransformationError {
+                                errors: vec![AstTransformError::NotYetImplemented(
+                                    "INSERT target other than a bare table name".to_string(),
+                                )],
+                            })
+                        }
+                    };
+                    // `Expr::Query` holds a bare `Query`, but `lower_query` needs a
+                    // `TopLevelQuery`; `with: None` is inert (a bare Query carries no CTE).
+                    let query = match &*insert.values {
+                        ast::Expr::Query(q) => {
+                            let wrapped = ast::TopLevelQuery {
+                                with: None,
+                                query: q.clone(),
+                            };
+                            self.lower_query(&wrapped, stmt.id)?
+                        }
+                        _ => {
+                            return Err(AstTransformationError {
+                                errors: vec![AstTransformError::NotYetImplemented(
+                                    "INSERT source must be a query".to_string(),
+                                )],
+                            })
+                        }
+                    };
+                    Ok(logical::LogicalStatement::InsertInto { table_name, query })
+                }
+                _ => Err(AstTransformationError {
+                    errors: vec![AstTransformError::NotYetImplemented(
+                        "non-INSERT DML".to_string(),
+                    )],
+                }),
+            },
         }
     }
 
@@ -99,17 +135,24 @@ impl<'c> LogicalPlanner<'c> {
                 )],
             });
         };
-        // Reject DDL at the front door, before any inner-query lowering, so this
-        // shim returns a uniform `NotYetImplemented("DDL statement lowering")`
-        // rather than leaking an inner-query error (e.g. an unresolved table in a
-        // CTAS source). CTAS is surfaced as a plan via `lower_statement`.
-        if matches!(stmt.node, ast::Statement::Ddl(_)) {
-            return Err(ddl_not_yet_implemented());
+        // Reject DDL/DML at the front door so this shim returns a uniform category
+        // error rather than leaking an inner-query error. These are surfaced as
+        // plans via `lower_statement`.
+        match stmt.node {
+            ast::Statement::Ddl(_) => return Err(ddl_not_yet_implemented()),
+            ast::Statement::Dml(_) => {
+                return Err(AstTransformationError {
+                    errors: vec![AstTransformError::NotYetImplemented(
+                        "DML statement lowering".to_string(),
+                    )],
+                })
+            }
+            ast::Statement::Query(_) => {}
         }
         match self.lower_statement(stmt)? {
             logical::LogicalStatement::Query(plan) => Ok(plan),
-            // DDL is already rejected at the front door above, so only a query plan
-            // reaches here. This arm is a defensive fallback for any non-query result.
+            // Non-query statements are rejected at the front door above; this arm
+            // is a defensive fallback.
             _ => Err(ddl_not_yet_implemented()),
         }
     }

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -2307,4 +2307,137 @@ mod tests {
             [AstTransformError::NotYetImplemented(msg)] if msg == "DDL statement lowering"
         );
     }
+
+    #[test]
+    fn test_insert_lowers_to_insert_into() {
+        use partiql_logical::{BindingsOp, LogicalStatement};
+        use partiql_value::BindingsName;
+
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("INSERT INTO t SELECT a FROM foo WHERE a > 1")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed.statements[0])
+            .expect("Expect successful lowering");
+
+        let (table_name, query) = assert_matches!(
+            stmt,
+            LogicalStatement::InsertInto { table_name, query } => (table_name, query)
+        );
+        // Target carried verbatim, case-insensitive (bare identifier).
+        assert_eq!(table_name, BindingsName::CaseInsensitive("t".into()));
+        // Inner plan is the ordinary relational DAG, terminating in Sink.
+        assert!(
+            query.operator_count() >= 2,
+            "expected a non-trivial inner plan"
+        );
+        assert_matches!(
+            query.operators().last(),
+            Some(BindingsOp::Sink),
+            "inner plan must terminate in Sink"
+        );
+    }
+
+    #[test]
+    fn test_insert_preserves_quoted_target_casing() {
+        use partiql_logical::LogicalStatement;
+        use partiql_value::BindingsName;
+
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("INSERT INTO \"T\" SELECT a FROM foo")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed.statements[0])
+            .expect("Expect successful lowering");
+
+        let table_name = assert_matches!(
+            stmt,
+            LogicalStatement::InsertInto { table_name, .. } => table_name
+        );
+        // Quoted identifier -> CaseSensitive, value preserved verbatim.
+        assert_eq!(table_name, BindingsName::CaseSensitive("T".into()));
+    }
+
+    #[test]
+    fn test_insert_inner_source_resolves_through_existing_path() {
+        use partiql_logical::{self as logical, LogicalStatement};
+        use partiql_value::BindingsName;
+
+        let mut catalog = PartiqlCatalog::default();
+        let _oid =
+            catalog.add_type_entry(TypeEnvEntry::new("customers", &[], PartiqlShape::Dynamic));
+        let catalog = catalog.to_shared_catalog();
+
+        let parsed = partiql_parser::Parser::default()
+            .parse("INSERT INTO t SELECT customers.name FROM customers AS c")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let stmt = planner
+            .lower_statement(&parsed.statements[0])
+            .expect("Expect successful lowering");
+
+        let query = assert_matches!(
+            stmt,
+            LogicalStatement::InsertInto { query, .. } => query
+        );
+        // The catalog-registered source lowers to a Scan over a DBRef (not a
+        // fallback Global VarRef), proving the wrapped inner query used the normal
+        // resolution path — the same assertion the CTAS twin makes.
+        let has_dbref_scan = query.operators().iter().any(|op| {
+            matches!(
+                op,
+                BindingsOp::Scan(logical::Scan { expr: ValueExpr::DBRef(db), .. })
+                    if db.catalog == "default"
+                        && db.path == vec![BindingsName::CaseInsensitive("customers".into())]
+            )
+        });
+        assert!(
+            has_dbref_scan,
+            "inner source `customers` must resolve to a DBRef Scan"
+        );
+    }
+
+    #[test]
+    fn test_legacy_lower_rejects_insert() {
+        // Same back-compat contract as the DDL arms: the legacy `lower` shim must
+        // reject DML with the uniform error, not silently change its return type.
+        // INSERT is surfaced via `lower_statement`.
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("INSERT INTO t SELECT a FROM foo")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let errs = planner
+            .lower(&parsed)
+            .expect_err("legacy lower() must reject INSERT")
+            .errors;
+        assert_matches!(
+            errs.as_slice(),
+            [AstTransformError::NotYetImplemented(msg)] if msg == "DML statement lowering"
+        );
+    }
+
+    #[test]
+    fn test_legacy_lower_short_circuits_dml_before_inner_query() {
+        // The shim must reject DML at the front door, BEFORE lowering the inner
+        // query. The INSERT source references an undefined function that would
+        // itself error, but `lower()` must still return the uniform DML rejection.
+        let catalog = PartiqlCatalog::default().to_shared_catalog();
+        let parsed = partiql_parser::Parser::default()
+            .parse("INSERT INTO t SELECT undefined_fn(a) FROM foo")
+            .expect("Expect successful parse");
+        let planner = LogicalPlanner::new(&catalog);
+        let errs = planner
+            .lower(&parsed)
+            .expect_err("legacy lower() must reject INSERT")
+            .errors;
+        assert_matches!(
+            errs.as_slice(),
+            [AstTransformError::NotYetImplemented(msg)] if msg == "DML statement lowering"
+        );
+    }
 }

--- a/partiql-logical/src/lib.rs
+++ b/partiql-logical/src/lib.rs
@@ -487,6 +487,11 @@ pub enum LogicalStatement {
     },
     /// `CREATE TABLE <name>` — the target only, no source query.
     CreateTable { table_name: BindingsName<'static> },
+    /// `INSERT INTO <name> <query>` — target table plus the lowered source query.
+    InsertInto {
+        table_name: BindingsName<'static>,
+        query: LogicalPlan<BindingsOp>,
+    },
 }
 
 /// Represents a `PartiQL` value expression. Evaluation of a [`ValueExpr`] leads to a `PartiQL` value as

--- a/partiql-parser/src/lexer/partiql.rs
+++ b/partiql-parser/src/lexer/partiql.rs
@@ -377,6 +377,10 @@ pub enum Token<'input> {
     In,
     #[regex("(?i:Inner)")]
     Inner,
+    #[regex("(?i:Insert)")]
+    Insert,
+    #[regex("(?i:Into)")]
+    Into,
     #[regex("(?i:Is)")]
     Is,
     #[regex("(?i:Intersect)")]
@@ -652,6 +656,8 @@ impl Token<'_> {
                 | Token::Having
                 | Token::In
                 | Token::Inner
+                | Token::Insert
+                | Token::Into
                 | Token::Is
                 | Token::Intersect
                 | Token::Join

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -1018,4 +1018,71 @@ mod tests {
             assert!(res.is_err());
         }
     }
+
+    mod dml {
+        use super::*;
+
+        // `INSERT INTO <name> <query>` lands as `Statement::Dml` with a
+        // `DmlOp::Insert`; the target is a `VarRef` and the source is `Expr::Query`.
+        #[test]
+        fn insert_into_select() {
+            let stmt = parse!(r"INSERT INTO foo SELECT m.a FROM mem(5, 2) m");
+            match stmt.node {
+                ast::Statement::Dml(ast::Dml {
+                    op: ast::DmlOp::Insert(insert),
+                    ..
+                }) => {
+                    assert!(matches!(*insert.target, ast::Expr::VarRef(_)));
+                    assert!(matches!(*insert.values, ast::Expr::Query(_)));
+                }
+                other => panic!("expected Dml(Insert), got {other:?}"),
+            }
+        }
+
+        // The source is the full `Query` rule, so ORDER BY / LIMIT are accepted.
+        #[test]
+        fn insert_into_select_complex() {
+            parse!(
+                r"INSERT INTO summary SELECT m.a FROM mem(5, 2) m WHERE m.a > 1 ORDER BY m.a DESC LIMIT 10"
+            );
+        }
+
+        // A quoted target identifier is accepted (SymbolPrimitive covers it).
+        #[test]
+        fn insert_into_quoted_target() {
+            parse!(r#"INSERT INTO "my table" SELECT m.a FROM mem(2, 1) m"#);
+        }
+
+        // VALUES is a keyword-initial query source, so it is a valid INSERT source.
+        #[test]
+        fn insert_into_values() {
+            parse!(r"INSERT INTO foo VALUES (1), (2)");
+        }
+
+        // Negative: `INSERT INTO` alone (no target, no source) must fail gracefully.
+        #[test]
+        fn insert_missing_target_and_source() {
+            assert!(parse_partiql(r"INSERT INTO").is_err());
+        }
+
+        // Negative: `INTO` is required after `INSERT`.
+        #[test]
+        fn insert_missing_into() {
+            assert!(parse_partiql(r"INSERT foo SELECT 1").is_err());
+        }
+
+        // Negative: a target with no source query must fail gracefully.
+        #[test]
+        fn insert_missing_source() {
+            assert!(parse_partiql(r"INSERT INTO foo").is_err());
+        }
+
+        // `INSERT`/`INTO` are reserved keywords, so they can no longer be used as
+        // bare identifiers. This documents the intended reservation.
+        #[test]
+        fn insert_into_are_reserved_keywords() {
+            assert!(parse_partiql(r"SELECT insert FROM t").is_err());
+            assert!(parse_partiql(r"SELECT into FROM t").is_err());
+        }
+    }
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -31,6 +31,11 @@ grammar<'input, 'state, Id>(input: &'input str, state: &'state mut ParserState<'
 pub(crate) Statement: ast::AstNode<ast::Statement> = {
     <lo:@L> <query:TopLevelQuery> <hi:@R> => state.node(ast::Statement::Query(query.node), lo..hi),
     <lo:@L> <ddl_op:DdlOp> <hi:@R> => state.node(ast::Statement::Ddl(ddl_op), lo..hi),
+    <lo:@L> <dml_op:DmlOp> <hi:@R> => state.node(
+        ast::Statement::Dml(ast::Dml {
+            op: dml_op, from_clause: None, where_clause: None, returning: None,
+        }),
+        lo..hi),
 }
 
 TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
@@ -58,6 +63,26 @@ CreateTable: ast::CreateTable = {
 #[inline]
 CtasClause: Box<ast::AstNode<ast::TopLevelQuery>> = {
     "AS" "(" <query:TopLevelQuery> ")" => Box::new(query),
+}
+
+DmlOp: ast::DmlOp = {
+    <i:Insert> => ast::DmlOp::Insert(i),
+}
+
+// `INSERT INTO <name> <query>`. The source is bare: the only spec paren-slot
+// after a table name is the (unsupported) column list. `Query` not
+// `TopLevelQuery`, so a leading `WITH` source is out of scope.
+Insert: ast::Insert = {
+    "INSERT" "INTO" <lo:@L> <target:SymbolPrimitive> <hi:@R> <source:Query> => {
+        let target_ref = state.node(
+            ast::VarRef { name: target, qualifier: ast::ScopeQualifier::Unqualified },
+            lo..hi,
+        );
+        ast::Insert {
+            target: Box::new(ast::Expr::VarRef(target_ref)),
+            values: Box::new(ast::Expr::Query(source)),
+        }
+    }
 }
 
 Query: ast::AstNode<ast::Query> = {
@@ -2211,7 +2236,9 @@ extern {
         "HAVING" => lexer::Token::Having,
         "IN" => lexer::Token::In,
         "INNER" => lexer::Token::Inner,
+        "INSERT" => lexer::Token::Insert,
         "INTERSECT" => lexer::Token::Intersect,
+        "INTO" => lexer::Token::Into,
         "IS" => lexer::Token::Is,
         "JOIN" => lexer::Token::Join,
         "KEEP" => lexer::Token::Keep,

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -326,6 +326,24 @@ fn print_ddl_planned_footer(elapsed: std::time::Duration) {
     );
 }
 
+/// Per-stage timing footer for the write statements (CTAS / INSERT).
+fn print_write_footer(
+    parse: std::time::Duration,
+    lower: std::time::Duration,
+    compile: std::time::Duration,
+    exec: std::time::Duration,
+) {
+    let total = parse + lower + compile + exec;
+    eprintln!(
+        "(took {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
+        total.as_secs_f64() * 1000.0,
+        parse.as_secs_f64() * 1000.0,
+        lower.as_secs_f64() * 1000.0,
+        compile.as_secs_f64() * 1000.0,
+        exec.as_secs_f64() * 1000.0,
+    );
+}
+
 /// Bundles `HeedCompilationCatalog` with the existing `TableFnCompilationCatalog`
 /// under `PlanCompiler`'s single `"default"` catalog name. Also records the
 /// first unresolved bare table name so `build_compiled` can fail fast with
@@ -430,6 +448,55 @@ fn build_exec_context(
     exec_context
 }
 
+/// Buffered source rows plus the timing a write-path caller needs to finish its
+/// own exec timer: `(encoded rows, compile time, exec start instant)`.
+type DrainedSource = (Vec<Vec<u8>>, std::time::Duration, Instant);
+
+/// Compile the source plan, run it, and buffer every result row into owned
+/// bytes. The source is fully drained here — before any caller opens a write
+/// txn — because a streaming source holds a read txn open across iteration, and
+/// LMDB rejects opening a table handle in a write txn while one is live
+/// (MDB_BAD_DBI). Returns the buffered rows, the compile time, and the exec
+/// start instant so the caller can finish timing after its own write + commit.
+fn drain_source_rows(
+    query: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+    debug: &DebugFlags,
+    db: &Arc<HeedDB>,
+) -> Result<DrainedSource, Box<dyn std::error::Error>> {
+    let compile_start = Instant::now();
+    let (compiled, catalog_id) = build_compiled(query, debug, Some(Arc::clone(db)))?;
+    let compile_time = compile_start.elapsed();
+
+    let exec_start = Instant::now();
+    let exec_context = build_exec_context(Some(Arc::clone(db)), catalog_id, &compiled);
+    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+        .map_err(|e| format!("Execution setup error: {:?}", e))?;
+
+    // Snapshot RowShape before vm.execute() borrows the VM mutably.
+    let row_shape = vm.shape().row_shape().clone();
+
+    let mut rows: Vec<Vec<u8>> = Vec::new();
+    // Reused warm across rows (serialize_row clears on entry); each retained row
+    // is a tight clone (cap == len), so no per-row 4 KiB is held.
+    let mut scratch: Vec<u8> = Vec::with_capacity(4096);
+    match vm.execute() {
+        Ok(partiql_eval::ExecutionResult::Query(iter)) => {
+            // SAFETY: QueryIterator::next lifetime-extends its RegisterReader;
+            // aliasing across next() is UB. Consume `row` before the next pull.
+            for r in iter {
+                let row = r.map_err(|e| {
+                    format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
+                })?;
+                partiql_tools::row_codec::serialize_row(&row, &row_shape, &mut scratch)
+                    .map_err(|e| format!("Error: {}", StorageError::Codec(format!("{e}"))))?;
+                rows.push(scratch.clone());
+            }
+        }
+        Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
+    }
+    Ok((rows, compile_time, exec_start))
+}
+
 fn execute_query(
     query_str: &str,
     debug: &DebugFlags,
@@ -467,42 +534,7 @@ fn execute_query(
                 .as_ref()
                 .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?;
 
-            let compile_start = Instant::now();
-            let (compiled, catalog_id) = build_compiled(&query, debug, Some(Arc::clone(db)))?;
-            let compile_time = compile_start.elapsed();
-
-            let exec_start = Instant::now();
-            let exec_context = build_exec_context(Some(Arc::clone(db)), catalog_id, &compiled);
-            let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
-                .map_err(|e| format!("Execution setup error: {:?}", e))?;
-
-            // Snapshot RowShape before vm.execute() borrows the VM mutably.
-            let row_shape = vm.shape().row_shape().clone();
-
-            // 4 KiB scratch matches LMDB's typical page size; reused per row.
-            let mut scratch_buf: Vec<u8> = Vec::with_capacity(4096);
-
-            // Drain the source before opening the write txn: a streaming source
-            // holds a read txn open across iteration, and LMDB rejects opening a
-            // table handle in a write txn while one is live (MDB_BAD_DBI).
-            let mut rows: Vec<Vec<u8>> = Vec::new();
-            match vm.execute() {
-                Ok(partiql_eval::ExecutionResult::Query(iter)) => {
-                    // SAFETY: QueryIterator::next lifetime-extends its RegisterReader;
-                    // aliasing across next() is UB. Consume `row` before the next pull.
-                    for r in iter {
-                        let row = r.map_err(|e| {
-                            format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
-                        })?;
-                        partiql_tools::row_codec::serialize_row(&row, &row_shape, &mut scratch_buf)
-                            .map_err(|e| {
-                                format!("Error: {}", StorageError::Codec(format!("{e}")))
-                            })?;
-                        rows.push(scratch_buf.clone());
-                    }
-                }
-                Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
-            }
+            let (rows, compile_time, exec_start) = drain_source_rows(&query, debug, db)?;
 
             let n = {
                 let mut writer = db.create_table(&key).map_err(|e| format!("Error: {}", e))?;
@@ -520,15 +552,43 @@ fn execute_query(
                 format_table_name(&table_name),
                 n
             );
-            let total_time = parse_time + lower_time + compile_time + exec_time;
+            print_write_footer(parse_time, lower_time, compile_time, exec_time);
+            return Ok(());
+        }
+        LogicalStatement::InsertInto { table_name, query } => {
+            let key = canonical_table_key(&table_name);
+
+            // Resolve --db before compile + VM setup so a missing flag fails
+            // cleanly before any expensive work.
+            let db = db
+                .as_ref()
+                .ok_or("Error: The `--db <PATH>` option is required for INSERT.")?;
+
+            let (rows, compile_time, exec_start) = drain_source_rows(&query, debug, db)?;
+
+            // Row count is tallied here, not from commit(): open_table_for_append
+            // seeds row_id at the high-water mark, so commit() returns the absolute
+            // counter (existing + inserted), not this statement's insert count.
+            let inserted = rows.len() as u64;
+            {
+                let mut writer = db
+                    .open_table_for_append(&key)
+                    .map_err(|e| format!("Error: {}", e))?;
+                for encoded in &rows {
+                    writer
+                        .push_row(encoded)
+                        .map_err(|e| format!("Error: {}", e))?;
+                }
+                writer.commit().map_err(|e| format!("Error: {}", e))?;
+            }
+            let exec_time = exec_start.elapsed();
+
             eprintln!(
-                "(took {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-                total_time.as_secs_f64() * 1000.0,
-                parse_time.as_secs_f64() * 1000.0,
-                lower_time.as_secs_f64() * 1000.0,
-                compile_time.as_secs_f64() * 1000.0,
-                exec_time.as_secs_f64() * 1000.0,
+                "Inserted {} rows into {}",
+                inserted,
+                format_table_name(&table_name)
             );
+            print_write_footer(parse_time, lower_time, compile_time, exec_time);
             return Ok(());
         }
         LogicalStatement::CreateTable { table_name } => {

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -190,16 +190,23 @@ impl HeedDB {
         })
     }
 
-    /// Open a write handle for a new table. `name` must already be
-    /// canonicalized by the caller (lowercase for bare identifiers, verbatim
-    /// for quoted).
-    pub fn create_table(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
+    /// Reject names the storage layer refuses: `_`-prefixed (reserved for the
+    /// system catalog) and interior NUL (would panic heed's key encoding).
+    fn guard_name(name: &str) -> Result<(), StorageError> {
         if name.starts_with('_') {
             return Err(StorageError::ReservedName(name.to_string()));
         }
         if name.contains('\0') {
             return Err(StorageError::InvalidName(name.to_string()));
         }
+        Ok(())
+    }
+
+    /// Open a write handle for a new table. `name` must already be
+    /// canonicalized by the caller (lowercase for bare identifiers, verbatim
+    /// for quoted).
+    pub fn create_table(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
+        Self::guard_name(name)?;
         let mut wtxn = self.env.write_txn()?;
         if self.tables.get(&wtxn, name)?.is_some() {
             return Err(StorageError::TableExists(name.to_string()));
@@ -211,6 +218,49 @@ impl HeedDB {
             wtxn,
             table,
             row_id: 0,
+            key_buf: [0u8; 8],
+        })
+    }
+
+    /// Open an existing table for appending. Errors if the table is absent, and
+    /// seeds the writer's `row_id` at the current high-water key + 1 so appended
+    /// rows get fresh keys after the max.
+    pub fn open_table_for_append(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
+        Self::guard_name(name)?;
+        let wtxn = self.env.write_txn()?;
+        // Catalog membership defines existence for reads (see `open_table`), so
+        // the append path checks it too: a table absent from `_tables` is not
+        // appendable, matching what a subsequent SELECT would see.
+        if self.tables.get(&wtxn, name)?.is_none() {
+            return Err(StorageError::TableMissing(name.to_string()));
+        }
+        // Open (not create): fail loudly if the named db is absent, rather than
+        // silently re-creating an empty table and appending at row_id 0 on a
+        // catalog/data drift. (`&wtxn` coerces to `&RoTxn` via Deref.)
+        let table: RowDb = self
+            .env
+            .open_database(&wtxn, Some(name))?
+            .ok_or_else(|| StorageError::TableMissing(name.to_string()))?;
+        // Keys are 8-byte BE u64, so byte order equals numeric order and the last
+        // key is the highest row_id. A non-8-byte key means the row-id scheme
+        // changed; fail loudly rather than truncate.
+        let next_row_id = match table.last(&wtxn)? {
+            Some((k, _)) => {
+                let arr = <[u8; 8]>::try_from(k).map_err(|_| {
+                    StorageError::Codec(format!(
+                        "table {}: row key is {} bytes, expected 8 (BE u64)",
+                        name,
+                        k.len()
+                    ))
+                })?;
+                u64::from_be_bytes(arr) + 1
+            }
+            None => 0,
+        };
+        Ok(TableWriter {
+            wtxn,
+            table,
+            row_id: next_row_id,
             key_buf: [0u8; 8],
         })
     }
@@ -563,6 +613,58 @@ mod tests {
             "expected TableMissing; got {:?}",
             res
         );
+    }
+
+    #[test]
+    fn append_to_existing_table_continues_row_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        let mut w = db.create_table("t").unwrap();
+        w.push_row(&[0xAA]).unwrap();
+        w.push_row(&[0xBB]).unwrap();
+        w.push_row(&[0xCC]).unwrap();
+        w.commit().unwrap();
+        let mut a = db.open_table_for_append("t").unwrap();
+        a.push_row(&[0xDD]).unwrap();
+        a.push_row(&[0xEE]).unwrap();
+        let final_row_id = a.commit().unwrap();
+        assert_eq!(final_row_id, 5, "row_id counter should be 5 after 3+2 rows");
+        assert_eq!(db.read_row_for_tests("t", 3), vec![0xDD]);
+        assert_eq!(db.read_row_for_tests("t", 4), vec![0xEE]);
+        assert_eq!(db.read_row_for_tests("t", 0), vec![0xAA]);
+    }
+
+    #[test]
+    fn append_to_empty_table_starts_at_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        db.create_table("t").unwrap().commit().unwrap(); // empty table, no rows
+        let mut a = db.open_table_for_append("t").unwrap();
+        a.push_row(&[0x01]).unwrap();
+        assert_eq!(a.commit().unwrap(), 1);
+        assert_eq!(db.read_row_for_tests("t", 0), vec![0x01]);
+    }
+
+    #[test]
+    fn append_to_missing_table_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        let r = db.open_table_for_append("ghost");
+        assert!(matches!(r, Err(StorageError::TableMissing(_))));
+    }
+
+    #[test]
+    fn append_rejects_reserved_and_invalid_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        assert!(matches!(
+            db.open_table_for_append("_x"),
+            Err(StorageError::ReservedName(_))
+        ));
+        assert!(matches!(
+            db.open_table_for_append("a\0b"),
+            Err(StorageError::InvalidName(_))
+        ));
     }
 
     #[test]

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -1566,3 +1566,204 @@ fn ctas_from_stored_table_roundtrips() {
         "dest should have 3 rows; stderr: {err}"
     );
 }
+
+// End-to-end `INSERT INTO t SELECT ...` tests. INSERT appends onto an existing
+// table (CTAS creates a fresh one), so these seed a table via CTAS first, then
+// append and re-read. INSERT source is BARE (no wrapping parens), unlike CTAS.
+
+#[test]
+fn insert_select_roundtrip_cases() {
+    // (setup DDL, insert stmt, values expected present after SELECT, total row count)
+    let cases: &[(&str, &str, &[&str], u32)] = &[
+        // Append 3 rows onto a seeded 2-row table -> 5 total.
+        (
+            "CREATE TABLE t AS (SELECT m.a FROM mem(2,1) m)",
+            "INSERT INTO t SELECT m.a FROM mem(3,1) m",
+            &["0", "1", "2"],
+            5,
+        ),
+        // Append onto a seeded 1-row table -> 3 total.
+        (
+            "CREATE TABLE t AS (SELECT m.a FROM mem(1,1) m)",
+            "INSERT INTO t SELECT m.a FROM mem(2,1) m",
+            &["0", "1"],
+            3,
+        ),
+    ];
+    for (i, (setup, insert, expected, total)) in cases.iter().enumerate() {
+        let dir = tempfile::tempdir().unwrap();
+        let dbp = dir.path().join(format!("ins_{i}.pqlite"));
+        let (ok, _o, err) = run_exec(setup, Some(&dbp));
+        assert!(ok, "case {i} setup failed: {err}");
+        let (ok, _o, err) = run_exec(insert, Some(&dbp));
+        assert!(ok, "case {i} INSERT failed: {err}");
+        assert!(
+            err.contains("Inserted"),
+            "case {i} missing confirmation: {err}"
+        );
+        let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+        assert!(ok, "case {i} SELECT failed: {err}");
+        for v in *expected {
+            assert!(
+                out.contains(&format!("'a': {v}")),
+                "case {i} missing {v}: {out}"
+            );
+        }
+        assert!(
+            err.contains(&format!("({total} rows ")),
+            "case {i} count: {err}"
+        );
+    }
+}
+
+#[test]
+fn insert_into_missing_table_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("m.pqlite");
+    // Create an unrelated table so the env/file exists.
+    run_exec(
+        "CREATE TABLE other AS (SELECT m.a FROM mem(1,1) m)",
+        Some(&dbp),
+    );
+    let (ok, _o, err) = run_exec("INSERT INTO ghost SELECT m.a FROM mem(1,1) m", Some(&dbp));
+    assert!(!ok, "INSERT into missing table must fail");
+    assert!(err.contains("table not found: ghost"), "got: {err}");
+}
+
+#[test]
+fn insert_preserves_existing_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("p.pqlite");
+    run_exec("CREATE TABLE t AS (SELECT m.a FROM mem(3,1) m)", Some(&dbp)); // 0,1,2
+    let (ok, _o, err) = run_exec("INSERT INTO t SELECT m.a FROM mem(2,1) m", Some(&dbp)); // +0,1
+    assert!(ok, "{err}");
+    let (ok, out, _e) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok);
+    // a=2 only exists in the seeded batch; it must survive the append.
+    assert!(
+        out.contains("'a': 2"),
+        "seeded rows must survive append: {out}"
+    );
+}
+
+#[test]
+fn insert_row_ids_continue_after_max() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("k.pqlite");
+    run_exec("CREATE TABLE t AS (SELECT m.a FROM mem(3,1) m)", Some(&dbp)); // keys 0,1,2
+    run_exec("INSERT INTO t SELECT m.a FROM mem(2,1) m", Some(&dbp)); // keys 3,4
+    let db = partiql_tools::storage::HeedDB::open(&dbp).unwrap();
+    // read_row panics if a key is absent, so reading 3,4 asserts they exist.
+    // Appended rows come from mem(2,1) = a:0,1 — byte-identical to the seed's
+    // first two rows (mem(3,1) = a:0,1,2), so keys 3,4 must equal keys 0,1.
+    let (k0, k1) = (
+        partiql_tools::test_support::read_row(&db, "t", 0),
+        partiql_tools::test_support::read_row(&db, "t", 1),
+    );
+    assert_eq!(
+        partiql_tools::test_support::read_row(&db, "t", 3),
+        k0,
+        "appended key 3 must equal the seed's a:0 row"
+    );
+    assert_eq!(
+        partiql_tools::test_support::read_row(&db, "t", 4),
+        k1,
+        "appended key 4 must equal the seed's a:1 row"
+    );
+}
+
+#[test]
+fn insert_without_db_errors() {
+    let (ok, _o, err) = run_exec("INSERT INTO t SELECT m.a FROM mem(1,1) m", None);
+    assert!(!ok, "INSERT without --db must fail");
+    assert!(err.contains("--db"), "got: {err}");
+}
+
+#[test]
+fn insert_empty_select_is_noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("e.pqlite");
+    run_exec("CREATE TABLE t AS (SELECT m.a FROM mem(2,1) m)", Some(&dbp));
+    // WHERE FALSE yields zero source rows (house idiom for an empty result).
+    let (ok, _o, err) = run_exec(
+        "INSERT INTO t SELECT m.a FROM mem(1,1) m WHERE FALSE",
+        Some(&dbp),
+    );
+    assert!(ok, "empty INSERT should succeed: {err}");
+    assert!(err.contains("Inserted 0 rows"), "got: {err}");
+    // The pre-existing rows are untouched.
+    let (ok, out, _e) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok);
+    assert!(
+        out.contains("'a': 0") && out.contains("'a': 1"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn insert_from_stored_table() {
+    // Disk-to-disk INSERT: source is a stored table (incl. the destination
+    // itself), so the source read txn must close before the append write txn
+    // opens (else MDB_BAD_DBI).
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("d2d_ins.pqlite");
+    run_exec(
+        "CREATE TABLE src AS (SELECT m.a FROM mem(3,1) m)",
+        Some(&dbp),
+    );
+    run_exec("CREATE TABLE t AS (SELECT m.a FROM mem(2,1) m)", Some(&dbp));
+
+    // Append from another stored table.
+    let (ok, _o, err) = run_exec("INSERT INTO t SELECT src.a FROM src", Some(&dbp));
+    assert!(
+        ok,
+        "INSERT from a stored table should succeed; stderr: {err}"
+    );
+    assert!(err.contains("Inserted 3 rows"), "got: {err}");
+
+    // Self-insert: read and write the same table in one statement.
+    let (ok, _o, err) = run_exec("INSERT INTO t SELECT t.a FROM t", Some(&dbp));
+    assert!(ok, "self-insert should succeed; stderr: {err}");
+    assert!(err.contains("Inserted 5 rows"), "got: {err}");
+
+    let (ok, _out, err) = run_exec("SELECT * FROM t", Some(&dbp));
+    assert!(ok);
+    assert!(
+        err.contains("(10 rows "),
+        "expected 10 rows total; stderr: {err}"
+    );
+}
+
+#[test]
+fn insert_into_quoted_case_sensitive_target() {
+    // Parity with CTAS's quoted-name roundtrip: a case-sensitive quoted target
+    // must resolve to the same physical table for CREATE, INSERT, and SELECT.
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("quoted_ins.pqlite");
+
+    let (ok, _o, err) = run_exec(
+        r#"CREATE TABLE "MyTable" AS (SELECT m.a FROM mem(2,1) m)"#,
+        Some(&dbp),
+    );
+    assert!(ok, "quoted CTAS should succeed; stderr: {err}");
+
+    let (ok, _o, err) = run_exec(
+        r#"INSERT INTO "MyTable" SELECT m.a FROM mem(3,1) m"#,
+        Some(&dbp),
+    );
+    assert!(
+        ok,
+        "INSERT into quoted target should succeed; stderr: {err}"
+    );
+    assert!(err.contains("Inserted 3 rows"), "got: {err}");
+
+    let (ok, _out, err) = run_exec(r#"SELECT * FROM "MyTable""#, Some(&dbp));
+    assert!(
+        ok,
+        "SELECT from quoted target should succeed; stderr: {err}"
+    );
+    assert!(
+        err.contains("(5 rows "),
+        "expected 5 rows total; stderr: {err}"
+    );
+}


### PR DESCRIPTION
Wires up `INSERT INTO <table> <query>` (INSERT ... SELECT) end to end, appending a query's result rows to an existing table. This mirrors the recently merged CTAS pipeline at every layer from the grammar down to the LMDB storage driver.

INSERT INTO t SELECT m.a FROM mem(3,1) m      -- append 3 rows to t
INSERT INTO t SELECT src.a FROM src           -- disk-to-disk
INSERT INTO t SELECT t.a FROM t               -- self-insert

`INSERT` and `INTO` are now reserved keywords (per SQL:2003), meaning queries like `SELECT x AS into FROM t` must now quote the identifier (`"into"`).

Key changes:
- **Grammar & AST:** Parses the spec-faithful, unparenthesized form `INSERT INTO <name> <query>`. It avoids the parenthesized syntax of CTAS's `AS ( <query> )` because `INTO` is structurally unique, preventing any alias/projection ambiguity and avoiding future collisions with column-list slots. Reuses the existing `ast::Insert` node, narrowing the target to a bare table-name `VarRef` during lowering.
- **Lowering:** Adds `LogicalStatement::InsertInto { table_name, query }` to mirror `CreateTableAs`. Unsupported shapes degrade safely to `NotYetImplemented` and lower() rejects DML.
- **Storage Driver:** Implements `HeedDB::open_table_for_append`, which opens an existing table (throwing an error if it's missing) and seeds the writer's `row_id` at `high_water_key + 1` to preserve ordering.
- **Execution & Avoid-Locking:** Shares a new `drain_source_rows` helper with the CTAS path. It fully materializes the source rows in memory before starting the LMDB write transaction. This read-before-write ordering prevents LMDB `MDB_BAD_DBI` errors when a query reads from and inserts into stored tables.

26 tests total (9 parser, 5 lowering, 4 storage, 8 CLI/E2E), covering key reservation regressions, self-inserts, and invalid target errors.