### PR TITLE
feat(pqlite): bootstrap system tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - partiql-parser: Parsing support for `CREATE TABLE <name>` and `CREATE TABLE <name> AS (<query>)` (CTAS). DDL lowering/evaluation is not yet implemented and surfaces a `NotYetImplemented` error.
 - partiql-parser: Parsing support for `INSERT INTO <name> <query>` (INSERT ... SELECT), lowered to `LogicalStatement::InsertInto`. Other DML forms surface a `NotYetImplemented` error.
+- partiql-parser: `Parser::parse_statements` parses a `;`-separated script into multiple statements (optional trailing `;`). Single-statement `Parser::parse` is unchanged and still rejects `;`.
 
 ### Removed
 

--- a/partiql-parser/src/lib.rs
+++ b/partiql-parser/src/lib.rs
@@ -58,7 +58,7 @@ mod parse;
 mod preprocessor;
 mod token_parser;
 
-use parse::{parse_partiql, AstData, ErrorData};
+use parse::{parse_partiql, parse_partiql_statements, AstData, ErrorData};
 use partiql_ast::ast;
 use partiql_common::syntax::line_offset_tracker::LineOffsetTracker;
 use partiql_common::syntax::location::BytePosition;
@@ -81,9 +81,32 @@ pub type ParserResult<'input> = Result<Parsed<'input>, ParserError<'input>>;
 pub struct Parser {}
 
 impl Parser {
-    /// Parse a `PartiQL` statement into an AST.
+    /// Parse a single `PartiQL` statement into an AST.
     pub fn parse<'input>(&self, text: &'input str) -> ParserResult<'input> {
         match parse_partiql(text) {
+            Ok(AstData {
+                statements,
+                locations,
+                offsets,
+            }) => Ok(Parsed {
+                text,
+                offsets,
+                statements,
+                locations,
+            }),
+            Err(ErrorData { errors, offsets }) => Err(ParserError {
+                text,
+                offsets,
+                errors,
+            }),
+        }
+    }
+
+    /// Parse a `;`-separated `PartiQL` script into a `Parsed` whose
+    /// `statements` holds each statement in source order. A trailing `;` is
+    /// optional; an empty or all-comment script yields no statements.
+    pub fn parse_statements<'input>(&self, text: &'input str) -> ParserResult<'input> {
+        match parse_partiql_statements(text) {
             Ok(AstData {
                 statements,
                 locations,

--- a/partiql-parser/src/parse/mod.rs
+++ b/partiql-parser/src/parse/mod.rs
@@ -31,6 +31,7 @@ mod grammar {
 type LalrpopError<'input> =
     lpop::ParseError<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
 type LalrpopResult<'input> = Result<ast::AstNode<ast::Statement>, LalrpopError<'input>>;
+type LalrpopListResult<'input> = Result<Vec<ast::AstNode<ast::Statement>>, LalrpopError<'input>>;
 type LalrpopErrorRecovery<'input> =
     lpop::ErrorRecovery<ByteOffset, lexer::Token<'input>, ParseError<'input, BytePosition>>;
 
@@ -52,6 +53,13 @@ pub(crate) type AstResult<'input> = Result<AstData, ErrorData<'input>>;
 /// Parse `PartiQL` query text into an AST.
 pub(crate) fn parse_partiql(s: &str) -> AstResult<'_> {
     parse_partiql_with_state(s, ParserState::default())
+}
+
+/// Parse a `;`-separated `PartiQL` script into a list of statement ASTs.
+/// A trailing `;` is optional; an empty (or all-comment) script yields no
+/// statements.
+pub(crate) fn parse_partiql_statements(s: &str) -> AstResult<'_> {
+    parse_partiql_statements_with_state(s, ParserState::default())
 }
 
 fn parse_partiql_with_state<'input, Id: NodeIdGenerator>(
@@ -86,6 +94,44 @@ fn parse_partiql_with_state<'input, Id: NodeIdGenerator>(
         }
         (Ok(stmt), true) => Ok(AstData {
             statements: vec![stmt],
+            locations,
+            offsets,
+        }),
+    }
+}
+
+fn parse_partiql_statements_with_state<'input, Id: NodeIdGenerator>(
+    s: &'input str,
+    mut state: ParserState<'input, Id>,
+) -> AstResult<'input> {
+    let mut offsets = LineOffsetTracker::default();
+    let lexer = PreprocessingPartiqlLexer::new(s, &mut offsets, &BUILT_INS);
+    let lexer = CommentSkippingLexer::new(lexer);
+
+    let result: LalrpopListResult<'_> =
+        grammar::StatementListParser::new().parse(s, &mut state, lexer);
+
+    let ParserState {
+        locations, errors, ..
+    } = state;
+
+    let mut errors: Vec<_> = errors
+        .into_iter()
+        .map(|e| ParseError::from(e.error))
+        .collect();
+
+    match (result, errors.is_empty()) {
+        (Ok(_), false) => Err(ErrorData { errors, offsets }),
+        (Err(e), true) => {
+            let errors = vec![ParseError::from(e)];
+            Err(ErrorData { errors, offsets })
+        }
+        (Err(e), false) => {
+            errors.push(ParseError::from(e));
+            Err(ErrorData { errors, offsets })
+        }
+        (Ok(statements), true) => Ok(AstData {
+            statements,
             locations,
             offsets,
         }),
@@ -1083,6 +1129,65 @@ mod tests {
         fn insert_into_are_reserved_keywords() {
             assert!(parse_partiql(r"SELECT insert FROM t").is_err());
             assert!(parse_partiql(r"SELECT into FROM t").is_err());
+        }
+    }
+
+    mod statement_list {
+        use super::*;
+
+        fn statements(s: &str) -> usize {
+            super::super::parse_partiql_statements(s)
+                .unwrap_or_else(|e| panic!("{e:?}"))
+                .statements
+                .len()
+        }
+
+        #[test]
+        fn multiple_statements() {
+            assert_eq!(statements("CREATE TABLE a; SELECT b FROM a"), 2);
+        }
+
+        #[test]
+        fn trailing_semicolon_is_optional() {
+            assert_eq!(statements("CREATE TABLE a; SELECT b FROM a;"), 2);
+            assert_eq!(statements("CREATE TABLE a"), 1);
+            assert_eq!(statements("CREATE TABLE a;"), 1);
+        }
+
+        #[test]
+        fn empty_and_comment_only_yield_no_statements() {
+            assert_eq!(statements(""), 0);
+            assert_eq!(statements("   \n  "), 0);
+            assert_eq!(statements("-- just a comment\n"), 0);
+        }
+
+        #[test]
+        fn comments_between_statements_are_skipped() {
+            assert_eq!(statements("CREATE TABLE a; -- make a\nSELECT b FROM a"), 2);
+        }
+
+        // The single-statement `parse` entry still rejects `;`-separated input,
+        // so callers opt into multi-statement explicitly via `parse_statements`.
+        #[test]
+        fn single_statement_parse_still_rejects_multi() {
+            assert!(parse_partiql("CREATE TABLE a; SELECT b FROM a").is_err());
+        }
+
+        // A malformed statement anywhere in the list fails the whole parse.
+        #[test]
+        fn malformed_statement_in_list_errors() {
+            assert!(super::super::parse_partiql_statements("CREATE TABLE a; SELECT FROM").is_err());
+        }
+
+        // Empty statements are rejected (no `;;`, leading `;`, or lone `;`),
+        // unlike the prior string splitter which silently dropped empty chunks.
+        #[test]
+        fn empty_statements_are_rejected() {
+            assert!(
+                super::super::parse_partiql_statements("CREATE TABLE a;; SELECT b FROM a").is_err()
+            );
+            assert!(super::super::parse_partiql_statements("; CREATE TABLE a").is_err());
+            assert!(super::super::parse_partiql_statements(";").is_err());
         }
     }
 }

--- a/partiql-parser/src/parse/partiql.lalrpop
+++ b/partiql-parser/src/parse/partiql.lalrpop
@@ -38,6 +38,20 @@ pub(crate) Statement: ast::AstNode<ast::Statement> = {
         lo..hi),
 }
 
