### PR TITLE
fix: unblock CI on current toolchain (semicolons + ion pin)

### DIFF
--- a/extension/partiql-extension-csv/Cargo.toml
+++ b/extension/partiql-extension-csv/Cargo.toml
@@ -32,6 +32,7 @@ itertools = "0.14"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 ion-rs_old = { version = "0.18", package = "ion-rs" }
+# TODO relax exact pin once ion-rs RC output is reproducible: https://github.com/partiql/partiql-lang-rust/issues/655
 ion-rs = { version = "=1.0.0-rc.11", features = ["experimental"] }
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"

--- a/extension/partiql-extension-csv/Cargo.toml
+++ b/extension/partiql-extension-csv/Cargo.toml
@@ -32,7 +32,7 @@ itertools = "0.14"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental"] }
+ion-rs = { version = "=1.0.0-rc.11", features = ["experimental"] }
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"
 regex = "1.10"

--- a/extension/partiql-extension-ion-functions/Cargo.toml
+++ b/extension/partiql-extension-ion-functions/Cargo.toml
@@ -31,7 +31,7 @@ itertools = "0.14"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental"] }
+ion-rs = { version = "=1.0.0-rc.11", features = ["experimental"] }
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"
 regex = "1.10"

--- a/extension/partiql-extension-ion-functions/Cargo.toml
+++ b/extension/partiql-extension-ion-functions/Cargo.toml
@@ -31,6 +31,7 @@ itertools = "0.14"
 unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 ion-rs_old = { version = "0.18", package = "ion-rs" }
+# TODO relax exact pin once ion-rs RC output is reproducible: https://github.com/partiql/partiql-lang-rust/issues/655
 ion-rs = { version = "=1.0.0-rc.11", features = ["experimental"] }
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"

--- a/extension/partiql-extension-ion/Cargo.toml
+++ b/extension/partiql-extension-ion/Cargo.toml
@@ -34,7 +34,7 @@ unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.36"
 ion-rs_old = { version = "0.18", package = "ion-rs" }
-ion-rs = { version = "1.0.0-rc.11", features = ["experimental", "experimental-ion-hash", "sha2"] }
+ion-rs = { version = "=1.0.0-rc.11", features = ["experimental", "experimental-ion-hash", "sha2"] }
 
 time = { version = "0.3", features = ["macros"] }
 once_cell = "1"

--- a/extension/partiql-extension-ion/Cargo.toml
+++ b/extension/partiql-extension-ion/Cargo.toml
@@ -34,6 +34,7 @@ unicase = "2.7"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
 rust_decimal_macros = "1.36"
 ion-rs_old = { version = "0.18", package = "ion-rs" }
+# TODO relax exact pin once ion-rs RC output is reproducible: https://github.com/partiql/partiql-lang-rust/issues/655
 ion-rs = { version = "=1.0.0-rc.11", features = ["experimental", "experimental-ion-hash", "sha2"] }
 
 time = { version = "0.3", features = ["macros"] }

--- a/extension/partiql-extension-ion/tests/snapshots/test__verify_ion_tests.snap
+++ b/extension/partiql-extension-ion/tests/snapshots/test__verify_ion_tests.snap
@@ -1,6 +1,5 @@
 ---
 source: extension/partiql-extension-ion/tests/test.rs
-assertion_line: 485
 expression: result
 ---
 

--- a/extension/partiql-extension-ion/tests/snapshots/test__verify_ion_tests.snap
+++ b/extension/partiql-extension-ion/tests/snapshots/test__verify_ion_tests.snap
@@ -1,7 +1,9 @@
 ---
 source: extension/partiql-extension-ion/tests/test.rs
+assertion_line: 485
 expression: result
 ---
+
 =====================
 /UnicodeNullInFieldName.ion
 ---------------------
@@ -725,7 +727,7 @@ Err: `Latent Type Error for Boxed Document Error reading Ion `integer size is cu
 =====================
 /intBigSize16.10n
 ---------------------
-Err: `Latent Type Error for Boxed Document Error reading Ion `could not safely convert value 340272423131748694355562029545669544747 of type 'u128' to Int: TryFromIntError(())``
+Err: `Latent Type Error for Boxed Document Error reading Ion `could not safely convert value 340272423131748694355562029545669544747 of type 'u128' to Int: TryFromIntError(PosOverflow)``
 =====================
 
 =====================

--- a/partiql-types/src/lib.rs
+++ b/partiql-types/src/lib.rs
@@ -163,7 +163,7 @@ macro_rules! struct_fields {
 #[macro_export]
 macro_rules! type_bag {
     ($bld:expr) => {
-        $bld.new_bag(BagType::new_any());
+        $bld.new_bag(BagType::new_any())
     };
     ($bld:expr, $elem:expr) => {{
         let elem = $elem;
@@ -174,7 +174,7 @@ macro_rules! type_bag {
 #[macro_export]
 macro_rules! type_array {
     ($bld:expr) => {
-        $bld.new_array(ArrayType::new_any());
+        $bld.new_array(ArrayType::new_any())
     };
     ($bld:expr, $elem:expr) => {{
         let elem = $elem;


### PR DESCRIPTION
 - **Trailing semicolons in `partiql-types` macros** — `type_bag!` / `type_array!`
    had a trailing `;` inside the macro body. The `semicolon_in_expressions_from_macros`
    lint now treats this as a hard error on nightly. Behavior-neutral.
  - **Pin `ion-rs` to `=1.0.0-rc.11`** — the caret requirement floated to rc.12
    (no committed lockfile), which changed Ion text output and broke snapshots.
    The exact pin holds it at rc.11. Unpinning is tracked in #<ION_ISSUE>.
  - **Re-accept `verify_ion_tests` snapshot** — one snapshot drifted from an
    unrelated std change (`TryFromIntError` Debug format: `(())` → `(PosOverflow)`),
    which no ion pin can fix. Re-accepted and audited to confirm only that known
    drift, no behavior change.
    
    
    Made #655 to track the ion-pin as a future TODO.