+// A `;`-separated sequence of statements with an optional trailing `;`, e.g.
+// `CREATE TABLE a; INSERT INTO a ...;`. Mirrors the `CommaTermStar` pattern but
+// with `Semicolon` as the terminator so scripts (bootstrap, multi-statement
+// input) can be parsed as a unit instead of split by hand.
+pub(crate) StatementList: Vec<ast::AstNode<ast::Statement>> = {
+    <mut v:(<Statement> ";")*> <e:Statement?> => match e {
+        None => v,
+        Some(e) => {
+            v.push(e);
+            v
+        }
+    }
+}
+
 TopLevelQuery: ast::AstNode<ast::TopLevelQuery> = {
     <lo:@L>
     <with:WithClause?>

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,6 +1,6 @@
 use partiql_tools::common;
 
-use common::{create_table_fn_catalog, lower_statement, parse};
+use common::{create_table_fn_catalog, lower_statement, parse, parse_statements};
 use partiql_common::catalog::CatalogId;
 use partiql_eval::plan::EvaluationMode;
 use partiql_eval::value::Shape;
@@ -126,26 +126,6 @@ fn normalize_query(input: &str) -> &str {
     trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end()
 }
 
-/// Split a trusted bootstrap script on `;`. Strips `--` line comments first so a
-/// `;` in a comment doesn't split. Only `--` comments are handled: no `/* */`,
-/// and no `;` inside string literals.
-fn split_script_statements(script: &str) -> Vec<String> {
-    let stripped: String = script
-        .lines()
-        .map(|line| match line.find("--") {
-            Some(i) => &line[..i],
-            None => line,
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    stripped
-        .split(';')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .collect()
-}
-
 /// Open the DB and bring it to CURRENT_SCHEMA_VERSION. Idempotent + crash-safe.
 fn open_and_bootstrap(path: &std::path::Path) -> Result<Arc<HeedDB>, Box<dyn std::error::Error>> {
     let db = Arc::new(HeedDB::open(path)?);
@@ -183,14 +163,24 @@ fn open_and_bootstrap(path: &std::path::Path) -> Result<Arc<HeedDB>, Box<dyn std
     Ok(db)
 }
 
-/// Run the v1 bootstrap script. Idempotent: a crash-recovery DB whose _tables
-/// already exists yields a typed StorageError::TableExists, reconciled against
-/// the self-entry; any other error propagates.
+/// Run the v1 bootstrap script. The `;`-separated script is parsed as a unit
+/// and each statement executed in order. Idempotent: a crash-recovery DB whose
+/// _tables already exists yields a typed StorageError::TableExists, reconciled
+/// against the self-entry; any other error propagates.
 fn bootstrap_v1(db: &Arc<HeedDB>) -> Result<(), Box<dyn std::error::Error>> {
     let script = include_str!("../bootstrap/v1.pql");
     let debug = DebugFlags::from_args(&[]);
-    for stmt in split_script_statements(script) {
-        match execute_query(&stmt, &debug, Some(Arc::clone(db)), OutputMode::Silent) {
+    let parsed = parse_statements(script).map_err(|e| format!("Parse error: {:?}", e))?;
+    for stmt in &parsed.statements {
+        // parse_time is a bootstrap step, not user-facing; Silent mode prints no
+        // timing footer, so a zero placeholder is never observed.
+        match execute_statement(
+            stmt,
+            &debug,
+            Some(Arc::clone(db)),
+            OutputMode::Silent,
+            std::time::Duration::ZERO,
+        ) {
             Ok(()) => {}
             Err(e) => {
                 let is_self_tables_exists = e
@@ -594,8 +584,6 @@ fn execute_query(
     db: Option<Arc<HeedDB>>,
     mode: OutputMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let catalog = create_table_fn_catalog();
-
     let parse_start = Instant::now();
     let parsed = parse(query_str).map_err(|e| format!("Parse error: {:?}", e))?;
     let parse_time = parse_start.elapsed();
@@ -604,12 +592,28 @@ fn execute_query(
         eprintln!("[AST] {:?}", parsed);
     }
 
-    // Lowering operates on a single statement.
+    // `exec` and the REPL run one statement at a time; a `;`-separated script is
+    // parsed with `parse_statements` and each statement run via `execute_statement`
+    // in a loop (see `bootstrap_v1`).
     let stmt = match parsed.statements.as_slice() {
         [stmt] => stmt,
         // Wording matches `LogicalPlanner::lower` for parity across error sites.
         _ => return Err("Lower error: multi-statement input".into()),
     };
+    execute_statement(stmt, debug, db, mode, parse_time)
+}
+
+/// Execute a single already-parsed statement. Split from [`execute_query`] so a
+/// parsed script can dispatch each statement in a loop without re-parsing.
+fn execute_statement(
+    stmt: &partiql_ast::ast::AstNode<partiql_ast::ast::Statement>,
+    debug: &DebugFlags,
+    db: Option<Arc<HeedDB>>,
+    mode: OutputMode,
+    parse_time: std::time::Duration,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let catalog = create_table_fn_catalog();
+
     let lower_start = Instant::now();
     let statement =
         lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -21,6 +21,16 @@ use reedline::{
 
 const HISTORY_CAPACITY: usize = 1000;
 
+/// The schema version this binary bootstraps to and requires.
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Whether `execute_query` prints. Bootstrap runs muted.
+#[derive(Clone, Copy)]
+enum OutputMode {
+    User,
+    Silent,
+}
+
 /// Crate version joined with the git commit SHA captured in build.rs.
 const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "@", env!("PQLITE_GIT_SHA"));
 
@@ -82,8 +92,8 @@ fn main() {
                 std::process::exit(1);
             }
             let db = match cli.db.as_deref() {
-                Some(p) => match HeedDB::open(p) {
-                    Ok(db) => Some(Arc::new(db)),
+                Some(p) => match open_and_bootstrap(p) {
+                    Ok(db) => Some(db),
                     Err(e) => {
                         eprintln!("Error: could not open database at {}: {}", p.display(), e);
                         std::process::exit(1);
@@ -91,7 +101,7 @@ fn main() {
                 },
                 None => None,
             };
-            if let Err(e) = execute_query(query, &debug, db) {
+            if let Err(e) = execute_query(query, &debug, db, OutputMode::User) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
@@ -114,6 +124,89 @@ fn main() {
 fn normalize_query(input: &str) -> &str {
     let trimmed = input.trim();
     trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end()
+}
+
+/// Split a trusted bootstrap script on `;`. Strips `--` line comments first so a
+/// `;` in a comment doesn't split. Only `--` comments are handled: no `/* */`,
+/// and no `;` inside string literals.
+fn split_script_statements(script: &str) -> Vec<String> {
+    let stripped: String = script
+        .lines()
+        .map(|line| match line.find("--") {
+            Some(i) => &line[..i],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    stripped
+        .split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Open the DB and bring it to CURRENT_SCHEMA_VERSION. Idempotent + crash-safe.
+fn open_and_bootstrap(path: &std::path::Path) -> Result<Arc<HeedDB>, Box<dyn std::error::Error>> {
+    let db = Arc::new(HeedDB::open(path)?);
+    let version = db.read_schema_version()?;
+    if version > CURRENT_SCHEMA_VERSION {
+        return Err(format!(
+            "database schema version {version} is newer than this binary \
+             supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
+        )
+        .into());
+    }
+    // A stamped current version must satisfy its postcondition (one extra
+    // catalog lookup at startup — a deliberate integrity check).
+    if version == CURRENT_SCHEMA_VERSION && !db.tables_has_self_entry()? {
+        return Err("database reports schema version 1 but the _tables catalog \
+                    is missing or incomplete"
+            .into());
+    }
+    // Migration ladder: each future migration is its own `version < N` block
+    // that stamps N, so an older DB runs every step in order. Bumping
+    // CURRENT_SCHEMA_VERSION alone is not enough — add a block.
+    if version < 1 {
+        bootstrap_v1(&db)?;
+        let stamped = db.set_schema_version(1)?;
+        // Guards a concurrent writer that stamped a newer version between our
+        // read above and this stamp; monotonic set returns that higher version.
+        if stamped > CURRENT_SCHEMA_VERSION {
+            return Err(format!(
+                "database schema version {stamped} is newer than this binary \
+                 supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
+            )
+            .into());
+        }
+    }
+    Ok(db)
+}
+
+/// Run the v1 bootstrap script. Idempotent: a crash-recovery DB whose _tables
+/// already exists yields a typed StorageError::TableExists, reconciled against
+/// the self-entry; any other error propagates.
+fn bootstrap_v1(db: &Arc<HeedDB>) -> Result<(), Box<dyn std::error::Error>> {
+    let script = include_str!("../bootstrap/v1.pql");
+    let debug = DebugFlags::from_args(&[]);
+    for stmt in split_script_statements(script) {
+        match execute_query(&stmt, &debug, Some(Arc::clone(db)), OutputMode::Silent) {
+            Ok(()) => {}
+            Err(e) => {
+                let is_self_tables_exists = e
+                    .downcast_ref::<StorageError>()
+                    .map(|se| matches!(se, StorageError::TableExists(n) if n == "_tables"))
+                    .unwrap_or(false);
+                // Crash-recovery: _tables already created on a prior run. Skip and
+                // continue; any other error is real and aborts bootstrap.
+                if is_self_tables_exists && db.tables_has_self_entry()? {
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
 }
 
 struct PqlitePrompt;
@@ -238,8 +331,8 @@ fn print_startup_banner(db_path: &std::path::Path) {
 fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
     // Hard-fail rather than fall back to in-memory: a silently non-persisting
     // db is worse than refusing to start.
-    let db = match HeedDB::open(db_path) {
-        Ok(db) => Arc::new(db),
+    let db = match open_and_bootstrap(db_path) {
+        Ok(db) => db,
         Err(e) => {
             eprintln!(
                 "Error: could not open database at {}: {}",
@@ -279,7 +372,8 @@ fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
                     continue;
                 }
 
-                if let Err(e) = execute_query(query, debug, Some(Arc::clone(&db))) {
+                if let Err(e) = execute_query(query, debug, Some(Arc::clone(&db)), OutputMode::User)
+                {
                     eprintln!("{}", e);
                 }
             }
@@ -319,11 +413,8 @@ fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
     }
 }
 
-fn print_ddl_planned_footer(elapsed: std::time::Duration) {
-    eprintln!(
-        "(planned in {:.1}ms — execution not yet implemented)",
-        elapsed.as_secs_f64() * 1000.0
-    );
+fn print_ddl_executed_footer(elapsed: std::time::Duration) {
+    eprintln!("(took {:.1}ms)", elapsed.as_secs_f64() * 1000.0);
 }
 
 /// Per-stage timing footer for the write statements (CTAS / INSERT).
@@ -501,6 +592,7 @@ fn execute_query(
     query_str: &str,
     debug: &DebugFlags,
     db: Option<Arc<HeedDB>>,
+    mode: OutputMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let catalog = create_table_fn_catalog();
 
@@ -534,10 +626,18 @@ fn execute_query(
                 .as_ref()
                 .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?;
 
+            // Encode the catalog value before draining so a deterministic
+            // encode error fails fast, ahead of any query execution.
+            let mut tables_value = Vec::new();
+            partiql_tools::row_codec::serialize_name_row(&[&key], &mut tables_value)
+                .map_err(|e| format!("Error: {}", e))?;
+
             let (rows, compile_time, exec_start) = drain_source_rows(&query, debug, db)?;
 
             let n = {
-                let mut writer = db.create_table(&key).map_err(|e| format!("Error: {}", e))?;
+                let mut writer = db
+                    .create_table(&key, &tables_value)
+                    .map_err(|e| format!("Error: {}", e))?;
                 for encoded in &rows {
                     writer
                         .push_row(encoded)
@@ -547,16 +647,22 @@ fn execute_query(
             };
             let exec_time = exec_start.elapsed();
 
-            eprintln!(
-                "Created table {} ({} rows)",
-                format_table_name(&table_name),
-                n
-            );
-            print_write_footer(parse_time, lower_time, compile_time, exec_time);
+            if matches!(mode, OutputMode::User) {
+                eprintln!(
+                    "Created table {} ({} rows)",
+                    format_table_name(&table_name),
+                    n
+                );
+                print_write_footer(parse_time, lower_time, compile_time, exec_time);
+            }
             return Ok(());
         }
         LogicalStatement::InsertInto { table_name, query } => {
             let key = canonical_table_key(&table_name);
+
+            if partiql_tools::storage::is_system_table(&key) {
+                return Err("Error: cannot INSERT into system table '_tables'".into());
+            }
 
             // Resolve --db before compile + VM setup so a missing flag fails
             // cleanly before any expensive work.
@@ -583,20 +689,35 @@ fn execute_query(
             }
             let exec_time = exec_start.elapsed();
 
-            eprintln!(
-                "Inserted {} rows into {}",
-                inserted,
-                format_table_name(&table_name)
-            );
-            print_write_footer(parse_time, lower_time, compile_time, exec_time);
+            if matches!(mode, OutputMode::User) {
+                eprintln!(
+                    "Inserted {} rows into {}",
+                    inserted,
+                    format_table_name(&table_name)
+                );
+                print_write_footer(parse_time, lower_time, compile_time, exec_time);
+            }
             return Ok(());
         }
         LogicalStatement::CreateTable { table_name } => {
-            println!(
-                "Planned CREATE TABLE {} (no source query)",
-                format_table_name(&table_name)
-            );
-            print_ddl_planned_footer(parse_time + lower_time);
+            let key = canonical_table_key(&table_name);
+            let db = db
+                .as_ref()
+                .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE.")?;
+
+            // Bare `?` (not `.map_err(format!)`) so the typed StorageError /
+            // SerializeError boxes intact — the startup bootstrap downcasts to
+            // StorageError::TableExists to reconcile a crash-recovery re-run.
+            let mut tables_value = Vec::new();
+            partiql_tools::row_codec::serialize_name_row(&[&key], &mut tables_value)?;
+            let exec_start = Instant::now();
+            db.create_table(&key, &tables_value)?.commit()?;
+            let exec_time = exec_start.elapsed();
+
+            if matches!(mode, OutputMode::User) {
+                eprintln!("Created table {}", format_table_name(&table_name));
+                print_ddl_executed_footer(parse_time + lower_time + exec_time);
+            }
             return Ok(());
         }
     };
@@ -619,33 +740,40 @@ fn execute_query(
         Shape::Single(_) => (None, "", None),
     };
 
+    let user_output = matches!(mode, OutputMode::User);
     let mut is_first = true;
     match vm.execute() {
         Ok(partiql_eval::ExecutionResult::Query(iter)) => {
-            if let Some(p) = prefix {
-                println!("{}", p);
+            if user_output {
+                if let Some(p) = prefix {
+                    println!("{}", p);
+                }
             }
             for row_result in iter {
                 match row_result {
                     Ok(row) => {
                         row_count += 1;
-                        if is_first {
-                            is_first = false;
-                        } else {
-                            println!(",");
+                        if user_output {
+                            if is_first {
+                                is_first = false;
+                            } else {
+                                println!(",");
+                            }
+                            let value = row_to_value(&row, &shape);
+                            print!("{}", tab);
+                            print!("{:?}", value);
                         }
-                        let value = row_to_value(&row, &shape);
-                        print!("{}", tab);
-                        print!("{:?}", value);
                     }
                     Err(e) => {
                         return Err(format!("Execution error: {:?}", e).into());
                     }
                 }
             }
-            println!();
-            if let Some(s) = suffix {
-                println!("{}", s);
+            if user_output {
+                println!();
+                if let Some(s) = suffix {
+                    println!("{}", s);
+                }
             }
         }
         Err(e) => {
@@ -654,16 +782,18 @@ fn execute_query(
     }
     let exec_time = exec_start.elapsed();
 
-    let total_time = parse_time + lower_time + compile_time + exec_time;
-    eprintln!(
-        "({} rows in {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-        row_count,
-        total_time.as_secs_f64() * 1000.0,
-        parse_time.as_secs_f64() * 1000.0,
-        lower_time.as_secs_f64() * 1000.0,
-        compile_time.as_secs_f64() * 1000.0,
-        exec_time.as_secs_f64() * 1000.0,
-    );
+    if user_output {
+        let total_time = parse_time + lower_time + compile_time + exec_time;
+        eprintln!(
+            "({} rows in {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
+            row_count,
+            total_time.as_secs_f64() * 1000.0,
+            parse_time.as_secs_f64() * 1000.0,
+            lower_time.as_secs_f64() * 1000.0,
+            compile_time.as_secs_f64() * 1000.0,
+            exec_time.as_secs_f64() * 1000.0,
+        );
+    }
 
     Ok(())
 }

--- a/partiql-tools/src/bootstrap/v1.pql
+++ b/partiql-tools/src/bootstrap/v1.pql
@@ -1,0 +1,5 @@
+-- pqlite bootstrap v1
+-- Executed once on first startup (schema_version < 1). Registers the _tables
+-- system catalog as a queryable table. Statements are separated by `;`; `--`
+-- line comments are ignored (including any `;` within them).
+CREATE TABLE _tables;

--- a/partiql-tools/src/catalog.rs
+++ b/partiql-tools/src/catalog.rs
@@ -10,9 +10,10 @@ use partiql_eval::source::{
 };
 use partiql_eval::{CompilationCatalog, EngineError, ExecutionCatalog};
 use partiql_value::BindingsName;
+use smallvec::SmallVec;
 
 use crate::row_codec::{deserialize_row_into, DeserializeError};
-use crate::storage::{HeedDB, StorageError};
+use crate::storage::{is_system_table, HeedDB, StorageError};
 
 type EvalResult<T> = std::result::Result<T, EngineError>;
 
@@ -172,12 +173,12 @@ fn hash_to_entry_id(name: &str) -> EntryId {
 pub(crate) struct HeedTableSource {
     db: Arc<HeedDB>,
     table: String,
-    bytes: Vec<u8>,                     // current chunk's packed rows
-    offsets: Vec<std::ops::Range<u32>>, // per-row slices into `bytes`
-    pos: usize,                         // next row within the chunk
-    resume_after: Option<[u8; 8]>,      // next chunk ranges strictly after this key
-    exhausted: bool,                    // last chunk was short: no more rows
-    rows_emitted: u64,                  // total so far, for decode-error messages
+    bytes: Vec<u8>,                          // current chunk's packed rows
+    offsets: Vec<std::ops::Range<u32>>,      // per-row slices into `bytes`
+    pos: usize,                              // next row within the chunk
+    resume_after: Option<SmallVec<[u8; 8]>>, // opaque keyset cursor; heap-free for u64 keys
+    exhausted: bool,                         // last chunk was short: no more rows
+    rows_emitted: u64,                       // total so far, for decode-error messages
 }
 
 impl DataSource for HeedTableSource {
@@ -232,6 +233,8 @@ impl HeedTableSource {
     /// future DELETEs never cause skipped or double-read rows.
     fn load_next_chunk(&mut self) -> Result<(), StorageError> {
         let rtxn = self.db.read_txn()?;
+        // Per-chunk _tables membership re-open is interim cost; a cached catalog
+        // handle is deferred to the streaming/handle work.
         let tbl = self.db.open_table(&rtxn, &self.table)?;
 
         self.bytes.clear();
@@ -248,11 +251,22 @@ impl HeedTableSource {
             None => (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded),
         };
 
+        // Loop-invariant (table name is fixed for the whole scan), hoisted out.
+        let key_len_checked = !is_system_table(&self.table);
         let mut count = 0usize;
         let mut prev_end: u32 = 0;
-        let mut last_key: Option<[u8; 8]> = None;
+        let mut last_key: SmallVec<[u8; 8]> = SmallVec::new(); // reused; inline for u64 keys
         for result in tbl.range(&rtxn, &range).map_err(StorageError::Heed)? {
             let (k, v) = result.map_err(StorageError::Heed)?;
+            // Corruption canary: user tables MUST use 8-byte BE-u64 keys. System
+            // tables (_tables) are string-keyed by design, so they opt out.
+            if key_len_checked && k.len() != 8 {
+                return Err(StorageError::Codec(format!(
+                    "table {}: row key is {} bytes, expected 8 (BE u64)",
+                    self.table,
+                    k.len()
+                )));
+            }
             self.bytes.extend_from_slice(v);
             let end = u32::try_from(self.bytes.len()).map_err(|_| StorageError::ScanTooLarge {
                 table: self.table.clone(),
@@ -260,15 +274,8 @@ impl HeedTableSource {
             })?;
             self.offsets.push(prev_end..end);
             prev_end = end;
-            // Stack-copy the key (no per-row alloc). A non-8-byte key means the
-            // row-id scheme changed; fail loudly rather than truncate the cursor.
-            last_key = Some(<[u8; 8]>::try_from(k).map_err(|_| {
-                StorageError::Codec(format!(
-                    "table {}: row key is {} bytes, expected 8 (BE u64)",
-                    self.table,
-                    k.len()
-                ))
-            })?);
+            last_key.clear();
+            last_key.extend_from_slice(k);
             count += 1;
             if count == CHUNK_ROWS {
                 break;
@@ -277,8 +284,8 @@ impl HeedTableSource {
         // txn drops at end of scope; the packed buffer is owned and outlives it.
         drop(rtxn);
 
-        if let Some(k) = last_key {
-            self.resume_after = Some(k);
+        if count > 0 {
+            self.resume_after = Some(last_key);
         }
         // A short chunk means the range is drained — no further chunks.
         if count < CHUNK_ROWS {
@@ -291,6 +298,23 @@ impl HeedTableSource {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tables_value(name: &str) -> Vec<u8> {
+        let mut v = Vec::new();
+        crate::row_codec::serialize_name_row(&[name], &mut v).unwrap();
+        v
+    }
+
+    /// Open a DB and bootstrap `_tables` so user-table creates can proceed
+    /// (`create_table` now requires the catalog to exist first).
+    fn open_bootstrapped(path: &std::path::Path) -> Arc<HeedDB> {
+        let db = Arc::new(HeedDB::open(path).unwrap());
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        db
+    }
 
     #[test]
     fn metadata_resolve_returns_none() {
@@ -331,9 +355,9 @@ mod tests {
     fn streaming_single_chunk_reads_all_rows_when_under_chunk_size() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("single.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
+        let db = open_bootstrapped(&path);
 
-        let mut w = db.create_table("t").unwrap();
+        let mut w = db.create_table("t", &tables_value("t")).unwrap();
         w.push_row(&[0xAA, 0xBB]).unwrap();
         w.push_row(&[0xCC]).unwrap();
         w.push_row(&[0xDD, 0xEE, 0xFF]).unwrap();
@@ -352,11 +376,11 @@ mod tests {
     fn streaming_spans_multiple_chunks() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("multi.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
+        let db = open_bootstrapped(&path);
 
         // Distinct byte per row so the asserts can catch any overlap or gap.
         let total = CHUNK_ROWS + 5;
-        let mut w = db.create_table("t").unwrap();
+        let mut w = db.create_table("t", &tables_value("t")).unwrap();
         for i in 0..total {
             w.push_row(&[i as u8]).unwrap();
         }
@@ -368,8 +392,8 @@ mod tests {
         assert_eq!(src.offsets.len(), CHUNK_ROWS);
         assert!(!src.exhausted);
         assert_eq!(
-            src.resume_after,
-            Some((CHUNK_ROWS as u64 - 1).to_be_bytes())
+            src.resume_after.as_deref(),
+            Some(&(CHUNK_ROWS as u64 - 1).to_be_bytes()[..])
         );
         let chunk1: Vec<u8> = src.bytes.clone();
         assert_eq!(chunk1, (0..CHUNK_ROWS as u8).collect::<Vec<u8>>());
@@ -393,8 +417,11 @@ mod tests {
     fn streaming_empty_table() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
-        db.create_table("t").unwrap().commit().unwrap();
+        let db = open_bootstrapped(&path);
+        db.create_table("t", &tables_value("t"))
+            .unwrap()
+            .commit()
+            .unwrap();
 
         let mut src = source_for(&db, "t");
         src.load_next_chunk().unwrap();
@@ -408,8 +435,11 @@ mod tests {
     fn streaming_reads_sparse_keys_within_one_chunk() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sparse.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
-        db.create_table("t").unwrap().commit().unwrap();
+        let db = open_bootstrapped(&path);
+        db.create_table("t", &tables_value("t"))
+            .unwrap()
+            .commit()
+            .unwrap();
 
         // inject bypasses the encoder to make the gapped keys a DELETE would leave.
         let keys = [0u64, 1, 2, 100, 101, 200];
@@ -423,15 +453,18 @@ mod tests {
         assert_eq!(src.offsets.len(), 6);
         assert!(src.exhausted);
         assert_eq!(src.bytes, (0u8..6).collect::<Vec<u8>>());
-        assert_eq!(src.resume_after, Some(200u64.to_be_bytes()));
+        assert_eq!(src.resume_after.as_deref(), Some(&200u64.to_be_bytes()[..]));
     }
 
     #[test]
     fn streaming_keyset_resume_survives_gaps() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("gaps.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
-        db.create_table("t").unwrap().commit().unwrap();
+        let db = open_bootstrapped(&path);
+        db.create_table("t", &tables_value("t"))
+            .unwrap()
+            .commit()
+            .unwrap();
 
         // Dense keys 0..64 (payload = low byte, so key 63 = 0x3F), a gap, then
         // keys 1000.. (payload 0xF0..) — distinct so chunk 2's first row is identifiable.
@@ -448,8 +481,8 @@ mod tests {
         assert_eq!(src.offsets.len(), CHUNK_ROWS);
         assert!(!src.exhausted);
         assert_eq!(
-            src.resume_after,
-            Some((CHUNK_ROWS as u64 - 1).to_be_bytes())
+            src.resume_after.as_deref(),
+            Some(&(CHUNK_ROWS as u64 - 1).to_be_bytes()[..])
         );
 
         src.load_next_chunk().unwrap();
@@ -461,15 +494,87 @@ mod tests {
             &[0xF0],
             "chunk 2 resumes at key 1000, not a re-read of 63"
         );
-        assert_eq!(src.resume_after, Some(1005u64.to_be_bytes()));
+        assert_eq!(
+            src.resume_after.as_deref(),
+            Some(&1005u64.to_be_bytes()[..])
+        );
+    }
+
+    #[test]
+    fn streaming_tolerates_string_keys_for_system_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(HeedDB::open(&dir.path().join("systbl.pqlite")).unwrap());
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        let mut src = source_for(&db, "_tables");
+        src.load_next_chunk().unwrap(); // must NOT fire the 8-byte canary
+        assert_eq!(src.offsets.len(), 1);
+        assert_eq!(src.resume_after.as_deref(), Some(&b"_tables"[..]));
+        assert!(src.exhausted);
+    }
+
+    #[test]
+    fn streaming_string_keys_resume_across_chunk_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(HeedDB::open(&dir.path().join("bigcat.pqlite")).unwrap());
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        for i in 0..70u32 {
+            let name = format!("tbl_{i:03}");
+            db.create_table(&name, &tables_value(&name))
+                .unwrap()
+                .commit()
+                .unwrap();
+        }
+        let mut src = source_for(&db, "_tables");
+        src.load_next_chunk().unwrap();
+        assert_eq!(src.offsets.len(), CHUNK_ROWS, "first chunk full");
+        assert!(!src.exhausted);
+        let first_resume = src.resume_after.clone();
+        src.load_next_chunk().unwrap();
+        assert!(src.exhausted, "second chunk drains the rest");
+        assert_ne!(
+            src.resume_after, first_resume,
+            "cursor advanced past chunk 1"
+        );
+        assert_eq!(src.offsets.len(), 7); // 71 total (_tables + tbl_000..069) = 64 + 7
+    }
+
+    #[test]
+    fn streaming_still_rejects_non_8_byte_keys_for_user_tables() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_bootstrapped(&dir.path().join("baduser.pqlite"));
+        db.create_table("t", &tables_value("t"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        {
+            let mut wtxn = db.env().write_txn().unwrap();
+            let tbl: heed::Database<heed::types::Bytes, heed::types::Bytes> =
+                db.env().open_database(&wtxn, Some("t")).unwrap().unwrap();
+            tbl.put(&mut wtxn, b"abc", &[0x00]).unwrap(); // 3-byte key in a USER table
+            wtxn.commit().unwrap();
+        }
+        let mut src = source_for(&db, "t");
+        let err = src.load_next_chunk().unwrap_err();
+        assert!(
+            matches!(err, StorageError::Codec(ref m) if m.contains("expected 8")),
+            "user-table non-8-byte key must fail the canary; got {err:?}"
+        );
     }
 
     #[test]
     fn compilation_catalog_returns_handle_for_existing_table() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("cat.pqlite");
-        let db = Arc::new(HeedDB::open(&path).unwrap());
-        let mut w = db.create_table("widgets").unwrap();
+        let db = open_bootstrapped(&path);
+        let mut w = db
+            .create_table("widgets", &tables_value("widgets"))
+            .unwrap();
         // TAG_NULL: a complete single-byte NULL row (NULL has no payload);
         // only used to confirm catalog plumbing.
         w.push_row(&[crate::row_codec::TAG_NULL]).unwrap();

--- a/partiql-tools/src/common.rs
+++ b/partiql-tools/src/common.rs
@@ -50,6 +50,11 @@ pub fn parse(statement: &str) -> Result<Parsed<'_>, ParserError<'_>> {
     Parser::default().parse(statement)
 }
 
+/// Parse a `;`-separated PartiQL script into its individual statements.
+pub fn parse_statements(script: &str) -> Result<Parsed<'_>, ParserError<'_>> {
+    Parser::default().parse_statements(script)
+}
+
 /// Lower AST to logical plan
 pub fn lower(
     catalog: &dyn SharedCatalog,

--- a/partiql-tools/src/row_codec.rs
+++ b/partiql-tools/src/row_codec.rs
@@ -89,6 +89,41 @@ pub fn serialize_row(
     }
 }
 
+/// Encode a `_tables` catalog row: `{ name: [<elements>] }`, where `name` is a
+/// PartiQL list of the (unescaped) path elements. Single-element today
+/// (`["foo"]`); multi-element paths are the forward-compatible shape. `buf` is
+/// cleared on entry. Hand-mirrors the wire format — no VM `RegisterReader` needed.
+pub fn serialize_name_row(elements: &[&str], buf: &mut Vec<u8>) -> Result<(), SerializeError> {
+    buf.clear();
+    if elements.len() > MAX_CONTAINER_ELEMENTS as usize {
+        return Err(SerializeError::Unsupported(format!(
+            "name path has {} elements, exceeds MAX_CONTAINER_ELEMENTS ({})",
+            elements.len(),
+            MAX_CONTAINER_ELEMENTS
+        )));
+    }
+    buf.push(TAG_TUPLE);
+    buf.extend_from_slice(&1u32.to_le_bytes()); // field_count = 1
+    buf.extend_from_slice(&4u32.to_le_bytes()); // name_len = 4
+    buf.extend_from_slice(b"name");
+    buf.push(TAG_LIST);
+    buf.extend_from_slice(&(elements.len() as u32).to_le_bytes());
+    for (i, el) in elements.iter().enumerate() {
+        let bytes = el.as_bytes();
+        if bytes.len() > MAX_STRING_LEN as usize {
+            return Err(SerializeError::Unsupported(format!(
+                "name element {i}: length {} exceeds MAX_STRING_LEN ({})",
+                bytes.len(),
+                MAX_STRING_LEN
+            )));
+        }
+        buf.push(TAG_STRING);
+        buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        buf.extend_from_slice(bytes);
+    }
+    Ok(())
+}
+
 fn write_value_at_root(
     row: &RegisterReader<'_>,
     slot: usize,
@@ -855,5 +890,56 @@ mod deserialize_tests {
             format!("{}", DeserializeError::Unsupported("x".to_string())),
             "unsupported: x"
         );
+    }
+}
+
+#[cfg(test)]
+mod name_row_tests {
+    use super::*;
+
+    #[test]
+    fn serialize_name_row_single_element_exact_bytes() {
+        let mut buf = Vec::new();
+        serialize_name_row(&["foo"], &mut buf).unwrap();
+        let expected: Vec<u8> = vec![
+            TAG_TUPLE, 0x01, 0x00, 0x00, 0x00, // field_count = 1
+            0x04, 0x00, 0x00, 0x00, // name_len = 4
+            b'n', b'a', b'm', b'e', TAG_LIST, 0x01, 0x00, 0x00, 0x00, // element_count = 1
+            TAG_STRING, 0x03, 0x00, 0x00, 0x00, // str_len = 3
+            b'f', b'o', b'o',
+        ];
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn serialize_name_row_multi_element_forward_compat() {
+        let mut buf = Vec::new();
+        serialize_name_row(&["a", "bb"], &mut buf).unwrap();
+        let expected: Vec<u8> = vec![
+            TAG_TUPLE, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, b'n', b'a', b'm', b'e',
+            TAG_LIST, 0x02, 0x00, 0x00, 0x00, TAG_STRING, 0x01, 0x00, 0x00, 0x00, b'a', TAG_STRING,
+            0x02, 0x00, 0x00, 0x00, b'b', b'b',
+        ];
+        assert_eq!(buf, expected);
+    }
+
+    #[test]
+    fn serialize_name_row_clears_buf_on_entry() {
+        let mut buf = vec![0xFF, 0xFF];
+        serialize_name_row(&["x"], &mut buf).unwrap();
+        assert_eq!(buf[0], TAG_TUPLE, "buf must be cleared before writing");
+    }
+
+    #[test]
+    fn serialize_name_row_empty_elements_is_empty_list() {
+        let mut buf = Vec::new();
+        serialize_name_row(&[], &mut buf).unwrap();
+        // { name: [] } — TAG_TUPLE, field_count=1, name_len=4, "name", TAG_LIST, count=0.
+        let expected: Vec<u8> = vec![
+            TAG_TUPLE, 0x01, 0x00, 0x00, 0x00, // field_count = 1
+            0x04, 0x00, 0x00, 0x00, // name_len = 4
+            b'n', b'a', b'm', b'e', TAG_LIST, 0x00, 0x00, 0x00, 0x00, // element_count = 0
+        ];
+        assert_eq!(buf, expected);
     }
 }

--- a/partiql-tools/src/storage.rs
+++ b/partiql-tools/src/storage.rs
@@ -8,7 +8,17 @@ const DEFAULT_MAP_SIZE: usize = 1024 * 1024 * 1024; // 1 GiB
 /// One catalog plus headroom for one named db per user table.
 const MAX_DBS: u32 = 128;
 
-const TABLES_DB: &str = "_tables";
+pub(crate) const TABLES_DB: &str = "_tables";
+
+/// NUL-prefixed so a user table (names can't contain NUL) can't collide.
+const SCHEMA_VERSION_KEY: &str = "\0schema_version";
+
+/// True for exact system-table names (currently just `_tables`). `pub` because
+/// the binary is a separate crate target and needs it for the INSERT guard —
+/// the single definition of "system name" that every guard checks against.
+pub fn is_system_table(name: &str) -> bool {
+    name == TABLES_DB
+}
 
 type TablesDb = heed::Database<heed::types::Str, heed::types::Bytes>;
 
@@ -58,8 +68,7 @@ pub enum StorageError {
     Io(std::io::Error),
     Heed(heed::Error),
     TableExists(String),
-    /// `_`-prefixed name; the namespace is reserved.
-    ReservedName(String),
+    SystemTableReadOnly(String),
     /// Interior NUL byte (heed would otherwise panic).
     InvalidName(String),
     TableMissing(String),
@@ -86,10 +95,9 @@ impl std::fmt::Display for StorageError {
             StorageError::Io(e) => write!(f, "storage I/O error: {e}"),
             StorageError::Heed(e) => write!(f, "storage engine error: {e}"),
             StorageError::TableExists(name) => write!(f, "table already exists: {name}"),
-            StorageError::ReservedName(name) => write!(
-                f,
-                "reserved table name '{name}' (names starting with '_' are for system use)"
-            ),
+            StorageError::SystemTableReadOnly(name) => {
+                write!(f, "cannot modify system table '{name}'")
+            }
             StorageError::InvalidName(name) => {
                 write!(f, "invalid table name {name:?}: contains a NUL byte")
             }
@@ -117,7 +125,7 @@ impl std::error::Error for StorageError {
             StorageError::Io(e) => Some(e),
             StorageError::Heed(e) => Some(e),
             StorageError::TableExists(_)
-            | StorageError::ReservedName(_)
+            | StorageError::SystemTableReadOnly(_)
             | StorageError::InvalidName(_)
             | StorageError::TableMissing(_)
             | StorageError::Execution(_)
@@ -152,18 +160,21 @@ fn normalize_db_path(path: &Path) -> PathBuf {
     }
 }
 
-/// The `_tables` catalog handle is valid only while the env is alive, so
-/// both live together.
+/// The named-database handles are valid only while the env is alive, so they
+/// live together with it.
 #[derive(Debug)]
 pub struct HeedDB {
     env: heed::Env,
-    tables: TablesDb,
+    /// Unnamed LMDB db holding raw schema-version bytes (NUL-prefixed key).
+    default_db: heed::Database<heed::types::Str, heed::types::Bytes>,
     path: PathBuf,
 }
 
 impl HeedDB {
-    /// Open (or create) the LMDB environment at `path` as a single file, and
-    /// open/create the `_tables` system catalog inside it.
+    /// Open (or create) the LMDB environment at `path` as a single file. The
+    /// `_tables` system catalog is NOT created here — it is materialized by the
+    /// startup bootstrap running `CREATE TABLE _tables` through the query
+    /// pipeline, and opened on demand thereafter.
     pub fn open(path: &Path) -> Result<HeedDB, StorageError> {
         let normalized = normalize_db_path(path);
 
@@ -180,22 +191,25 @@ impl HeedDB {
 
         let mut wtxn = env.write_txn()?;
         // `create_database` is idempotent.
-        let tables: TablesDb = env.create_database(&mut wtxn, Some(TABLES_DB))?;
+        let default_db = env.create_database(&mut wtxn, None)?;
         wtxn.commit()?;
 
         Ok(HeedDB {
             env,
-            tables,
+            default_db,
             path: path.to_path_buf(),
         })
     }
 
-    /// Reject names the storage layer refuses: `_`-prefixed (reserved for the
-    /// system catalog) and interior NUL (would panic heed's key encoding).
+    /// Open `_tables` for reading if it exists yet. `None` on a fresh DB whose
+    /// catalog the bootstrap has not created.
+    fn tables_ro(&self, txn: &heed::RoTxn<'_>) -> Result<Option<TablesDb>, StorageError> {
+        Ok(self.env.open_database(txn, Some(TABLES_DB))?)
+    }
+
+    /// Reject names the storage layer refuses: interior NUL (would panic heed's
+    /// key encoding).
     fn guard_name(name: &str) -> Result<(), StorageError> {
-        if name.starts_with('_') {
-            return Err(StorageError::ReservedName(name.to_string()));
-        }
         if name.contains('\0') {
             return Err(StorageError::InvalidName(name.to_string()));
         }
@@ -204,16 +218,28 @@ impl HeedDB {
 
     /// Open a write handle for a new table. `name` must already be
     /// canonicalized by the caller (lowercase for bare identifiers, verbatim
-    /// for quoted).
-    pub fn create_table(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
+    /// for quoted). `tables_value` is the caller-encoded catalog row stored in
+    /// `_tables` under `name` — storage stays codec-free and writes opaque bytes.
+    pub fn create_table(
+        &self,
+        name: &str,
+        tables_value: &[u8],
+    ) -> Result<TableWriter<'_>, StorageError> {
         Self::guard_name(name)?;
         let mut wtxn = self.env.write_txn()?;
-        if self.tables.get(&wtxn, name)?.is_some() {
+        // Create the target DB FIRST. For the bootstrap call `name == "_tables"`
+        // this brings the catalog into existence (self-referential, no special-
+        // casing). When txn ownership moves to the app layer for streaming, this
+        // registration relocates to the binary.
+        let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
+        let tables = self
+            .env
+            .open_database::<heed::types::Str, heed::types::Bytes>(&wtxn, Some(TABLES_DB))?
+            .ok_or_else(|| StorageError::TableMissing(TABLES_DB.to_string()))?;
+        if tables.get(&wtxn, name)?.is_some() {
             return Err(StorageError::TableExists(name.to_string()));
         }
-        let table: RowDb = self.env.create_database(&mut wtxn, Some(name))?;
-        // Catalog cell records existence only.
-        self.tables.put(&mut wtxn, name, &[])?;
+        tables.put(&mut wtxn, name, tables_value)?;
         Ok(TableWriter {
             wtxn,
             table,
@@ -227,11 +253,20 @@ impl HeedDB {
     /// rows get fresh keys after the max.
     pub fn open_table_for_append(&self, name: &str) -> Result<TableWriter<'_>, StorageError> {
         Self::guard_name(name)?;
+        if is_system_table(name) {
+            return Err(StorageError::SystemTableReadOnly(name.to_string()));
+        }
         let wtxn = self.env.write_txn()?;
         // Catalog membership defines existence for reads (see `open_table`), so
         // the append path checks it too: a table absent from `_tables` is not
-        // appendable, matching what a subsequent SELECT would see.
-        if self.tables.get(&wtxn, name)?.is_none() {
+        // appendable, matching what a subsequent SELECT would see. `_tables`
+        // must exist to append to any table — a fresh, un-bootstrapped DB has
+        // no appendable tables.
+        let tables = self
+            .env
+            .open_database::<heed::types::Str, heed::types::Bytes>(&wtxn, Some(TABLES_DB))?
+            .ok_or_else(|| StorageError::TableMissing(TABLES_DB.to_string()))?;
+        if tables.get(&wtxn, name)?.is_none() {
             return Err(StorageError::TableMissing(name.to_string()));
         }
         // Open (not create): fail loudly if the named db is absent, rather than
@@ -274,8 +309,9 @@ impl HeedDB {
     /// database called `name` exists in the env (i.e., the table was never
     /// created or was dropped).
     pub fn open_table(&self, txn: &heed::RoTxn<'_>, name: &str) -> Result<RowDb, StorageError> {
-        if self.tables.get(txn, name)?.is_none() {
-            return Err(StorageError::TableMissing(name.to_string()));
+        match self.tables_ro(txn)? {
+            Some(tables) if tables.get(txn, name)?.is_some() => {}
+            _ => return Err(StorageError::TableMissing(name.to_string())),
         }
         self.env
             .open_database(txn, Some(name))?
@@ -283,23 +319,69 @@ impl HeedDB {
     }
 
     /// Enumerate every table name in `_tables`, in lexicographic key order.
+    /// A fresh DB whose catalog the bootstrap has not created yields an empty
+    /// list.
     pub fn list_table_names(&self, txn: &heed::RoTxn<'_>) -> Result<Vec<String>, StorageError> {
-        let mut out = Vec::with_capacity(self.tables.len(txn)? as usize);
-        for result in self.tables.iter(txn)? {
+        let Some(tables) = self.tables_ro(txn)? else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::with_capacity(tables.len(txn)? as usize);
+        for result in tables.iter(txn)? {
             let (k, _v) = result?;
             out.push(k.to_string());
         }
         Ok(out)
     }
 
-    #[cfg(test)]
-    pub(crate) fn env(&self) -> &heed::Env {
-        &self.env
+    pub fn read_schema_version(&self) -> Result<u32, StorageError> {
+        let rtxn = self.env.read_txn()?;
+        match self.default_db.get(&rtxn, SCHEMA_VERSION_KEY)? {
+            Some(b) => Ok(u32::from_le_bytes(<[u8; 4]>::try_from(b).map_err(
+                |_| {
+                    StorageError::Codec(format!(
+                        "schema_version is {} bytes, expected 4 (u32 LE)",
+                        b.len()
+                    ))
+                },
+            )?)),
+            None => Ok(0),
+        }
+    }
+
+    /// Stamp the version (raw u32 LE). Monotonic: never decreases. Returns the
+    /// version now on disk (>= requested) so the caller can detect a concurrent
+    /// newer stamp and reject the DB.
+    pub fn set_schema_version(&self, version: u32) -> Result<u32, StorageError> {
+        let mut wtxn = self.env.write_txn()?;
+        let current = match self.default_db.get(&wtxn, SCHEMA_VERSION_KEY)? {
+            Some(b) => u32::from_le_bytes(<[u8; 4]>::try_from(b).map_err(|_| {
+                StorageError::Codec(format!(
+                    "schema_version is {} bytes, expected 4 (u32 LE)",
+                    b.len()
+                ))
+            })?),
+            None => 0,
+        };
+        if current >= version {
+            return Ok(current);
+        }
+        self.default_db
+            .put(&mut wtxn, SCHEMA_VERSION_KEY, &version.to_le_bytes())?;
+        wtxn.commit()?;
+        Ok(version)
+    }
+
+    pub fn tables_has_self_entry(&self) -> Result<bool, StorageError> {
+        let rtxn = self.env.read_txn()?;
+        match self.tables_ro(&rtxn)? {
+            Some(tables) => Ok(tables.get(&rtxn, TABLES_DB)?.is_some()),
+            None => Ok(false),
+        }
     }
 
     #[cfg(test)]
-    pub(crate) fn tables(&self) -> &TablesDb {
-        &self.tables
+    pub(crate) fn env(&self) -> &heed::Env {
+        &self.env
     }
 
     pub fn path(&self) -> &Path {
@@ -344,20 +426,167 @@ impl HeedDB {
 mod tests {
     use super::*;
 
+    fn tables_value(name: &str) -> Vec<u8> {
+        let mut v = Vec::new();
+        crate::row_codec::serialize_name_row(&[name], &mut v).unwrap();
+        v
+    }
+
+    /// Open a DB and bootstrap `_tables` so user-table creates can proceed.
+    fn open_bootstrapped(path: &std::path::Path) -> HeedDB {
+        let db = HeedDB::open(path).unwrap();
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        db
+    }
+
+    /// Open the `_tables` catalog for reading; panics if it does not exist.
+    fn tables_of(
+        db: &HeedDB,
+        rtxn: &heed::RoTxn<'_>,
+    ) -> heed::Database<heed::types::Str, heed::types::Bytes> {
+        db.env()
+            .open_database(rtxn, Some("_tables"))
+            .unwrap()
+            .unwrap()
+    }
+
+    #[test]
+    fn open_does_not_create_tables_catalog_eagerly() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("lazy.pqlite")).unwrap();
+        let rtxn = db.env().read_txn().unwrap();
+        let named = db
+            .env()
+            .open_database::<heed::types::Str, heed::types::Bytes>(&rtxn, Some("_tables"))
+            .unwrap();
+        assert!(named.is_none(), "_tables must not be created eagerly");
+    }
+
+    #[test]
+    fn create_user_table_before_catalog_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("nocat.pqlite")).unwrap();
+        let res = db.create_table("foo", &tables_value("foo"));
+        assert!(matches!(res, Err(StorageError::TableMissing(ref n)) if n == "_tables"));
+    }
+
+    #[test]
+    fn self_referential_create_tables_bootstraps_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("selfref.pqlite")).unwrap();
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        assert!(db.tables_has_self_entry().unwrap());
+        db.create_table("foo", &tables_value("foo"))
+            .unwrap()
+            .commit()
+            .unwrap();
+    }
+
+    #[test]
+    fn create_table_stores_caller_supplied_tables_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_bootstrapped(&dir.path().join("val.pqlite"));
+        let value = tables_value("widgets");
+        db.create_table("widgets", &value)
+            .unwrap()
+            .commit()
+            .unwrap();
+        let rtxn = db.env().read_txn().unwrap();
+        let tables = tables_of(&db, &rtxn);
+        assert_eq!(tables.get(&rtxn, "widgets").unwrap().unwrap(), &value[..]);
+    }
+
+    #[test]
+    fn schema_version_absent_reads_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("v.pqlite")).unwrap();
+        assert_eq!(db.read_schema_version().unwrap(), 0);
+    }
+
+    #[test]
+    fn schema_version_round_trips_raw_le_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("v.pqlite")).unwrap();
+        assert_eq!(db.set_schema_version(1).unwrap(), 1);
+        assert_eq!(db.read_schema_version().unwrap(), 1);
+        let rtxn = db.env().read_txn().unwrap();
+        let d: heed::Database<heed::types::Str, heed::types::Bytes> =
+            db.env().open_database(&rtxn, None).unwrap().unwrap();
+        assert_eq!(
+            d.get(&rtxn, "\0schema_version").unwrap().unwrap(),
+            &1u32.to_le_bytes()
+        );
+    }
+
+    #[test]
+    fn set_schema_version_is_monotonic_and_returns_observed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("v.pqlite")).unwrap();
+        assert_eq!(db.set_schema_version(2).unwrap(), 2);
+        assert_eq!(
+            db.set_schema_version(1).unwrap(),
+            2,
+            "downgrade no-ops, returns observed"
+        );
+        assert_eq!(db.read_schema_version().unwrap(), 2);
+    }
+
+    #[test]
+    fn malformed_version_bytes_error_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("v.pqlite")).unwrap();
+        {
+            let mut wtxn = db.env().write_txn().unwrap();
+            let d: heed::Database<heed::types::Str, heed::types::Bytes> =
+                db.env().create_database(&mut wtxn, None).unwrap();
+            d.put(&mut wtxn, "\0schema_version", &[0x01, 0x02, 0x03])
+                .unwrap();
+            wtxn.commit().unwrap();
+        }
+        assert!(matches!(
+            db.read_schema_version(),
+            Err(StorageError::Codec(_))
+        ));
+    }
+
+    #[test]
+    fn tables_has_self_entry_reflects_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("v.pqlite")).unwrap();
+        // No catalog exists until _tables is created as a table.
+        assert!(!db.tables_has_self_entry().unwrap());
+        db.create_table("_tables", &tables_value("_tables"))
+            .unwrap()
+            .commit()
+            .unwrap();
+        assert!(db.tables_has_self_entry().unwrap());
+    }
+
     #[test]
     fn table_writer_round_trip_via_push_and_commit() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("writer.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
-        let mut w = db.create_table("widgets").expect("create_table");
+        let mut w = db
+            .create_table("widgets", &tables_value("widgets"))
+            .expect("create_table");
         w.push_row(&[0xDE, 0xAD]).unwrap();
         w.push_row(&[0xBE, 0xEF, 0x01]).unwrap();
         let n = w.commit().unwrap();
         assert_eq!(n, 2);
 
         let rtxn = db.env().read_txn().unwrap();
-        assert!(db.tables().get(&rtxn, "widgets").unwrap().is_some());
+        assert!(tables_of(&db, &rtxn)
+            .get(&rtxn, "widgets")
+            .unwrap()
+            .is_some());
         let rowdb: RowDb = db
             .env()
             .open_database(&rtxn, Some("widgets"))
@@ -370,14 +599,16 @@ mod tests {
     fn create_table_writes_bytes_verbatim_and_registers_catalog() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ctas.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
         let payloads: [&[u8]; 3] = [
             &[0xDE, 0xAD, 0xBE, 0xEF],
             &[0x01],
             &[0xFF, 0x00, 0xFF, 0x00, 0xFF],
         ];
-        let mut w = db.create_table("widgets").unwrap();
+        let mut w = db
+            .create_table("widgets", &tables_value("widgets"))
+            .unwrap();
         for p in payloads.iter() {
             w.push_row(p).unwrap();
         }
@@ -386,7 +617,10 @@ mod tests {
 
         let rtxn = db.env().read_txn().unwrap();
         assert!(
-            db.tables().get(&rtxn, "widgets").unwrap().is_some(),
+            tables_of(&db, &rtxn)
+                .get(&rtxn, "widgets")
+                .unwrap()
+                .is_some(),
             "widgets should be registered in _tables"
         );
 
@@ -410,13 +644,17 @@ mod tests {
     fn create_table_with_no_rows_creates_empty_table() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
-        let n = db.create_table("blank").unwrap().commit().unwrap();
+        let n = db
+            .create_table("blank", &tables_value("blank"))
+            .unwrap()
+            .commit()
+            .unwrap();
         assert_eq!(n, 0);
 
         let rtxn = db.env().read_txn().unwrap();
-        assert!(db.tables().get(&rtxn, "blank").unwrap().is_some());
+        assert!(tables_of(&db, &rtxn).get(&rtxn, "blank").unwrap().is_some());
         let rowdb: RowDb = db
             .env()
             .open_database::<RowKey, heed::types::Bytes>(&rtxn, Some("blank"))
@@ -429,12 +667,12 @@ mod tests {
     fn create_table_rejects_duplicate_name() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dup.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
-        let mut w1 = db.create_table("t").unwrap();
+        let mut w1 = db.create_table("t", &tables_value("t")).unwrap();
         w1.push_row(&[0x01]).unwrap();
         w1.commit().unwrap();
-        let again = db.create_table("t");
+        let again = db.create_table("t", &tables_value("t"));
         assert!(
             matches!(again, Err(StorageError::TableExists(ref n)) if n == "t"),
             "expected TableExists; got {:?}",
@@ -442,36 +680,43 @@ mod tests {
         );
 
         let rtxn = db.env().read_txn().unwrap();
-        assert_eq!(db.tables().len(&rtxn).unwrap(), 1);
+        // _tables (self-entry) plus the one user table t.
+        assert_eq!(tables_of(&db, &rtxn).len(&rtxn).unwrap(), 2);
+        // Release the read txn before read_row_for_tests opens its own; LMDB
+        // rejects a second concurrent read txn on the same thread (BadRslot).
+        drop(rtxn);
+
+        // Rejected re-create must not clear the original row: create_table now
+        // creates the target DB before the duplicate check, so a future
+        // clear-then-recreate regression would silently drop existing data.
+        assert_eq!(db.read_row_for_tests("t", 0), vec![0x01]);
     }
 
     #[test]
-    fn create_table_rejects_reserved_names() {
+    fn create_table_allows_underscore_prefixed_names_and_persists() {
         let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("reserved.pqlite");
-        let db = HeedDB::open(&path).unwrap();
-
-        for name in ["_tables", "_x", "_"] {
-            let res = db.create_table(name);
-            assert!(
-                matches!(res, Err(StorageError::ReservedName(_))),
-                "expected ReservedName for {name:?}; got {:?}",
-                res
-            );
+        let db = open_bootstrapped(&dir.path().join("underscore.pqlite"));
+        for name in ["_x", "_temp", "_internal"] {
+            db.create_table(name, &tables_value(name))
+                .unwrap()
+                .commit()
+                .unwrap(); // commit → prove persistence
         }
-
         let rtxn = db.env().read_txn().unwrap();
-        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
+        let names = db.list_table_names(&rtxn).unwrap();
+        for name in ["_x", "_temp", "_internal"] {
+            assert!(names.contains(&name.to_string()), "{name} should persist");
+        }
     }
 
     #[test]
     fn create_table_rejects_interior_nul_names() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nul.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
         // Interior NUL would otherwise panic heed's CString::new.
-        let res = db.create_table("a\0b");
+        let res = db.create_table("a\0b", &tables_value("x"));
         assert!(
             matches!(res, Err(StorageError::InvalidName(_))),
             "expected InvalidName; got {:?}",
@@ -479,22 +724,28 @@ mod tests {
         );
 
         let rtxn = db.env().read_txn().unwrap();
-        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
+        // Only the bootstrapped _tables self-entry; the rejected name added nothing.
+        assert_eq!(tables_of(&db, &rtxn).len(&rtxn).unwrap(), 1);
     }
 
     #[test]
     fn dropping_writer_rolls_back_uncommitted_rows() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rb.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
         {
-            let mut w = db.create_table("partial").unwrap();
+            let mut w = db
+                .create_table("partial", &tables_value("partial"))
+                .unwrap();
             w.push_row(&[0x42]).unwrap();
             // Drop without commit — wtxn rolls back.
         }
         let rtxn = db.env().read_txn().unwrap();
         assert!(
-            db.tables().get(&rtxn, "partial").unwrap().is_none(),
+            tables_of(&db, &rtxn)
+                .get(&rtxn, "partial")
+                .unwrap()
+                .is_none(),
             "rolled-back create must leave no catalog entry"
         );
     }
@@ -515,10 +766,10 @@ mod tests {
         assert!(te.to_string().contains("already exists"), "got: {te}");
         assert!(te.to_string().contains("foo"), "got: {te}");
 
-        let rn = StorageError::ReservedName("_x".to_string());
-        let s = rn.to_string();
-        assert!(s.contains("reserved"), "got: {s}");
-        assert!(s.contains("_x"), "got: {s}");
+        let sr = StorageError::SystemTableReadOnly("_tables".to_string());
+        let s = sr.to_string();
+        assert!(s.contains("system table"), "got: {s}");
+        assert!(s.contains("_tables"), "got: {s}");
 
         let inv = StorageError::InvalidName("a\0b".to_string());
         let s = inv.to_string();
@@ -544,30 +795,6 @@ mod tests {
     }
 
     #[test]
-    fn open_creates_empty_tables_catalog() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("cat.pqlite");
-        let db = HeedDB::open(&path).unwrap();
-
-        // NO_SUB_DIR stores the environment as a single file.
-        assert!(path.is_file(), "db should be a single file (NO_SUB_DIR)");
-
-        let rtxn = db.env().read_txn().unwrap();
-
-        // Look up by literal name so renaming the TABLES_DB constant can't pass spuriously.
-        let named = db
-            .env()
-            .open_database::<heed::types::Str, heed::types::Bytes>(&rtxn, Some("_tables"))
-            .unwrap();
-        assert!(
-            named.is_some(),
-            "the `_tables` catalog should exist by name"
-        );
-
-        assert_eq!(db.tables().len(&rtxn).unwrap(), 0);
-    }
-
-    #[test]
     fn open_is_idempotent_on_reopen() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("reopen.pqlite");
@@ -582,9 +809,9 @@ mod tests {
     fn open_table_yields_pushed_rows_in_insertion_order() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("read.pqlite");
-        let db = HeedDB::open(&path).unwrap();
+        let db = open_bootstrapped(&path);
 
-        let mut w = db.create_table("t").unwrap();
+        let mut w = db.create_table("t", &tables_value("t")).unwrap();
         w.push_row(&[0x01, 0x02]).unwrap();
         w.push_row(&[0x03, 0x04, 0x05]).unwrap();
         w.commit().unwrap();
@@ -618,8 +845,8 @@ mod tests {
     #[test]
     fn append_to_existing_table_continues_row_ids() {
         let dir = tempfile::tempdir().unwrap();
-        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
-        let mut w = db.create_table("t").unwrap();
+        let db = open_bootstrapped(&dir.path().join("t.pqlite"));
+        let mut w = db.create_table("t", &tables_value("t")).unwrap();
         w.push_row(&[0xAA]).unwrap();
         w.push_row(&[0xBB]).unwrap();
         w.push_row(&[0xCC]).unwrap();
@@ -637,8 +864,11 @@ mod tests {
     #[test]
     fn append_to_empty_table_starts_at_zero() {
         let dir = tempfile::tempdir().unwrap();
-        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
-        db.create_table("t").unwrap().commit().unwrap(); // empty table, no rows
+        let db = open_bootstrapped(&dir.path().join("t.pqlite"));
+        db.create_table("t", &tables_value("t"))
+            .unwrap()
+            .commit()
+            .unwrap(); // empty table, no rows
         let mut a = db.open_table_for_append("t").unwrap();
         a.push_row(&[0x01]).unwrap();
         assert_eq!(a.commit().unwrap(), 1);
@@ -648,23 +878,36 @@ mod tests {
     #[test]
     fn append_to_missing_table_errors() {
         let dir = tempfile::tempdir().unwrap();
-        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        let db = open_bootstrapped(&dir.path().join("t.pqlite"));
         let r = db.open_table_for_append("ghost");
-        assert!(matches!(r, Err(StorageError::TableMissing(_))));
+        assert!(matches!(r, Err(StorageError::TableMissing(ref n)) if n == "ghost"));
     }
 
     #[test]
-    fn append_rejects_reserved_and_invalid_names() {
+    fn append_rejects_nul_names() {
         let dir = tempfile::tempdir().unwrap();
         let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
-        assert!(matches!(
-            db.open_table_for_append("_x"),
-            Err(StorageError::ReservedName(_))
-        ));
         assert!(matches!(
             db.open_table_for_append("a\0b"),
             Err(StorageError::InvalidName(_))
         ));
+    }
+
+    #[test]
+    fn append_rejects_exact_system_table_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = HeedDB::open(&dir.path().join("t.pqlite")).unwrap();
+        assert!(
+            matches!(db.open_table_for_append("_tables"), Err(StorageError::SystemTableReadOnly(ref n)) if n == "_tables"),
+            "INSERT into _tables must be rejected to protect the catalog"
+        );
+    }
+
+    #[test]
+    fn is_system_table_matches_only_tables_db() {
+        assert!(is_system_table("_tables"));
+        assert!(!is_system_table("_foo"));
+        assert!(!is_system_table("tables"));
     }
 
     #[test]

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -72,6 +72,24 @@ fn plain_select_via_exec_needs_no_db_and_creates_no_file() {
 }
 
 #[test]
+fn fresh_db_bootstraps_and_select_star_from_tables_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("boot.pqlite");
+    let (ok, stdout, stderr) = run_exec("SELECT t.a FROM mem(1,1) t", Some(&db));
+    assert!(ok, "stderr: {stderr}");
+    assert!(
+        !stdout.contains("_tables") && !stderr.contains("Created table _tables"),
+        "bootstrap must be silent: out={stdout} err={stderr}"
+    );
+    let (ok2, stdout2, stderr2) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(ok2, "stderr: {stderr2}");
+    assert!(
+        stdout2.contains("_tables"),
+        "expected self-entry: {stdout2}"
+    );
+}
+
+#[test]
 fn ctas_without_db_errors_cleanly() {
     let (ok, stdout, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(1,2) t)", None);
 
@@ -1765,5 +1783,179 @@ fn insert_into_quoted_case_sensitive_target() {
     assert!(
         err.contains("(5 rows "),
         "expected 5 rows total; stderr: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end bootstrap + system-table (`_tables`) acceptance suite. These drive
+// the built binary against a fresh `--db` to verify the startup bootstrap:
+// the `_tables` catalog is created on first run, a schema version is stamped,
+// user tables register in the catalog, and the system table is read-only.
+
+#[test]
+fn select_star_from_tables_shows_self_and_user_tables() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("intro.pqlite");
+    let (ok, _, err) = run_exec(
+        "CREATE TABLE users AS (SELECT t.a FROM mem(1,1) t)",
+        Some(&db),
+    );
+    assert!(ok, "stderr: {err}");
+    let (ok2, out, err2) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(ok2, "stderr: {err2}");
+    assert!(
+        out.contains("_tables") && out.contains("users"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn bare_create_table_registers_in_catalog() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("bare.pqlite");
+    let (ok, _, err) = run_exec("CREATE TABLE widgets", Some(&db));
+    assert!(ok, "stderr: {err}");
+    let (ok2, out, _) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(
+        ok2 && out.contains("widgets"),
+        "bare CREATE must register: {out}"
+    );
+}
+
+#[test]
+fn fresh_bootstrap_stamps_version_one() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("stamp.pqlite");
+    assert!(run_exec("SELECT t.a FROM mem(1,1) t", Some(&db_path)).0);
+    let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+    assert_eq!(db.read_schema_version().unwrap(), 1);
+    assert!(db.tables_has_self_entry().unwrap());
+}
+
+#[test]
+fn second_startup_skips_bootstrap_and_keeps_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("second.pqlite");
+    assert!(run_exec("SELECT t.a FROM mem(1,1) t", Some(&db_path)).0);
+    let (ok2, out2, err2) = run_exec("SELECT t.a FROM mem(1,1) t", Some(&db_path));
+    assert!(ok2, "stderr: {err2}");
+    assert!(
+        !out2.contains("_tables") && !err2.contains("Created table _tables"),
+        "no re-bootstrap"
+    );
+    let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+    assert_eq!(db.read_schema_version().unwrap(), 1);
+}
+
+#[test]
+fn insert_into_tables_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("ins.pqlite");
+    let (ok, _, err) = run_exec("INSERT INTO _tables SELECT t.a FROM mem(1,1) t", Some(&db));
+    assert!(!ok && err.contains("system table"), "got: {err}");
+}
+
+#[test]
+fn create_table_as_system_table_is_rejected_after_bootstrap_catalog_intact() {
+    // After bootstrap _tables holds its self-entry, so a user CREATE TABLE _tables
+    // fails cleanly with a duplicate error — and the catalog stays queryable.
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("dupsys.pqlite");
+    let (ok0, _, err0) = run_exec(
+        "CREATE TABLE users AS (SELECT t.a FROM mem(1,1) t)",
+        Some(&db),
+    );
+    assert!(ok0, "stderr: {err0}");
+    let (ok, _, err) = run_exec(
+        "CREATE TABLE _tables AS (SELECT t.a FROM mem(1,1) t)",
+        Some(&db),
+    );
+    assert!(
+        !ok && err.contains("already exists"),
+        "CREATE TABLE _tables after bootstrap must fail with a duplicate error; err: {err}"
+    );
+    // Catalog intact: still queryable, still shows the real tables.
+    let (ok2, out, err2) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(
+        ok2,
+        "catalog must survive the rejected create; stderr: {err2}"
+    );
+    assert!(
+        out.contains("_tables") && out.contains("users"),
+        "got: {out}"
+    );
+}
+
+#[test]
+fn create_table_named_schema_version_still_works() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("sv.pqlite");
+    let (ok, _, err) = run_exec(
+        "CREATE TABLE \"schema_version\" AS (SELECT t.a FROM mem(1,1) t)",
+        Some(&db),
+    );
+    assert!(ok, "stderr: {err}");
+    let (ok2, out, _) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(ok2 && out.contains("schema_version"), "got: {out}");
+}
+
+#[test]
+fn underscore_prefixed_user_table_is_allowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("under.pqlite");
+    assert!(
+        run_exec(
+            "CREATE TABLE _scratch AS (SELECT t.a FROM mem(1,1) t)",
+            Some(&db)
+        )
+        .0
+    );
+    let (ok2, out, _) = run_exec("SELECT * FROM _tables", Some(&db));
+    assert!(ok2 && out.contains("_scratch"), "got: {out}");
+}
+
+#[test]
+fn newer_schema_version_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("newer.pqlite");
+    {
+        let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+        db.set_schema_version(2).unwrap();
+    }
+    let (ok, _, err) = run_exec("SELECT t.a FROM mem(1,1) t", Some(&db_path));
+    assert!(!ok && err.contains("newer than this binary"), "got: {err}");
+}
+
+#[test]
+fn version_one_without_self_entry_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("inv.pqlite");
+    {
+        let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+        db.set_schema_version(1).unwrap();
+    }
+    let (ok, _, err) = run_exec("SELECT t.a FROM mem(1,1) t", Some(&db_path));
+    assert!(!ok && err.contains("missing or incomplete"), "got: {err}");
+}
+
+#[test]
+fn bootstrap_reconciles_when_self_entry_present_but_version_zero() {
+    // Crash-after-create, before-stamp: self-entry exists, version still 0.
+    // Bootstrap must run CREATE (hitting TableExists) and reconcile, NOT skip.
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("recover.pqlite");
+    {
+        let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+        let mut v = Vec::new();
+        partiql_tools::row_codec::serialize_name_row(&["_tables"], &mut v).unwrap();
+        db.create_table("_tables", &v).unwrap().commit().unwrap(); // version still 0
+    }
+    let (ok, _, err) = run_exec("SELECT * FROM _tables", Some(&db_path));
+    assert!(ok, "recovery must succeed; stderr: {err}");
+    let db = partiql_tools::storage::HeedDB::open(&db_path).unwrap();
+    assert_eq!(
+        db.read_schema_version().unwrap(),
+        1,
+        "recovery stamps version 1"
     );
 }

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -163,7 +163,7 @@ macro_rules! struct_fields {
 #[macro_export]
 macro_rules! type_bag {
     ($bld:expr) => {
-        $bld.new_bag(BagType::new_any());
+        $bld.new_bag(BagType::new_any())
     };
     ($bld:expr, $elem:expr) => {{
         let elem = $elem;
@@ -174,7 +174,7 @@ macro_rules! type_bag {
 #[macro_export]
 macro_rules! type_array {
     ($bld:expr) => {
-        $bld.new_array(ArrayType::new_any());
+        $bld.new_array(ArrayType::new_any())
     };
     ($bld:expr, $elem:expr) => {{
         let elem = $elem;


### PR DESCRIPTION
# feat(pqlite): bootstrap system tables on startup

Closes #648.

## Summary
When pqlite starts for the first time, it now automatically creates the _tables system catalog. It does this by running bootstrap/v1.pql through the standard query pipeline and saving a schema version in the database to skip this step on future boots. The _tables catalog is now queryable via SELECT * FROM _tables.

## Key Changes

- Stores a version number (u32 LE) in the LMDB default database to detect if first startup.

- _tables automatically includes an entry for itself.

- Removed _ prefix restriction.

- _tables is read-only for users to prevent manual corruption of the catalog.

- Added a utility that handles multi-statement scripts (splits by ; and strips comments). This is limited to bootstrap mode only.

## Deviations from Spec


I made a few adjustments to the original design to improve maintainability and future-proof the implementation:

- I moved bootstrapping out of HeedDB::open() and into the main binary. This keeps the storage module lean by ensuring it only handles low-level primitives instead of needing access to the parser and VM.

- I updated the _tables format to store names as a list ({name: ['foo']}) rather than a single string. This allows us to support qualified table names later without needing a data migration.

- Used a NUL-prefixed key (b"\0schema_version") for the version stamp. This makes it structurally impossible for a user to accidentally overwrite the version key by naming a table schema_version.

- The system now fails fast if the schema version is newer than the binary or if a marked database is missing its self-referential _tables entry.