### PR TITLE
feat(pqlite): file-driven end-to-end test harness

### DIFF
--- a/partiql-tools/.gitignore
+++ b/partiql-tools/.gitignore
@@ -2,6 +2,8 @@
 test_data/
 data/
 *.ion
+# but keep checked-in e2e fixtures
+!tests/pqlite/cases/**/*.test.ion
 *.10n
 *.arrow
 *.parquet

--- a/partiql-tools/Cargo.toml
+++ b/partiql-tools/Cargo.toml
@@ -75,6 +75,7 @@ rust_decimal = { version = "1", default-features = false, features = ["std"] }
 [dev-dependencies]
 criterion = "0.5"
 proptest = "1.0"
+rstest = "0.23"
 tempfile = "3.0"
 # Self-activate `test-support` for integration tests in `tests/` so the gated
 # module is reachable without requiring `--features test-support` on the CLI.

--- a/partiql-tools/build.rs
+++ b/partiql-tools/build.rs
@@ -37,6 +37,9 @@ fn main() {
             println!("cargo:rerun-if-changed={}", packed.display());
         }
     }
+
+    // Re-discover `.test.ion` fixtures when the cases directory changes.
+    println!("cargo:rerun-if-changed=tests/pqlite/cases");
 }
 
 /// Run a git command, returning trimmed stdout on success, or `None` on any

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,35 +1,14 @@
-use partiql_tools::common;
-
-use common::{create_table_fn_catalog, lower_statement, parse, parse_statements};
-use partiql_common::catalog::CatalogId;
-use partiql_eval::plan::EvaluationMode;
-use partiql_eval::value::Shape;
-use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanCompiler};
-use partiql_logical::LogicalStatement;
-use partiql_tools::catalog::{HeedCompilationCatalog, HeedExecutionCatalog};
-use partiql_tools::storage::{HeedDB, StorageError};
-use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex};
-use std::time::Instant;
 
-use clap::{Parser, Subcommand};
+use partiql_tools::session::{normalize_query, Commands, DebugFlags, OutputFormat, PqliteSession};
+
+use clap::Parser;
 use reedline::{
     FileBackedHistory, History, Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal,
     ValidationResult, Validator,
 };
 
 const HISTORY_CAPACITY: usize = 1000;
-
-/// The schema version this binary bootstraps to and requires.
-const CURRENT_SCHEMA_VERSION: u32 = 1;
-
-/// Whether `execute_query` prints. Bootstrap runs muted.
-#[derive(Clone, Copy)]
-enum OutputMode {
-    User,
-    Silent,
-}
 
 /// Crate version joined with the git commit SHA captured in build.rs.
 const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), "@", env!("PQLITE_GIT_SHA"));
@@ -54,54 +33,32 @@ struct Cli {
     command: Option<Commands>,
 }
 
-struct DebugFlags {
-    ast: bool,
-    plan: bool,
-    program: bool,
-}
-
-impl DebugFlags {
-    fn from_args(args: &[String]) -> Self {
-        let all = args.iter().any(|s| s == "*");
-        DebugFlags {
-            ast: all || args.iter().any(|s| s == "ast"),
-            plan: all || args.iter().any(|s| s == "plan"),
-            program: all || args.iter().any(|s| s == "program"),
-        }
-    }
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Execute a single query immediately
-    Exec {
-        /// The mandatory PartiQL query string to run
-        query: String,
-    },
-}
-
 fn main() {
     let cli = Cli::parse();
     let debug = DebugFlags::from_args(&cli.debug);
 
-    match &cli.command {
-        Some(Commands::Exec { query }) => {
-            let query = normalize_query(query);
-            if query.is_empty() {
+    match cli.command {
+        Some(Commands::Exec { query, format }) => {
+            // Reject empty query before opening the database so a `--db <path>`
+            // invocation with a blank query does not create the file on disk.
+            if normalize_query(&query).is_empty() {
                 eprintln!("Error: empty query");
                 std::process::exit(1);
             }
-            let db = match cli.db.as_deref() {
-                Some(p) => match open_and_bootstrap(p) {
-                    Ok(db) => Some(db),
+            let cmd = Commands::Exec { query, format };
+            let session = match cli.db.as_deref() {
+                Some(p) => match PqliteSession::open(p, debug) {
+                    Ok(s) => s,
                     Err(e) => {
                         eprintln!("Error: could not open database at {}: {}", p.display(), e);
                         std::process::exit(1);
                     }
                 },
-                None => None,
+                None => PqliteSession::open_without_db(debug),
             };
-            if let Err(e) = execute_query(query, &debug, db, OutputMode::User) {
+            let mut stdout = std::io::stdout();
+            let mut stderr = std::io::stderr();
+            if let Err(e) = session.run(&cmd, &mut stdout, &mut stderr) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
@@ -113,90 +70,9 @@ fn main() {
                 std::process::exit(1);
             });
 
-            run_repl(&debug, &db_path);
+            run_repl(debug, &db_path);
         }
     }
-}
-
-/// Trim outer whitespace and strip a single trailing `;` so the REPL can use
-/// `;` as a completion signal without it leaking into the PartiQL grammar.
-/// TODO: drop this once the parser accepts `;` natively.
-fn normalize_query(input: &str) -> &str {
-    let trimmed = input.trim();
-    trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end()
-}
-
-/// Open the DB and bring it to CURRENT_SCHEMA_VERSION. Idempotent + crash-safe.
-fn open_and_bootstrap(path: &std::path::Path) -> Result<Arc<HeedDB>, Box<dyn std::error::Error>> {
-    let db = Arc::new(HeedDB::open(path)?);
-    let version = db.read_schema_version()?;
-    if version > CURRENT_SCHEMA_VERSION {
-        return Err(format!(
-            "database schema version {version} is newer than this binary \
-             supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
-        )
-        .into());
-    }
-    // A stamped current version must satisfy its postcondition (one extra
-    // catalog lookup at startup — a deliberate integrity check).
-    if version == CURRENT_SCHEMA_VERSION && !db.tables_has_self_entry()? {
-        return Err("database reports schema version 1 but the _tables catalog \
-                    is missing or incomplete"
-            .into());
-    }
-    // Migration ladder: each future migration is its own `version < N` block
-    // that stamps N, so an older DB runs every step in order. Bumping
-    // CURRENT_SCHEMA_VERSION alone is not enough — add a block.
-    if version < 1 {
-        bootstrap_v1(&db)?;
-        let stamped = db.set_schema_version(1)?;
-        // Guards a concurrent writer that stamped a newer version between our
-        // read above and this stamp; monotonic set returns that higher version.
-        if stamped > CURRENT_SCHEMA_VERSION {
-            return Err(format!(
-                "database schema version {stamped} is newer than this binary \
-                 supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
-            )
-            .into());
-        }
-    }
-    Ok(db)
-}
-
-/// Run the v1 bootstrap script. The `;`-separated script is parsed as a unit
-/// and each statement executed in order. Idempotent: a crash-recovery DB whose
-/// _tables already exists yields a typed StorageError::TableExists, reconciled
-/// against the self-entry; any other error propagates.
-fn bootstrap_v1(db: &Arc<HeedDB>) -> Result<(), Box<dyn std::error::Error>> {
-    let script = include_str!("../bootstrap/v1.pql");
-    let debug = DebugFlags::from_args(&[]);
-    let parsed = parse_statements(script).map_err(|e| format!("Parse error: {:?}", e))?;
-    for stmt in &parsed.statements {
-        // parse_time is a bootstrap step, not user-facing; Silent mode prints no
-        // timing footer, so a zero placeholder is never observed.
-        match execute_statement(
-            stmt,
-            &debug,
-            Some(Arc::clone(db)),
-            OutputMode::Silent,
-            std::time::Duration::ZERO,
-        ) {
-            Ok(()) => {}
-            Err(e) => {
-                let is_self_tables_exists = e
-                    .downcast_ref::<StorageError>()
-                    .map(|se| matches!(se, StorageError::TableExists(n) if n == "_tables"))
-                    .unwrap_or(false);
-                // Crash-recovery: _tables already created on a prior run. Skip and
-                // continue; any other error is real and aborts bootstrap.
-                if is_self_tables_exists && db.tables_has_self_entry()? {
-                    continue;
-                }
-                return Err(e);
-            }
-        }
-    }
-    Ok(())
 }
 
 struct PqlitePrompt;
@@ -317,12 +193,12 @@ fn print_startup_banner(db_path: &std::path::Path) {
     eprintln!("For usage information, enter \".help\".");
 }
 
-/// `execute_query` errors are reported but never terminate the session.
-fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
+/// `exec_one` errors are reported but never terminate the session.
+fn run_repl(debug: DebugFlags, db_path: &std::path::Path) {
     // Hard-fail rather than fall back to in-memory: a silently non-persisting
     // db is worse than refusing to start.
-    let db = match open_and_bootstrap(db_path) {
-        Ok(db) => db,
+    let session = match PqliteSession::open(db_path, debug) {
+        Ok(s) => s,
         Err(e) => {
             eprintln!(
                 "Error: could not open database at {}: {}",
@@ -362,8 +238,13 @@ fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
                     continue;
                 }
 
-                if let Err(e) = execute_query(query, debug, Some(Arc::clone(&db)), OutputMode::User)
-                {
+                let mut stdout = std::io::stdout();
+                let mut stderr = std::io::stderr();
+                let cmd = Commands::Exec {
+                    query: query.to_string(),
+                    format: OutputFormat::Text,
+                };
+                if let Err(e) = session.run(&cmd, &mut stdout, &mut stderr) {
                     eprintln!("{}", e);
                 }
             }
@@ -380,536 +261,5 @@ fn run_repl(debug: &DebugFlags, db_path: &std::path::Path) {
                 break;
             }
         }
-    }
-}
-
-/// SQL-idiomatic rendering: quoted identifiers re-quoted, bare ones bare.
-fn format_table_name(name: &partiql_value::BindingsName<'_>) -> String {
-    match name {
-        partiql_value::BindingsName::CaseSensitive(s) => format!("\"{}\"", s),
-        partiql_value::BindingsName::CaseInsensitive(s) => s.as_ref().to_string(),
-    }
-}
-
-/// Bare identifiers fold to ASCII lowercase; quoted identifiers are verbatim.
-/// `HeedDB::create_table` rejects interior NULs that would panic heed.
-///
-/// ASCII-only — full Unicode-consistent folding (matching the engine's UniCase
-/// fold for non-ASCII identifiers) is a later-PR refinement.
-fn canonical_table_key(name: &partiql_value::BindingsName<'_>) -> String {
-    match name {
-        partiql_value::BindingsName::CaseInsensitive(s) => s.to_lowercase(),
-        partiql_value::BindingsName::CaseSensitive(s) => s.to_string(),
-    }
-}
-
-fn print_ddl_executed_footer(elapsed: std::time::Duration) {
-    eprintln!("(took {:.1}ms)", elapsed.as_secs_f64() * 1000.0);
-}
-
-/// Per-stage timing footer for the write statements (CTAS / INSERT).
-fn print_write_footer(
-    parse: std::time::Duration,
-    lower: std::time::Duration,
-    compile: std::time::Duration,
-    exec: std::time::Duration,
-) {
-    let total = parse + lower + compile + exec;
-    eprintln!(
-        "(took {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-        total.as_secs_f64() * 1000.0,
-        parse.as_secs_f64() * 1000.0,
-        lower.as_secs_f64() * 1000.0,
-        compile.as_secs_f64() * 1000.0,
-        exec.as_secs_f64() * 1000.0,
-    );
-}
-
-/// Bundles `HeedCompilationCatalog` with the existing `TableFnCompilationCatalog`
-/// under `PlanCompiler`'s single `"default"` catalog name. Also records the
-/// first unresolved bare table name so `build_compiled` can fail fast with
-/// "Table not found" instead of letting Permissive mode yield a MISSING row.
-struct CombinedCatalog {
-    table_fns: common::TableFnCompilationCatalog,
-    heed: Option<HeedCompilationCatalog>,
-    unresolved_table_name: Arc<Mutex<Option<String>>>,
-}
-
-impl partiql_eval::CompilationCatalog for CombinedCatalog {
-    fn get_table(
-        &self,
-        path: &[partiql_value::BindingsName<'_>],
-    ) -> Option<partiql_eval::source::DataSourceHandle> {
-        if let Some(handle) = self.heed.as_ref().and_then(|h| h.get_table(path)) {
-            return Some(handle);
-        }
-        // Only record bare single-element bindings — schema-qualified paths
-        // never match anything here and aren't useful to surface as table names.
-        // The compiler may probe a name multiple times; keep the first.
-        if path.len() == 1 {
-            if let Ok(mut guard) = self.unresolved_table_name.lock() {
-                if guard.is_none() {
-                    let name = match &path[0] {
-                        partiql_value::BindingsName::CaseSensitive(s) => s.to_string(),
-                        partiql_value::BindingsName::CaseInsensitive(s) => s.to_string(),
-                    };
-                    *guard = Some(name);
-                }
-            }
-        }
-        None
-    }
-
-    fn get_table_function(&self, name: &str) -> Option<partiql_eval::source::TableFunctionHandle> {
-        self.table_fns.get_table_function(name)
-    }
-}
-
-/// CatalogId is reused by the matching ExecutionCatalog.
-fn build_compiled(
-    logical: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
-    debug: &DebugFlags,
-    db: Option<Arc<HeedDB>>,
-) -> Result<(partiql_eval::CompiledPlan, CatalogId), Box<dyn std::error::Error>> {
-    if debug.plan {
-        eprintln!("[Plan] {:?}", logical);
-    }
-
-    let mut context = CompilationContext::new();
-
-    let column_names = vec!["a".to_string(), "b".to_string()];
-    let unresolved_table_name: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-    let combined = CombinedCatalog {
-        table_fns: common::TableFnCompilationCatalog::new(column_names),
-        heed: db.map(HeedCompilationCatalog::new),
-        unresolved_table_name: Arc::clone(&unresolved_table_name),
-    };
-    let catalog: Arc<dyn partiql_eval::CompilationCatalog> = Arc::new(combined);
-    let catalog_id = context.add_catalog("default", catalog);
-
-    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
-    let compiled = compiler
-        .compile(logical)
-        .map_err(|e| format!("Compile error: {:?}", e))?;
-
-    let first_unresolved = unresolved_table_name
-        .lock()
-        .map(|mut g| g.take())
-        .unwrap_or(None);
-    if let Some(name) = first_unresolved {
-        return Err(format!("Error: Table '{}' not found", name).into());
-    }
-
-    if debug.program {
-        eprintln!("[Program]\n{}", compiled);
-    }
-
-    Ok((compiled, catalog_id))
-}
-
-/// The Heed catalog is `prepare()`-d from `compiled` before being boxed so
-/// `ScanId → table-name` mappings are populated before the VM calls `create()`.
-fn build_exec_context(
-    db: Option<Arc<HeedDB>>,
-    catalog_id: CatalogId,
-    compiled: &partiql_eval::CompiledPlan,
-) -> ExecutionContext {
-    let mut exec_context = ExecutionContext::new();
-    exec_context.register_table_function("rand", Arc::new(common::RandTableFunction));
-    exec_context.register_table_function("mem", Arc::new(common::MemTableFunction));
-    exec_context.register_table_function("scan_ion", Arc::new(common::ScanIonTableFunction));
-
-    if let Some(db) = db {
-        let mut heed_exec = HeedExecutionCatalog::new(db);
-        let scans = compiled.scans_for_catalog(catalog_id);
-        heed_exec.prepare(&scans);
-        exec_context.add_catalog(catalog_id, Box::new(heed_exec));
-    }
-
-    exec_context
-}
-
-/// Buffered source rows plus the timing a write-path caller needs to finish its
-/// own exec timer: `(encoded rows, compile time, exec start instant)`.
-type DrainedSource = (Vec<Vec<u8>>, std::time::Duration, Instant);
-
-/// Compile the source plan, run it, and buffer every result row into owned
-/// bytes. The source is fully drained here — before any caller opens a write
-/// txn — because a streaming source holds a read txn open across iteration, and
-/// LMDB rejects opening a table handle in a write txn while one is live
-/// (MDB_BAD_DBI). Returns the buffered rows, the compile time, and the exec
-/// start instant so the caller can finish timing after its own write + commit.
-fn drain_source_rows(
-    query: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
-    debug: &DebugFlags,
-    db: &Arc<HeedDB>,
-) -> Result<DrainedSource, Box<dyn std::error::Error>> {
-    let compile_start = Instant::now();
-    let (compiled, catalog_id) = build_compiled(query, debug, Some(Arc::clone(db)))?;
-    let compile_time = compile_start.elapsed();
-
-    let exec_start = Instant::now();
-    let exec_context = build_exec_context(Some(Arc::clone(db)), catalog_id, &compiled);
-    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
-        .map_err(|e| format!("Execution setup error: {:?}", e))?;
-
-    // Snapshot RowShape before vm.execute() borrows the VM mutably.
-    let row_shape = vm.shape().row_shape().clone();
-
-    let mut rows: Vec<Vec<u8>> = Vec::new();
-    // Reused warm across rows (serialize_row clears on entry); each retained row
-    // is a tight clone (cap == len), so no per-row 4 KiB is held.
-    let mut scratch: Vec<u8> = Vec::with_capacity(4096);
-    match vm.execute() {
-        Ok(partiql_eval::ExecutionResult::Query(iter)) => {
-            // SAFETY: QueryIterator::next lifetime-extends its RegisterReader;
-            // aliasing across next() is UB. Consume `row` before the next pull.
-            for r in iter {
-                let row = r.map_err(|e| {
-                    format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
-                })?;
-                partiql_tools::row_codec::serialize_row(&row, &row_shape, &mut scratch)
-                    .map_err(|e| format!("Error: {}", StorageError::Codec(format!("{e}"))))?;
-                rows.push(scratch.clone());
-            }
-        }
-        Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
-    }
-    Ok((rows, compile_time, exec_start))
-}
-
-fn execute_query(
-    query_str: &str,
-    debug: &DebugFlags,
-    db: Option<Arc<HeedDB>>,
-    mode: OutputMode,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let parse_start = Instant::now();
-    let parsed = parse(query_str).map_err(|e| format!("Parse error: {:?}", e))?;
-    let parse_time = parse_start.elapsed();
-
-    if debug.ast {
-        eprintln!("[AST] {:?}", parsed);
-    }
-
-    // `exec` and the REPL run one statement at a time; a `;`-separated script is
-    // parsed with `parse_statements` and each statement run via `execute_statement`
-    // in a loop (see `bootstrap_v1`).
-    let stmt = match parsed.statements.as_slice() {
-        [stmt] => stmt,
-        // Wording matches `LogicalPlanner::lower` for parity across error sites.
-        _ => return Err("Lower error: multi-statement input".into()),
-    };
-    execute_statement(stmt, debug, db, mode, parse_time)
-}
-
-/// Execute a single already-parsed statement. Split from [`execute_query`] so a
-/// parsed script can dispatch each statement in a loop without re-parsing.
-fn execute_statement(
-    stmt: &partiql_ast::ast::AstNode<partiql_ast::ast::Statement>,
-    debug: &DebugFlags,
-    db: Option<Arc<HeedDB>>,
-    mode: OutputMode,
-    parse_time: std::time::Duration,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let catalog = create_table_fn_catalog();
-
-    let lower_start = Instant::now();
-    let statement =
-        lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;
-    let lower_time = lower_start.elapsed();
-
-    let logical = match statement {
-        LogicalStatement::Query(plan) => plan,
-        LogicalStatement::CreateTableAs { table_name, query } => {
-            let key = canonical_table_key(&table_name);
-
-            // Resolve --db before compile + VM setup so a missing flag fails
-            // cleanly before any expensive work.
-            let db = db
-                .as_ref()
-                .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?;
-
-            // Encode the catalog value before draining so a deterministic
-            // encode error fails fast, ahead of any query execution.
-            let mut tables_value = Vec::new();
-            partiql_tools::row_codec::serialize_name_row(&[&key], &mut tables_value)
-                .map_err(|e| format!("Error: {}", e))?;
-
-            let (rows, compile_time, exec_start) = drain_source_rows(&query, debug, db)?;
-
-            let n = {
-                let mut writer = db
-                    .create_table(&key, &tables_value)
-                    .map_err(|e| format!("Error: {}", e))?;
-                for encoded in &rows {
-                    writer
-                        .push_row(encoded)
-                        .map_err(|e| format!("Error: {}", e))?;
-                }
-                writer.commit().map_err(|e| format!("Error: {}", e))?
-            };
-            let exec_time = exec_start.elapsed();
-
-            if matches!(mode, OutputMode::User) {
-                eprintln!(
-                    "Created table {} ({} rows)",
-                    format_table_name(&table_name),
-                    n
-                );
-                print_write_footer(parse_time, lower_time, compile_time, exec_time);
-            }
-            return Ok(());
-        }
-        LogicalStatement::InsertInto { table_name, query } => {
-            let key = canonical_table_key(&table_name);
-
-            if partiql_tools::storage::is_system_table(&key) {
-                return Err("Error: cannot INSERT into system table '_tables'".into());
-            }
-
-            // Resolve --db before compile + VM setup so a missing flag fails
-            // cleanly before any expensive work.
-            let db = db
-                .as_ref()
-                .ok_or("Error: The `--db <PATH>` option is required for INSERT.")?;
-
-            let (rows, compile_time, exec_start) = drain_source_rows(&query, debug, db)?;
-
-            // Row count is tallied here, not from commit(): open_table_for_append
-            // seeds row_id at the high-water mark, so commit() returns the absolute
-            // counter (existing + inserted), not this statement's insert count.
-            let inserted = rows.len() as u64;
-            {
-                let mut writer = db
-                    .open_table_for_append(&key)
-                    .map_err(|e| format!("Error: {}", e))?;
-                for encoded in &rows {
-                    writer
-                        .push_row(encoded)
-                        .map_err(|e| format!("Error: {}", e))?;
-                }
-                writer.commit().map_err(|e| format!("Error: {}", e))?;
-            }
-            let exec_time = exec_start.elapsed();
-
-            if matches!(mode, OutputMode::User) {
-                eprintln!(
-                    "Inserted {} rows into {}",
-                    inserted,
-                    format_table_name(&table_name)
-                );
-                print_write_footer(parse_time, lower_time, compile_time, exec_time);
-            }
-            return Ok(());
-        }
-        LogicalStatement::CreateTable { table_name } => {
-            let key = canonical_table_key(&table_name);
-            let db = db
-                .as_ref()
-                .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE.")?;
-
-            // Bare `?` (not `.map_err(format!)`) so the typed StorageError /
-            // SerializeError boxes intact — the startup bootstrap downcasts to
-            // StorageError::TableExists to reconcile a crash-recovery re-run.
-            let mut tables_value = Vec::new();
-            partiql_tools::row_codec::serialize_name_row(&[&key], &mut tables_value)?;
-            let exec_start = Instant::now();
-            db.create_table(&key, &tables_value)?.commit()?;
-            let exec_time = exec_start.elapsed();
-
-            if matches!(mode, OutputMode::User) {
-                eprintln!("Created table {}", format_table_name(&table_name));
-                print_ddl_executed_footer(parse_time + lower_time + exec_time);
-            }
-            return Ok(());
-        }
-    };
-
-    let compile_start = Instant::now();
-    let (compiled, catalog_id) = build_compiled(&logical, debug, db.clone())?;
-    let compile_time = compile_start.elapsed();
-
-    let exec_start = Instant::now();
-    let exec_context = build_exec_context(db, catalog_id, &compiled);
-    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
-        .map_err(|e| format!("Execution setup error: {:?}", e))?;
-
-    let shape = vm.shape().clone();
-    let mut row_count = 0usize;
-
-    let (prefix, tab, suffix) = match shape {
-        Shape::Bag(_) => (Some("<<"), "  ", Some(">>")),
-        Shape::List(_) => (Some("["), "  ", Some("]")),
-        Shape::Single(_) => (None, "", None),
-    };
-
-    let user_output = matches!(mode, OutputMode::User);
-    let mut is_first = true;
-    match vm.execute() {
-        Ok(partiql_eval::ExecutionResult::Query(iter)) => {
-            if user_output {
-                if let Some(p) = prefix {
-                    println!("{}", p);
-                }
-            }
-            for row_result in iter {
-                match row_result {
-                    Ok(row) => {
-                        row_count += 1;
-                        if user_output {
-                            if is_first {
-                                is_first = false;
-                            } else {
-                                println!(",");
-                            }
-                            let value = row_to_value(&row, &shape);
-                            print!("{}", tab);
-                            print!("{:?}", value);
-                        }
-                    }
-                    Err(e) => {
-                        return Err(format!("Execution error: {:?}", e).into());
-                    }
-                }
-            }
-            if user_output {
-                println!();
-                if let Some(s) = suffix {
-                    println!("{}", s);
-                }
-            }
-        }
-        Err(e) => {
-            return Err(format!("Execution setup error: {:?}", e).into());
-        }
-    }
-    let exec_time = exec_start.elapsed();
-
-    if user_output {
-        let total_time = parse_time + lower_time + compile_time + exec_time;
-        eprintln!(
-            "({} rows in {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-            row_count,
-            total_time.as_secs_f64() * 1000.0,
-            parse_time.as_secs_f64() * 1000.0,
-            lower_time.as_secs_f64() * 1000.0,
-            compile_time.as_secs_f64() * 1000.0,
-            exec_time.as_secs_f64() * 1000.0,
-        );
-    }
-
-    Ok(())
-}
-
-fn row_to_value(
-    row: &partiql_eval::value::RegisterReader<'_>,
-    shape: &partiql_eval::value::Shape,
-) -> Value {
-    use partiql_eval::value::{FieldName, RowShape};
-
-    match shape.row_shape() {
-        RowShape::Struct(fields) => {
-            let mut tuple = Tuple::new();
-            for field in fields.iter() {
-                let name: &str = match &field.name {
-                    FieldName::Static(s) => s,
-                    FieldName::Register(reg) => row.get_str(*reg).unwrap_or("?"),
-                };
-                let reg_idx = match &field.value {
-                    RowShape::Register(idx, _) => *idx,
-                    _ => continue, // nested structs not yet supported here
-                };
-                let mut view = row.get_value_view(reg_idx).expect("register should exist");
-                tuple.insert(name, value_view_to_value(&mut view));
-            }
-            Value::Tuple(Box::new(tuple))
-        }
-        RowShape::Register(idx, _) => {
-            let mut view = row.get_value_view(*idx).expect("register should exist");
-            value_view_to_value(&mut view)
-        }
-    }
-}
-
-fn value_view_to_value(view: &mut partiql_eval::value::ValueView<'_>) -> Value {
-    use partiql_eval::value::ValueType;
-
-    match view.get_type() {
-        ValueType::Missing => Value::Missing,
-        ValueType::Null => Value::Null,
-        ValueType::Bool => Value::Boolean(view.get_bool().unwrap()),
-        ValueType::Integer => Value::Integer(view.get_i64().unwrap()),
-        ValueType::Decimal => Value::Decimal(Box::new(view.get_decimal().unwrap())),
-        ValueType::Float => Value::Real(view.get_f64().unwrap().into()),
-        ValueType::String => Value::String(Box::new(view.get_str().unwrap().to_string())),
-        ValueType::Bytes => Value::Blob(Box::new(view.get_bytes().unwrap().to_vec())),
-        ValueType::Tuple => {
-            let mut tuple = Tuple::new();
-            if view.step_in().is_ok() {
-                loop {
-                    let field_name = view.get_field_name().unwrap().to_string();
-                    let field_value = value_view_to_value(view);
-                    tuple.insert(&field_name, field_value);
-                    if !view.advance().unwrap_or(false) {
-                        break;
-                    }
-                }
-                let _ = view.step_out();
-            }
-            Value::Tuple(Box::new(tuple))
-        }
-        ValueType::List => {
-            let mut items = Vec::new();
-            if view.step_in().is_ok() {
-                loop {
-                    items.push(value_view_to_value(view));
-                    if !view.advance().unwrap_or(false) {
-                        break;
-                    }
-                }
-                let _ = view.step_out();
-            }
-            Value::List(Box::new(items.into()))
-        }
-        ValueType::Bag => {
-            let mut items = Vec::new();
-            if view.step_in().is_ok() {
-                loop {
-                    items.push(value_view_to_value(view));
-                    if !view.advance().unwrap_or(false) {
-                        break;
-                    }
-                }
-                let _ = view.step_out();
-            }
-            Value::Bag(Box::new(items.into()))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use partiql_value::BindingsName;
-    use std::borrow::Cow;
-
-    #[test]
-    fn canonical_key_folds_case_insensitive_to_lowercase() {
-        let n = BindingsName::CaseInsensitive(Cow::Borrowed("FOO"));
-        assert_eq!(canonical_table_key(&n), "foo");
-    }
-
-    #[test]
-    fn canonical_key_preserves_case_sensitive_verbatim() {
-        let n = BindingsName::CaseSensitive(Cow::Borrowed("Foo"));
-        assert_eq!(canonical_table_key(&n), "Foo");
-    }
-
-    #[test]
-    fn canonical_key_collides_bare_names_regardless_of_case() {
-        let a = BindingsName::CaseInsensitive(Cow::Borrowed("Foo"));
-        let b = BindingsName::CaseInsensitive(Cow::Borrowed("FOO"));
-        assert_eq!(canonical_table_key(&a), canonical_table_key(&b));
     }
 }

--- a/partiql-tools/src/bin/pqlite.rs
+++ b/partiql-tools/src/bin/pqlite.rs
@@ -1,8 +1,13 @@
 use std::borrow::Cow;
+use std::io::Write;
 
-use partiql_tools::session::{normalize_query, Commands, DebugFlags, OutputFormat, PqliteSession};
+use partiql_tools::session::{
+    flush_debug, normalize_query, render_outcome_ion, render_outcome_text,
+    render_query_footer_text, render_query_ion, render_query_text, Commands, DebugFlags,
+    OutputFormat, PqliteSession, RunOutcome,
+};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use reedline::{
     FileBackedHistory, History, Prompt, PromptEditMode, PromptHistorySearch, Reedline, Signal,
     ValidationResult, Validator,
@@ -25,12 +30,28 @@ struct Cli {
     #[arg(long, global = true, value_delimiter = ',')]
     debug: Vec<String>,
 
-    /// Path to the database file. The parent directory must already exist.
-    #[arg(long, global = true)]
-    db: Option<std::path::PathBuf>,
-
     #[command(subcommand)]
-    command: Option<Commands>,
+    command: CliCommand,
+}
+
+#[derive(Subcommand)]
+enum CliCommand {
+    /// Open a database file and start the interactive REPL.
+    Open {
+        /// Path to the database file. The parent directory must already exist.
+        db: std::path::PathBuf,
+    },
+    /// Execute a single query immediately, optionally against a database file.
+    Exec {
+        /// The PartiQL query string to run.
+        query: String,
+        /// Path to the database file. Omit for db-free queries.
+        #[arg(long)]
+        db: Option<std::path::PathBuf>,
+        /// Output format: `text` (default) or `ion`.
+        #[arg(long, default_value_t = OutputFormat::Text, value_enum)]
+        format: OutputFormat,
+    },
 }
 
 fn main() {
@@ -38,15 +59,15 @@ fn main() {
     let debug = DebugFlags::from_args(&cli.debug);
 
     match cli.command {
-        Some(Commands::Exec { query, format }) => {
+        CliCommand::Exec { query, db, format } => {
             // Reject empty query before opening the database so a `--db <path>`
             // invocation with a blank query does not create the file on disk.
             if normalize_query(&query).is_empty() {
                 eprintln!("Error: empty query");
                 std::process::exit(1);
             }
-            let cmd = Commands::Exec { query, format };
-            let session = match cli.db.as_deref() {
+            let cmd = Commands::Exec { query };
+            let session = match db.as_deref() {
                 Some(p) => match PqliteSession::open(p, debug) {
                     Ok(s) => s,
                     Err(e) => {
@@ -58,19 +79,55 @@ fn main() {
             };
             let mut stdout = std::io::stdout();
             let mut stderr = std::io::stderr();
-            if let Err(e) = session.run(&cmd, &mut stdout, &mut stderr) {
+            if let Err(e) = dispatch(&session, &cmd, format, &mut stdout, &mut stderr) {
                 eprintln!("{}", e);
                 std::process::exit(1);
             }
         }
-        None => {
-            // Require explicit --db rather than inventing a default path.
-            let db_path = cli.db.clone().unwrap_or_else(|| {
-                eprintln!("Error: The `--db <PATH>` option is required to open the database.");
-                std::process::exit(1);
-            });
+        CliCommand::Open { db } => run_repl(debug, &db),
+    }
+}
 
-            run_repl(debug, &db_path);
+/// Render a session outcome to `stdout`/`stderr`. Debug capture flushes to
+/// stderr BEFORE any query rows land on stdout so the ordering matches every
+/// `--debug` test expectation.
+fn dispatch(
+    session: &PqliteSession,
+    cmd: &Commands,
+    format: OutputFormat,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (result, on_error_capture) = session.run(cmd);
+    let outcome = match result {
+        Ok(o) => o,
+        Err(e) => {
+            flush_debug(&on_error_capture, stderr)?;
+            return Err(e);
+        }
+    };
+
+    match outcome {
+        RunOutcome::Query(mut handle) => {
+            flush_debug(&handle.take_debug(), stderr)?;
+            let ((), footer) = handle.drain(|rows, shape| match format {
+                OutputFormat::Text => render_query_text(rows, shape, stdout),
+                OutputFormat::Ion => render_query_ion(rows, shape, stdout),
+            })?;
+            // Ion mode is silent on stderr for successful queries; the caller
+            // pipes stdout to an Ion parser and expects no interleaved lines.
+            if !matches!(format, OutputFormat::Ion) {
+                render_query_footer_text(&footer, stderr)?;
+            }
+            Ok(())
+        }
+        RunOutcome::Statement(outcome) => {
+            flush_debug(outcome.debug(), stderr)?;
+            match format {
+                OutputFormat::Ion => render_outcome_ion(&outcome, stdout)?,
+                OutputFormat::Text => render_outcome_text(&outcome, stderr)?,
+            }
+            Ok(())
         }
     }
 }
@@ -193,7 +250,7 @@ fn print_startup_banner(db_path: &std::path::Path) {
     eprintln!("For usage information, enter \".help\".");
 }
 
-/// `exec_one` errors are reported but never terminate the session.
+/// Per-statement errors are reported but never terminate the session.
 fn run_repl(debug: DebugFlags, db_path: &std::path::Path) {
     // Hard-fail rather than fall back to in-memory: a silently non-persisting
     // db is worse than refusing to start.
@@ -242,9 +299,10 @@ fn run_repl(debug: DebugFlags, db_path: &std::path::Path) {
                 let mut stderr = std::io::stderr();
                 let cmd = Commands::Exec {
                     query: query.to_string(),
-                    format: OutputFormat::Text,
                 };
-                if let Err(e) = session.run(&cmd, &mut stdout, &mut stderr) {
+                if let Err(e) =
+                    dispatch(&session, &cmd, OutputFormat::Text, &mut stdout, &mut stderr)
+                {
                     eprintln!("{}", e);
                 }
             }

--- a/partiql-tools/src/lib.rs
+++ b/partiql-tools/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod common;
 pub mod row_codec;
+pub mod session;
 pub mod storage;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/partiql-tools/src/session.rs
+++ b/partiql-tools/src/session.rs
@@ -1,4 +1,8 @@
-//! Library-callable CLI logic for pqlite.
+//! Library-callable PartiQL session for pqlite.
+//!
+//! `session.run` returns a `RunOutcome` — either a `QueryHandle` for a live
+//! query, or a completed non-query `StatementOutcome`. Session does not write
+//! to stdout/stderr; callers render via the `render` module.
 
 mod bootstrap;
 mod debug;
@@ -7,34 +11,29 @@ mod ion_output;
 mod naming;
 mod outcome;
 mod planner;
+mod render;
 mod value;
 
-use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
 
-use clap::Subcommand;
-
 pub use crate::session::debug::DebugFlags;
+pub use crate::session::exec::{QueryFooter, QueryHandle, RunOutcome};
 pub use crate::session::naming::normalize_query;
-pub use crate::session::outcome::OutputFormat;
+pub use crate::session::outcome::{DebugCapture, OutputFormat, StatementOutcome, StatementTiming};
+pub use crate::session::render::{
+    flush_debug, render_outcome_ion, render_outcome_text, render_query_footer_text,
+    render_query_ion, render_query_text,
+};
 
-use crate::session::exec::RunResult;
-use crate::session::ion_output::write_outcome_ion;
-use crate::session::naming::format_table_name;
-use crate::session::outcome::{DebugCapture, StatementOutcome};
-
-/// Clap subcommands shared between the CLI and the test harness so both drive
-/// `run` through the same dispatch path.
-#[derive(Subcommand, Debug)]
+/// The unit of work `PqliteSession::run` dispatches on. Rendering choices
+/// (output format, timing footer, etc.) are the caller's — session only cares
+/// about the SQL.
+#[derive(Debug)]
 pub enum Commands {
-    /// Execute a single query immediately
     Exec {
-        /// The mandatory PartiQL query string to run
+        /// The mandatory PartiQL query string to run.
         query: String,
-        /// Output format: `text` (default) or `ion`
-        #[arg(long, default_value_t = OutputFormat::Text, value_enum)]
-        format: OutputFormat,
     },
 }
 
@@ -61,163 +60,31 @@ impl PqliteSession {
         PqliteSession { db: None, debug }
     }
 
-    /// Dispatch a parsed clap subcommand; the CLI and test harness share this entry.
+    /// Parse + lower + compile the statement and return a `RunOutcome`. For a
+    /// query, the caller drives the returned `QueryHandle`; for a write
+    /// statement, the outcome is already final.
+    ///
+    /// On error, the compile-time debug capture is returned alongside so the
+    /// caller can flush it (see `DebugCapture` doc).
     pub fn run(
         &self,
         command: &Commands,
-        out: &mut dyn Write,
-        err: &mut dyn Write,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> (Result<RunOutcome, Box<dyn std::error::Error>>, DebugCapture) {
         match command {
-            Commands::Exec { query, format } => self.run_exec(query, *format, out, err),
+            Commands::Exec { query } => exec::run(self.db.as_ref(), &self.debug, query),
         }
     }
 
-    /// Body/envelope to `out`, debug + timing to `err`. On Err, any captured
-    /// `--debug` output is still flushed to `err`.
-    pub fn run_exec(
-        &self,
-        sql: &str,
-        format: OutputFormat,
-        out: &mut dyn Write,
-        err: &mut dyn Write,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let (result, on_error_capture) =
-            exec::run(self.db.as_ref(), &self.debug, sql, format, out, err);
-        match result {
-            Ok(RunResult::Query { row_count, timing }) => {
-                // `--format ion` stays silent on stderr for successful queries.
-                if !matches!(format, OutputFormat::Ion) {
-                    write_timing_line(
-                        err,
-                        &format!("{row_count} rows in"),
-                        timing.parse,
-                        timing.lower,
-                        timing.compile,
-                        timing.exec,
-                    )?;
-                }
-                Ok(())
-            }
-            Ok(RunResult::NonQuery(outcome)) => {
-                flush_debug(outcome.debug(), err)?;
-                if let OutputFormat::Ion = format {
-                    write_outcome_ion(&outcome, out)?;
-                } else {
-                    render_non_query_text(&outcome, err)?;
-                }
-                Ok(())
-            }
-            Err(e) => {
-                flush_debug(&on_error_capture, err)?;
-                Err(e)
-            }
-        }
+    pub fn debug_flags(&self) -> &DebugFlags {
+        &self.debug
     }
-}
-
-fn render_non_query_text(outcome: &StatementOutcome, err: &mut dyn Write) -> std::io::Result<()> {
-    match outcome {
-        StatementOutcome::CreateTableAs {
-            table_name,
-            rows,
-            timing,
-            ..
-        } => {
-            writeln!(
-                err,
-                "Created table {} ({} rows)",
-                format_table_name(table_name),
-                rows
-            )?;
-            write_timing_line(
-                err,
-                "took",
-                timing.parse,
-                timing.lower,
-                timing.compile,
-                timing.exec,
-            )?;
-        }
-        StatementOutcome::InsertInto {
-            table_name,
-            rows,
-            timing,
-            ..
-        } => {
-            writeln!(
-                err,
-                "Inserted {} rows into {}",
-                rows,
-                format_table_name(table_name)
-            )?;
-            write_timing_line(
-                err,
-                "took",
-                timing.parse,
-                timing.lower,
-                timing.compile,
-                timing.exec,
-            )?;
-        }
-        StatementOutcome::CreateTable {
-            table_name, timing, ..
-        } => {
-            writeln!(err, "Created table {}", format_table_name(table_name))?;
-            write_timing_line(
-                err,
-                "took",
-                timing.parse,
-                timing.lower,
-                timing.compile,
-                timing.exec,
-            )?;
-        }
-    }
-    err.flush()?;
-    Ok(())
-}
-
-pub(super) fn flush_debug(debug: &DebugCapture, err: &mut dyn Write) -> std::io::Result<()> {
-    if let Some(ast) = &debug.ast {
-        writeln!(err, "{}", ast)?;
-    }
-    if let Some(plan) = &debug.plan {
-        writeln!(err, "{}", plan)?;
-    }
-    if let Some(program) = &debug.program {
-        writeln!(err, "{}", program)?;
-    }
-    err.flush()?;
-    Ok(())
-}
-
-/// `(<prefix> Xms — parse: ..., lower: ..., compile: ..., exec: ...)` line.
-fn write_timing_line(
-    err: &mut dyn Write,
-    prefix: &str,
-    parse: std::time::Duration,
-    lower: std::time::Duration,
-    compile: std::time::Duration,
-    exec: std::time::Duration,
-) -> std::io::Result<()> {
-    let total = parse + lower + compile + exec;
-    writeln!(
-        err,
-        "({} {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
-        prefix,
-        total.as_secs_f64() * 1000.0,
-        parse.as_secs_f64() * 1000.0,
-        lower.as_secs_f64() * 1000.0,
-        compile.as_secs_f64() * 1000.0,
-        exec.as_secs_f64() * 1000.0,
-    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// End-to-end: a lower error must still flush its captured AST.
     #[test]
     fn ast_capture_flushed_on_lower_error() {
         let session = PqliteSession::open_without_db(DebugFlags {
@@ -225,25 +92,22 @@ mod tests {
             plan: false,
             program: false,
         });
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let result = session.run_exec(
-            "SELECT * FROM does_not_exist_table",
-            OutputFormat::Ion,
-            &mut out,
-            &mut err,
-        );
-        assert!(result.is_err(), "lower/exec must fail: {result:?}");
-        let stderr = String::from_utf8_lossy(&err);
+        let cmd = Commands::Exec {
+            query: "SELECT * FROM does_not_exist_table".to_string(),
+        };
+        let (result, on_error_capture) = session.run(&cmd);
+        assert!(result.is_err(), "lower/exec must fail");
+        let mut stderr = Vec::new();
+        flush_debug(&on_error_capture, &mut stderr).unwrap();
+        let text = String::from_utf8_lossy(&stderr);
         assert!(
-            stderr.contains("[AST]"),
-            "captured AST must be flushed on error; stderr was: {stderr}"
+            text.contains("[AST]"),
+            "captured AST must be present on error; stderr was: {text}"
         );
     }
 
-    /// Covers three invariants of the streaming-Ion Query path:
-    /// envelope on stdout, `--debug ast` on stderr, and >1 write() call per
-    /// large result (streaming, not buffered).
+    /// Streaming Ion query: envelope on stdout, debug on stderr (before rows),
+    /// and many writes rather than one (streaming, not buffered).
     #[test]
     fn streaming_ion_query_end_to_end() {
         struct CountingWriter {
@@ -267,107 +131,60 @@ mod tests {
         });
         let elems: Vec<String> = (0..50).map(|i| format!("{{'n':{}}}", i)).collect();
         let sql = format!("SELECT VALUE t.n FROM << {} >> t", elems.join(", "));
-        let mut out = CountingWriter {
-            calls: 0,
-            buf: Vec::new(),
-        };
-        let mut err = Vec::new();
-        session
-            .run(
-                &Commands::Exec {
-                    query: sql,
-                    format: OutputFormat::Ion,
-                },
-                &mut out,
-                &mut err,
-            )
-            .unwrap();
+        let cmd = Commands::Exec { query: sql };
 
-        let body = String::from_utf8_lossy(&out.buf);
-        assert!(
-            body.contains("$partiql_bag") || body.contains("$bag"),
-            "expected an Ion envelope on stdout, got: {body}"
-        );
-        let stderr = String::from_utf8_lossy(&err);
-        assert!(
-            stderr.contains("[AST]"),
-            "AST must flush to stderr even with --format ion; stderr was: {stderr}"
-        );
-        assert!(
-            out.calls > 5,
-            "streaming should issue many write() calls, got {} (bytes: {})",
-            out.calls,
-            out.buf.len()
-        );
+        let (result, _err_capture) = session.run(&cmd);
+        let outcome = result.expect("run must succeed");
+        match outcome {
+            RunOutcome::Query(mut handle) => {
+                let mut stderr = Vec::new();
+                flush_debug(&handle.take_debug(), &mut stderr).unwrap();
+                let mut out = CountingWriter {
+                    calls: 0,
+                    buf: Vec::new(),
+                };
+                let ((), footer) = handle
+                    .drain(|rows, shape| render_query_ion(rows, shape, &mut out))
+                    .expect("render must succeed");
+                assert_eq!(footer.row_count, 50, "row count should equal source rows");
+                let body = String::from_utf8_lossy(&out.buf);
+                assert!(
+                    body.contains("$partiql_bag") || body.contains("$bag"),
+                    "expected an Ion envelope on stdout, got: {body}"
+                );
+                let stderr = String::from_utf8_lossy(&stderr);
+                assert!(
+                    stderr.contains("[AST]"),
+                    "AST must flush before rows; stderr was: {stderr}"
+                );
+                assert!(
+                    out.calls > 5,
+                    "streaming should issue many write() calls, got {} (bytes: {})",
+                    out.calls,
+                    out.buf.len()
+                );
+            }
+            RunOutcome::Statement(_) => panic!("expected Query"),
+        }
     }
 
+    /// Parse-error path returns no capture: parsing happens before the AST
+    /// capture step, so on parse failure we have nothing to flush.
     #[test]
-    fn flush_debug_and_text_paths_flush_explicitly() {
-        // A writer that counts flush() calls: if the code paths never flush,
-        // this catches it (block-buffered stdout can otherwise outrun stderr
-        // ordering with no test-visible signal).
-        struct FlushCounter {
-            flushes: usize,
-            buf: Vec<u8>,
-        }
-        impl std::io::Write for FlushCounter {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.buf.extend_from_slice(buf);
-                Ok(buf.len())
-            }
-            fn flush(&mut self) -> std::io::Result<()> {
-                self.flushes += 1;
-                Ok(())
-            }
-        }
-        let session = PqliteSession::open_without_db(DebugFlags {
-            ast: true,
-            plan: false,
-            program: false,
-        });
-        let cmd = Commands::Exec {
-            query: "SELECT * FROM << {'a': 1} >>".to_string(),
-            format: OutputFormat::Text,
-        };
-        let mut out = FlushCounter {
-            flushes: 0,
-            buf: Vec::new(),
-        };
-        let mut err = FlushCounter {
-            flushes: 0,
-            buf: Vec::new(),
-        };
-        session.run(&cmd, &mut out, &mut err).unwrap();
-        assert!(
-            out.flushes >= 1,
-            "text stdout must flush at end of stream_query_text"
-        );
-        assert!(
-            err.flushes >= 1,
-            "err path must flush (debug capture + footer)"
-        );
-    }
-
-    #[test]
-    fn no_debug_output_on_parse_error() {
+    fn no_debug_capture_on_parse_error() {
         let session = PqliteSession::open_without_db(DebugFlags {
             ast: true,
             plan: true,
             program: true,
         });
-        let mut out = Vec::new();
-        let mut err = Vec::new();
-        let result = session.run_exec(
-            "SELECT * FROM x WHERE",
-            OutputFormat::Ion,
-            &mut out,
-            &mut err,
-        );
+        let cmd = Commands::Exec {
+            query: "SELECT * FROM x WHERE".to_string(),
+        };
+        let (result, capture) = session.run(&cmd);
         assert!(result.is_err());
         assert!(
-            err.is_empty(),
-            "no capture should exist yet, err was: {:?}",
-            String::from_utf8_lossy(&err)
+            capture.ast.is_none() && capture.plan.is_none() && capture.program.is_none(),
+            "no capture should be built on parse error"
         );
     }
 }

--- a/partiql-tools/src/session.rs
+++ b/partiql-tools/src/session.rs
@@ -1,0 +1,373 @@
+//! Library-callable CLI logic for pqlite.
+
+mod bootstrap;
+mod debug;
+mod exec;
+mod ion_output;
+mod naming;
+mod outcome;
+mod planner;
+mod value;
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use clap::Subcommand;
+
+pub use crate::session::debug::DebugFlags;
+pub use crate::session::naming::normalize_query;
+pub use crate::session::outcome::OutputFormat;
+
+use crate::session::exec::RunResult;
+use crate::session::ion_output::write_outcome_ion;
+use crate::session::naming::format_table_name;
+use crate::session::outcome::{DebugCapture, StatementOutcome};
+
+/// Clap subcommands shared between the CLI and the test harness so both drive
+/// `run` through the same dispatch path.
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Execute a single query immediately
+    Exec {
+        /// The mandatory PartiQL query string to run
+        query: String,
+        /// Output format: `text` (default) or `ion`
+        #[arg(long, default_value_t = OutputFormat::Text, value_enum)]
+        format: OutputFormat,
+    },
+}
+
+use crate::storage::HeedDB;
+
+/// A stateful pqlite session: an optionally-open database plus debug settings.
+pub struct PqliteSession {
+    db: Option<Arc<HeedDB>>,
+    debug: DebugFlags,
+}
+
+impl PqliteSession {
+    /// Open the database at `db_path`, bootstrapping it to the current schema.
+    pub fn open(db_path: &Path, debug: DebugFlags) -> Result<Self, Box<dyn std::error::Error>> {
+        let db = bootstrap::open_and_bootstrap(db_path)?;
+        Ok(PqliteSession {
+            db: Some(db),
+            debug,
+        })
+    }
+
+    /// A session with no database (lazy-open): only db-free queries succeed.
+    pub fn open_without_db(debug: DebugFlags) -> Self {
+        PqliteSession { db: None, debug }
+    }
+
+    /// Dispatch a parsed clap subcommand; the CLI and test harness share this entry.
+    pub fn run(
+        &self,
+        command: &Commands,
+        out: &mut dyn Write,
+        err: &mut dyn Write,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match command {
+            Commands::Exec { query, format } => self.run_exec(query, *format, out, err),
+        }
+    }
+
+    /// Body/envelope to `out`, debug + timing to `err`. On Err, any captured
+    /// `--debug` output is still flushed to `err`.
+    pub fn run_exec(
+        &self,
+        sql: &str,
+        format: OutputFormat,
+        out: &mut dyn Write,
+        err: &mut dyn Write,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (result, on_error_capture) =
+            exec::run(self.db.as_ref(), &self.debug, sql, format, out, err);
+        match result {
+            Ok(RunResult::Query { row_count, timing }) => {
+                // `--format ion` stays silent on stderr for successful queries.
+                if !matches!(format, OutputFormat::Ion) {
+                    write_timing_line(
+                        err,
+                        &format!("{row_count} rows in"),
+                        timing.parse,
+                        timing.lower,
+                        timing.compile,
+                        timing.exec,
+                    )?;
+                }
+                Ok(())
+            }
+            Ok(RunResult::NonQuery(outcome)) => {
+                flush_debug(outcome.debug(), err)?;
+                if let OutputFormat::Ion = format {
+                    write_outcome_ion(&outcome, out)?;
+                } else {
+                    render_non_query_text(&outcome, err)?;
+                }
+                Ok(())
+            }
+            Err(e) => {
+                flush_debug(&on_error_capture, err)?;
+                Err(e)
+            }
+        }
+    }
+}
+
+fn render_non_query_text(outcome: &StatementOutcome, err: &mut dyn Write) -> std::io::Result<()> {
+    match outcome {
+        StatementOutcome::CreateTableAs {
+            table_name,
+            rows,
+            timing,
+            ..
+        } => {
+            writeln!(
+                err,
+                "Created table {} ({} rows)",
+                format_table_name(table_name),
+                rows
+            )?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+        StatementOutcome::InsertInto {
+            table_name,
+            rows,
+            timing,
+            ..
+        } => {
+            writeln!(
+                err,
+                "Inserted {} rows into {}",
+                rows,
+                format_table_name(table_name)
+            )?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+        StatementOutcome::CreateTable {
+            table_name, timing, ..
+        } => {
+            writeln!(err, "Created table {}", format_table_name(table_name))?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+    }
+    err.flush()?;
+    Ok(())
+}
+
+pub(super) fn flush_debug(debug: &DebugCapture, err: &mut dyn Write) -> std::io::Result<()> {
+    if let Some(ast) = &debug.ast {
+        writeln!(err, "{}", ast)?;
+    }
+    if let Some(plan) = &debug.plan {
+        writeln!(err, "{}", plan)?;
+    }
+    if let Some(program) = &debug.program {
+        writeln!(err, "{}", program)?;
+    }
+    err.flush()?;
+    Ok(())
+}
+
+/// `(<prefix> Xms — parse: ..., lower: ..., compile: ..., exec: ...)` line.
+fn write_timing_line(
+    err: &mut dyn Write,
+    prefix: &str,
+    parse: std::time::Duration,
+    lower: std::time::Duration,
+    compile: std::time::Duration,
+    exec: std::time::Duration,
+) -> std::io::Result<()> {
+    let total = parse + lower + compile + exec;
+    writeln!(
+        err,
+        "({} {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
+        prefix,
+        total.as_secs_f64() * 1000.0,
+        parse.as_secs_f64() * 1000.0,
+        lower.as_secs_f64() * 1000.0,
+        compile.as_secs_f64() * 1000.0,
+        exec.as_secs_f64() * 1000.0,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ast_capture_flushed_on_lower_error() {
+        let session = PqliteSession::open_without_db(DebugFlags {
+            ast: true,
+            plan: false,
+            program: false,
+        });
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = session.run_exec(
+            "SELECT * FROM does_not_exist_table",
+            OutputFormat::Ion,
+            &mut out,
+            &mut err,
+        );
+        assert!(result.is_err(), "lower/exec must fail: {result:?}");
+        let stderr = String::from_utf8_lossy(&err);
+        assert!(
+            stderr.contains("[AST]"),
+            "captured AST must be flushed on error; stderr was: {stderr}"
+        );
+    }
+
+    /// Covers three invariants of the streaming-Ion Query path:
+    /// envelope on stdout, `--debug ast` on stderr, and >1 write() call per
+    /// large result (streaming, not buffered).
+    #[test]
+    fn streaming_ion_query_end_to_end() {
+        struct CountingWriter {
+            calls: usize,
+            buf: Vec<u8>,
+        }
+        impl std::io::Write for CountingWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.calls += 1;
+                self.buf.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let session = PqliteSession::open_without_db(DebugFlags {
+            ast: true,
+            plan: false,
+            program: false,
+        });
+        let elems: Vec<String> = (0..50).map(|i| format!("{{'n':{}}}", i)).collect();
+        let sql = format!("SELECT VALUE t.n FROM << {} >> t", elems.join(", "));
+        let mut out = CountingWriter {
+            calls: 0,
+            buf: Vec::new(),
+        };
+        let mut err = Vec::new();
+        session
+            .run(
+                &Commands::Exec {
+                    query: sql,
+                    format: OutputFormat::Ion,
+                },
+                &mut out,
+                &mut err,
+            )
+            .unwrap();
+
+        let body = String::from_utf8_lossy(&out.buf);
+        assert!(
+            body.contains("$partiql_bag") || body.contains("$bag"),
+            "expected an Ion envelope on stdout, got: {body}"
+        );
+        let stderr = String::from_utf8_lossy(&err);
+        assert!(
+            stderr.contains("[AST]"),
+            "AST must flush to stderr even with --format ion; stderr was: {stderr}"
+        );
+        assert!(
+            out.calls > 5,
+            "streaming should issue many write() calls, got {} (bytes: {})",
+            out.calls,
+            out.buf.len()
+        );
+    }
+
+    #[test]
+    fn flush_debug_and_text_paths_flush_explicitly() {
+        // A writer that counts flush() calls: if the code paths never flush,
+        // this catches it (block-buffered stdout can otherwise outrun stderr
+        // ordering with no test-visible signal).
+        struct FlushCounter {
+            flushes: usize,
+            buf: Vec<u8>,
+        }
+        impl std::io::Write for FlushCounter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.buf.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                self.flushes += 1;
+                Ok(())
+            }
+        }
+        let session = PqliteSession::open_without_db(DebugFlags {
+            ast: true,
+            plan: false,
+            program: false,
+        });
+        let cmd = Commands::Exec {
+            query: "SELECT * FROM << {'a': 1} >>".to_string(),
+            format: OutputFormat::Text,
+        };
+        let mut out = FlushCounter {
+            flushes: 0,
+            buf: Vec::new(),
+        };
+        let mut err = FlushCounter {
+            flushes: 0,
+            buf: Vec::new(),
+        };
+        session.run(&cmd, &mut out, &mut err).unwrap();
+        assert!(
+            out.flushes >= 1,
+            "text stdout must flush at end of stream_query_text"
+        );
+        assert!(
+            err.flushes >= 1,
+            "err path must flush (debug capture + footer)"
+        );
+    }
+
+    #[test]
+    fn no_debug_output_on_parse_error() {
+        let session = PqliteSession::open_without_db(DebugFlags {
+            ast: true,
+            plan: true,
+            program: true,
+        });
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = session.run_exec(
+            "SELECT * FROM x WHERE",
+            OutputFormat::Ion,
+            &mut out,
+            &mut err,
+        );
+        assert!(result.is_err());
+        assert!(
+            err.is_empty(),
+            "no capture should exist yet, err was: {:?}",
+            String::from_utf8_lossy(&err)
+        );
+    }
+}

--- a/partiql-tools/src/session/bootstrap.rs
+++ b/partiql-tools/src/session/bootstrap.rs
@@ -1,0 +1,81 @@
+//! DB open + schema migration ladder. Callers (CLI, tests) go through
+//! `open_and_bootstrap`; direct construction is disallowed.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::common::parse_statements;
+use crate::session::debug::DebugFlags;
+use crate::session::exec;
+use crate::storage::{HeedDB, StorageError};
+
+/// The schema version this binary bootstraps to and requires.
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Open the DB and bring it to CURRENT_SCHEMA_VERSION. Idempotent + crash-safe.
+pub(super) fn open_and_bootstrap(path: &Path) -> Result<Arc<HeedDB>, Box<dyn std::error::Error>> {
+    let db = Arc::new(HeedDB::open(path)?);
+    let version = db.read_schema_version()?;
+    if version > CURRENT_SCHEMA_VERSION {
+        return Err(format!(
+            "database schema version {version} is newer than this binary \
+             supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
+        )
+        .into());
+    }
+    // A stamped current version must satisfy its postcondition (one extra
+    // catalog lookup at startup — a deliberate integrity check).
+    if version == CURRENT_SCHEMA_VERSION && !db.tables_has_self_entry()? {
+        return Err("database reports schema version 1 but the _tables catalog \
+                    is missing or incomplete"
+            .into());
+    }
+    // Migration ladder: each future migration is its own `version < N` block
+    // that stamps N, so an older DB runs every step in order. Bumping
+    // CURRENT_SCHEMA_VERSION alone is not enough — add a block.
+    if version < 1 {
+        bootstrap_v1(&db)?;
+        let stamped = db.set_schema_version(1)?;
+        // Guards a concurrent writer that stamped a newer version between our
+        // read above and this stamp; monotonic set returns that higher version.
+        if stamped > CURRENT_SCHEMA_VERSION {
+            return Err(format!(
+                "database schema version {stamped} is newer than this binary \
+                 supports ({CURRENT_SCHEMA_VERSION}); upgrade pqlite"
+            )
+            .into());
+        }
+    }
+    Ok(db)
+}
+
+/// Run the v1 bootstrap script. The `;`-separated script is parsed as a unit
+/// and each statement executed in order. Idempotent: a crash-recovery DB whose
+/// _tables already exists yields a typed StorageError::TableExists, reconciled
+/// against the self-entry; any other error propagates.
+fn bootstrap_v1(db: &Arc<HeedDB>) -> Result<(), Box<dyn std::error::Error>> {
+    // include_str! resolves relative to this file's directory (src/session/),
+    // which is the same depth as the old bin (src/bin/); the path is unchanged.
+    let script = include_str!("../bootstrap/v1.pql");
+    let debug = DebugFlags::from_args(&[]);
+    let parsed = parse_statements(script).map_err(|e| format!("Parse error: {:?}", e))?;
+    for stmt in &parsed.statements {
+        // Bootstrap statements run muted: no timing footer, no captured debug.
+        match exec::execute_statement_silent(stmt, &debug, Arc::clone(db)) {
+            Ok(()) => {}
+            Err(e) => {
+                let is_self_tables_exists = e
+                    .downcast_ref::<StorageError>()
+                    .map(|se| matches!(se, StorageError::TableExists(n) if n == "_tables"))
+                    .unwrap_or(false);
+                // Crash-recovery: _tables already created on a prior run. Skip and
+                // continue; any other error is real and aborts bootstrap.
+                if is_self_tables_exists && db.tables_has_self_entry()? {
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
+}

--- a/partiql-tools/src/session/debug.rs
+++ b/partiql-tools/src/session/debug.rs
@@ -1,0 +1,20 @@
+//! Debug flag parsing from CLI args. Bin-side accessor into what statements
+//! do (ast/plan/program) — used by both the CLI and the test harness.
+
+#[derive(Debug, Default, Clone)]
+pub struct DebugFlags {
+    pub ast: bool,
+    pub plan: bool,
+    pub program: bool,
+}
+
+impl DebugFlags {
+    pub fn from_args(args: &[String]) -> Self {
+        let all = args.iter().any(|s| s == "*");
+        DebugFlags {
+            ast: all || args.iter().any(|s| s == "ast"),
+            plan: all || args.iter().any(|s| s == "plan"),
+            program: all || args.iter().any(|s| s == "program"),
+        }
+    }
+}

--- a/partiql-tools/src/session/exec.rs
+++ b/partiql-tools/src/session/exec.rs
@@ -1,0 +1,372 @@
+//! Parse + lower + compile + execute one statement.
+//!
+//! SELECT streams row-by-row into `out`; non-query statements buffer a small
+//! `StatementOutcome` for the caller to render.
+
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use partiql_ast::ast;
+use partiql_eval::value::Shape;
+use partiql_logical::{BindingsOp, LogicalPlan, LogicalStatement};
+
+use crate::common;
+use crate::session::debug::DebugFlags;
+use crate::session::ion_output::stream_query_ion;
+use crate::session::naming::{canonical_table_key, normalize_query};
+use crate::session::outcome::{DebugCapture, OutputFormat, StatementOutcome, StatementTiming};
+use crate::session::planner;
+use crate::session::value;
+use crate::storage::{self, HeedDB};
+
+/// What `exec::run` streamed to `out`. Query rows are already on the wire; the
+/// caller only needs count + timing for the footer. Non-query outcomes carry
+/// their own metadata for the caller to render.
+pub(super) enum RunResult {
+    Query {
+        row_count: u64,
+        timing: StatementTiming,
+    },
+    NonQuery(StatementOutcome),
+}
+
+struct StatementCtx<'a> {
+    debug: &'a DebugFlags,
+    db: Option<&'a Arc<HeedDB>>,
+    parse_time: Duration,
+    lower_time: Duration,
+    capture: &'a mut DebugCapture,
+}
+
+impl StatementCtx<'_> {
+    fn timing(&self, compile: Duration, exec: Duration) -> StatementTiming {
+        StatementTiming {
+            parse: self.parse_time,
+            lower: self.lower_time,
+            compile,
+            exec,
+        }
+    }
+}
+
+/// Parse + lower + dispatch. On the Query path, AST/plan/program flush to
+/// `err` BEFORE row iteration so debug precedes results (dev parity). On Err,
+/// any capture built up so far is returned in the second position.
+pub(super) fn run(
+    db: Option<&Arc<HeedDB>>,
+    debug: &DebugFlags,
+    sql: &str,
+    format: OutputFormat,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
+) -> (Result<RunResult, Box<dyn std::error::Error>>, DebugCapture) {
+    let sql = normalize_query(sql);
+    if sql.is_empty() {
+        return (Err("empty query".into()), DebugCapture::default());
+    }
+
+    let parse_start = Instant::now();
+    let parsed = match common::parse(sql) {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                Err(format!("Parse error: {:?}", e).into()),
+                DebugCapture::default(),
+            );
+        }
+    };
+    let parse_time = parse_start.elapsed();
+
+    let mut capture = DebugCapture::default();
+    if debug.ast {
+        capture.ast = Some(format!("[AST] {parsed:?}"));
+    }
+
+    let stmt = match parsed.statements.first() {
+        Some(s) => s,
+        None => return (Err("no statements after parse".into()), capture),
+    };
+
+    match dispatch(stmt, debug, db, parse_time, &mut capture, format, out, err) {
+        Ok(res) => (Ok(res), DebugCapture::default()),
+        Err(e) => (Err(e), capture),
+    }
+}
+
+/// Bootstrap entry: no debug capture, no rendering. Query statements route
+/// their output to `io::sink()` so future SELECTs in the bootstrap script
+/// don't brick startup.
+pub(super) fn execute_statement_silent(
+    stmt: &ast::AstNode<ast::Statement>,
+    debug: &DebugFlags,
+    db: Arc<HeedDB>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut capture = DebugCapture::default();
+    let catalog = common::create_table_fn_catalog();
+    let statement =
+        common::lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;
+
+    let mut ctx = StatementCtx {
+        debug,
+        db: Some(&db),
+        parse_time: Duration::ZERO,
+        lower_time: Duration::ZERO,
+        capture: &mut capture,
+    };
+
+    match statement {
+        LogicalStatement::Query(plan) => {
+            let mut sink_out = std::io::sink();
+            let mut sink_err = std::io::sink();
+            stream_query(
+                plan,
+                &mut ctx,
+                OutputFormat::Text,
+                &mut sink_out,
+                &mut sink_err,
+            )
+            .map(|_| ())
+        }
+        other => dispatch_write(other, &mut ctx).map(|_| ()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch(
+    stmt: &ast::AstNode<ast::Statement>,
+    debug: &DebugFlags,
+    db: Option<&Arc<HeedDB>>,
+    parse_time: Duration,
+    capture: &mut DebugCapture,
+    format: OutputFormat,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
+) -> Result<RunResult, Box<dyn std::error::Error>> {
+    let catalog = common::create_table_fn_catalog();
+
+    let lower_start = Instant::now();
+    let statement =
+        common::lower_statement(&*catalog, stmt).map_err(|e| format!("Lower error: {:?}", e))?;
+    let lower_time = lower_start.elapsed();
+
+    let mut ctx = StatementCtx {
+        debug,
+        db,
+        parse_time,
+        lower_time,
+        capture,
+    };
+
+    match statement {
+        LogicalStatement::Query(plan) => stream_query(plan, &mut ctx, format, out, err),
+        other => dispatch_write(other, &mut ctx).map(RunResult::NonQuery),
+    }
+}
+
+/// Non-query dispatch. Callers must have handled `Query` first.
+fn dispatch_write(
+    statement: LogicalStatement,
+    ctx: &mut StatementCtx<'_>,
+) -> Result<StatementOutcome, Box<dyn std::error::Error>> {
+    match statement {
+        LogicalStatement::Query(_) => Err("dispatch_write called with a Query statement".into()),
+        LogicalStatement::CreateTableAs { table_name, query } => exec_ctas(table_name, query, ctx),
+        LogicalStatement::InsertInto { table_name, query } => exec_insert(table_name, query, ctx),
+        LogicalStatement::CreateTable { table_name } => exec_create_table(table_name, ctx),
+    }
+}
+
+fn stream_query(
+    plan: LogicalPlan<BindingsOp>,
+    ctx: &mut StatementCtx<'_>,
+    format: OutputFormat,
+    out: &mut dyn Write,
+    err: &mut dyn Write,
+) -> Result<RunResult, Box<dyn std::error::Error>> {
+    let compile_start = Instant::now();
+    let (compiled, catalog_id) =
+        planner::build_compiled(&plan, ctx.debug, ctx.db.cloned(), ctx.capture)?;
+    let compile_time = compile_start.elapsed();
+
+    let exec_start = Instant::now();
+    let exec_context = planner::build_exec_context(ctx.db.cloned(), catalog_id, &compiled);
+    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+        .map_err(|e| format!("Execution setup error: {:?}", e))?;
+    let shape = vm.shape().clone();
+
+    // Flush AST/plan/program NOW so debug on stderr precedes results on stdout.
+    crate::session::flush_debug(ctx.capture, err)?;
+    *ctx.capture = DebugCapture::default();
+
+    let row_count = match vm.execute() {
+        Ok(partiql_eval::ExecutionResult::Query(iter)) => match format {
+            OutputFormat::Text => stream_query_text(iter, &shape, out)?,
+            OutputFormat::Ion => stream_query_ion(iter, &shape, out)?,
+        },
+        Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
+    };
+    let exec_time = exec_start.elapsed();
+
+    Ok(RunResult::Query {
+        row_count,
+        timing: StatementTiming {
+            parse: ctx.parse_time,
+            lower: ctx.lower_time,
+            compile: compile_time,
+            exec: exec_time,
+        },
+    })
+}
+
+/// Human-readable text: `<<\n  <row>,\n  ...\n>>\n` for Bag, `[`/`]` for List,
+/// bare `{value:?}` for Single.
+fn stream_query_text(
+    iter: partiql_eval::QueryIterator<'_>,
+    shape: &Shape,
+    out: &mut dyn Write,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    let (prefix, tab, suffix) = match shape {
+        Shape::Bag(_) => (Some("<<"), "  ", Some(">>")),
+        Shape::List(_) => (Some("["), "  ", Some("]")),
+        Shape::Single(_) => (None, "", None),
+    };
+    if let Some(p) = prefix {
+        writeln!(out, "{}", p)?;
+    }
+
+    let mut count: u64 = 0;
+    let mut is_first = true;
+    for row_result in iter {
+        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
+        let v = value::row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
+        if is_first {
+            is_first = false;
+        } else {
+            writeln!(out, ",")?;
+        }
+        write!(out, "{tab}{v:?}")?;
+        count += 1;
+    }
+    writeln!(out)?;
+    if let Some(s) = suffix {
+        writeln!(out, "{}", s)?;
+    }
+    out.flush()?;
+    Ok(count)
+}
+
+fn exec_ctas(
+    table_name: partiql_value::BindingsName<'static>,
+    query: LogicalPlan<BindingsOp>,
+    ctx: &mut StatementCtx<'_>,
+) -> Result<StatementOutcome, Box<dyn std::error::Error>> {
+    let key = canonical_table_key(&table_name);
+
+    // Resolve --db before compile + VM setup so a missing flag fails
+    // cleanly before any expensive work.
+    let db = ctx
+        .db
+        .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE AS.")?;
+
+    // Encode the catalog value before draining so a deterministic encode error
+    // fails fast, ahead of any query execution.
+    let mut tables_value = Vec::new();
+    crate::row_codec::serialize_name_row(&[&key], &mut tables_value)
+        .map_err(|e| format!("Error: {}", e))?;
+
+    let (rows, compile_time, exec_start) =
+        planner::drain_source_rows(&query, ctx.debug, db, ctx.capture)?;
+
+    let n = {
+        let mut writer = db
+            .create_table(&key, &tables_value)
+            .map_err(|e| format!("Error: {}", e))?;
+        for encoded in &rows {
+            writer
+                .push_row(encoded)
+                .map_err(|e| format!("Error: {}", e))?;
+        }
+        writer.commit().map_err(|e| format!("Error: {}", e))?
+    };
+    let exec_time = exec_start.elapsed();
+
+    Ok(StatementOutcome::CreateTableAs {
+        table_name,
+        canonical_key: key,
+        rows: n,
+        timing: ctx.timing(compile_time, exec_time),
+        debug: std::mem::take(ctx.capture),
+    })
+}
+
+fn exec_insert(
+    table_name: partiql_value::BindingsName<'static>,
+    query: LogicalPlan<BindingsOp>,
+    ctx: &mut StatementCtx<'_>,
+) -> Result<StatementOutcome, Box<dyn std::error::Error>> {
+    let key = canonical_table_key(&table_name);
+
+    if storage::is_system_table(&key) {
+        return Err("Error: cannot INSERT into system table '_tables'".into());
+    }
+
+    // Resolve --db before compile + VM setup so a missing flag fails
+    // cleanly before any expensive work.
+    let db = ctx
+        .db
+        .ok_or("Error: The `--db <PATH>` option is required for INSERT.")?;
+
+    let (rows, compile_time, exec_start) =
+        planner::drain_source_rows(&query, ctx.debug, db, ctx.capture)?;
+
+    // Row count is tallied here, not from commit(): open_table_for_append seeds
+    // row_id at the high-water mark, so commit() returns the absolute counter
+    // (existing + inserted), not this statement's insert count.
+    let inserted = rows.len() as u64;
+    {
+        let mut writer = db
+            .open_table_for_append(&key)
+            .map_err(|e| format!("Error: {}", e))?;
+        for encoded in &rows {
+            writer
+                .push_row(encoded)
+                .map_err(|e| format!("Error: {}", e))?;
+        }
+        writer.commit().map_err(|e| format!("Error: {}", e))?;
+    }
+    let exec_time = exec_start.elapsed();
+
+    Ok(StatementOutcome::InsertInto {
+        table_name,
+        rows: inserted,
+        timing: ctx.timing(compile_time, exec_time),
+        debug: std::mem::take(ctx.capture),
+    })
+}
+
+fn exec_create_table(
+    table_name: partiql_value::BindingsName<'static>,
+    ctx: &mut StatementCtx<'_>,
+) -> Result<StatementOutcome, Box<dyn std::error::Error>> {
+    let key = canonical_table_key(&table_name);
+    let db = ctx
+        .db
+        .ok_or("Error: The `--db <PATH>` option is required for CREATE TABLE.")?;
+
+    // Bare `?` (not `.map_err(format!)`) so the typed StorageError /
+    // SerializeError boxes intact — the startup bootstrap downcasts to
+    // StorageError::TableExists to reconcile a crash-recovery re-run.
+    let mut tables_value = Vec::new();
+    crate::row_codec::serialize_name_row(&[&key], &mut tables_value)?;
+    let exec_start = Instant::now();
+    db.create_table(&key, &tables_value)?.commit()?;
+    let exec_time = exec_start.elapsed();
+
+    Ok(StatementOutcome::CreateTable {
+        table_name,
+        canonical_key: key,
+        timing: ctx.timing(Duration::ZERO, exec_time),
+        debug: std::mem::take(ctx.capture),
+    })
+}

--- a/partiql-tools/src/session/exec.rs
+++ b/partiql-tools/src/session/exec.rs
@@ -1,34 +1,122 @@
 //! Parse + lower + compile + execute one statement.
 //!
-//! SELECT streams row-by-row into `out`; non-query statements buffer a small
-//! `StatementOutcome` for the caller to render.
+//! Non-query statements are executed to completion and returned as a
+//! `StatementOutcome`. Queries return `RunOutcome::Query` carrying a handle
+//! the caller drives via `QueryHandle::drain(render_fn)`. Session never writes
+//! to stdout/stderr.
 
-use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use partiql_ast::ast;
-use partiql_eval::value::Shape;
+use partiql_eval::value::{RegisterReader, Shape};
 use partiql_logical::{BindingsOp, LogicalPlan, LogicalStatement};
 
 use crate::common;
 use crate::session::debug::DebugFlags;
-use crate::session::ion_output::stream_query_ion;
 use crate::session::naming::{canonical_table_key, normalize_query};
-use crate::session::outcome::{DebugCapture, OutputFormat, StatementOutcome, StatementTiming};
+use crate::session::outcome::{DebugCapture, StatementOutcome, StatementTiming};
 use crate::session::planner;
-use crate::session::value;
 use crate::storage::{self, HeedDB};
 
-/// What `exec::run` streamed to `out`. Query rows are already on the wire; the
-/// caller only needs count + timing for the footer. Non-query outcomes carry
-/// their own metadata for the caller to render.
-pub(super) enum RunResult {
-    Query {
-        row_count: u64,
-        timing: StatementTiming,
-    },
-    NonQuery(StatementOutcome),
+/// Result of dispatching a statement. Queries hand back a `QueryHandle` so the
+/// caller can drain rows on its own terms; non-query statements are already
+/// complete.
+pub enum RunOutcome {
+    Query(QueryHandle),
+    Statement(StatementOutcome),
+}
+
+/// A compiled query the caller must drive to completion via `drain`. Owns the
+/// VM so rows stay valid for the drain call's lifetime; the exec-time clock
+/// starts inside `drain` (NOT at handle construction) so caller-side stalls
+/// between `run` and `drain` don't count as execution.
+pub struct QueryHandle {
+    vm: Box<partiql_eval::PartiQLVM>,
+    shape: Shape,
+    debug: DebugCapture,
+    parse_time: Duration,
+    lower_time: Duration,
+    compile_time: Duration,
+}
+
+impl QueryHandle {
+    pub fn shape(&self) -> &Shape {
+        &self.shape
+    }
+
+    /// Take the debug capture out of the handle. Call this BEFORE `drain` if
+    /// the caller wants `--debug` output on stderr to precede rows on stdout.
+    pub fn take_debug(&mut self) -> DebugCapture {
+        std::mem::take(&mut self.debug)
+    }
+
+    /// Drive the query to completion. The renderer receives a row-counting
+    /// iterator plus the shape; whatever it returns comes back paired with a
+    /// finalized `QueryFooter`. Session owns the exec-time clock. After the
+    /// renderer returns `Ok`, any rows it did NOT consume are drained here so
+    /// `row_count` is authoritative — a lazy renderer cannot silently under-
+    /// count. A row error surfaced during that post-drain becomes the return
+    /// value's error.
+    ///
+    /// Consumes `self`: a handle cannot be executed twice.
+    pub fn drain<F, R>(mut self, render: F) -> Result<(R, QueryFooter), Box<dyn std::error::Error>>
+    where
+        F: FnOnce(&mut CountingRows<'_>, &Shape) -> Result<R, Box<dyn std::error::Error>>,
+    {
+        let exec_start = Instant::now();
+        let iter = match self.vm.execute() {
+            Ok(partiql_eval::ExecutionResult::Query(it)) => it,
+            Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
+        };
+        let mut counter = CountingRows {
+            inner: iter,
+            count: 0,
+        };
+        let user_result = render(&mut counter, &self.shape)?;
+        // Post-drain: if the renderer stopped early, finish consuming the
+        // iterator so row_count is complete and any late row error surfaces.
+        for row in counter.by_ref() {
+            row.map_err(|e| format!("Execution error: {:?}", e))?;
+        }
+        let row_count = counter.count;
+        Ok((
+            user_result,
+            QueryFooter {
+                row_count,
+                timing: StatementTiming {
+                    parse: self.parse_time,
+                    lower: self.lower_time,
+                    compile: self.compile_time,
+                    exec: exec_start.elapsed(),
+                },
+            },
+        ))
+    }
+}
+
+/// Row-count + timing for a completed Query, ready to render.
+pub struct QueryFooter {
+    pub row_count: u64,
+    pub timing: StatementTiming,
+}
+
+/// Row iterator adapter: session owns the counter, renderer just pulls rows.
+pub struct CountingRows<'vm> {
+    inner: partiql_eval::QueryIterator<'vm>,
+    count: u64,
+}
+
+impl<'vm> Iterator for CountingRows<'vm> {
+    type Item = Result<RegisterReader<'vm>, partiql_eval::EngineError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.inner.next()?;
+        if item.is_ok() {
+            self.count += 1;
+        }
+        Some(item)
+    }
 }
 
 struct StatementCtx<'a> {
@@ -50,17 +138,13 @@ impl StatementCtx<'_> {
     }
 }
 
-/// Parse + lower + dispatch. On the Query path, AST/plan/program flush to
-/// `err` BEFORE row iteration so debug precedes results (dev parity). On Err,
-/// any capture built up so far is returned in the second position.
+/// Parse + lower + dispatch. On error, the compile-time debug capture is
+/// returned in the second position so the caller can flush it.
 pub(super) fn run(
     db: Option<&Arc<HeedDB>>,
     debug: &DebugFlags,
     sql: &str,
-    format: OutputFormat,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
-) -> (Result<RunResult, Box<dyn std::error::Error>>, DebugCapture) {
+) -> (Result<RunOutcome, Box<dyn std::error::Error>>, DebugCapture) {
     let sql = normalize_query(sql);
     if sql.is_empty() {
         return (Err("empty query".into()), DebugCapture::default());
@@ -88,15 +172,14 @@ pub(super) fn run(
         None => return (Err("no statements after parse".into()), capture),
     };
 
-    match dispatch(stmt, debug, db, parse_time, &mut capture, format, out, err) {
-        Ok(res) => (Ok(res), DebugCapture::default()),
+    match dispatch(stmt, debug, db, parse_time, &mut capture) {
+        Ok(out) => (Ok(out), DebugCapture::default()),
         Err(e) => (Err(e), capture),
     }
 }
 
-/// Bootstrap entry: no debug capture, no rendering. Query statements route
-/// their output to `io::sink()` so future SELECTs in the bootstrap script
-/// don't brick startup.
+/// Bootstrap entry: no debug capture, no rendering. Query statements drain
+/// their rows internally so their side effects run without needing a renderer.
 pub(super) fn execute_statement_silent(
     stmt: &ast::AstNode<ast::Statement>,
     debug: &DebugFlags,
@@ -117,32 +200,26 @@ pub(super) fn execute_statement_silent(
 
     match statement {
         LogicalStatement::Query(plan) => {
-            let mut sink_out = std::io::sink();
-            let mut sink_err = std::io::sink();
-            stream_query(
-                plan,
-                &mut ctx,
-                OutputFormat::Text,
-                &mut sink_out,
-                &mut sink_err,
-            )
-            .map(|_| ())
+            let handle = compile_query(plan, &mut ctx)?;
+            handle.drain(|rows, _shape| {
+                for row in rows {
+                    row.map_err(|e| format!("Execution error: {:?}", e))?;
+                }
+                Ok(())
+            })?;
+            Ok(())
         }
         other => dispatch_write(other, &mut ctx).map(|_| ()),
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn dispatch(
     stmt: &ast::AstNode<ast::Statement>,
     debug: &DebugFlags,
     db: Option<&Arc<HeedDB>>,
     parse_time: Duration,
     capture: &mut DebugCapture,
-    format: OutputFormat,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
-) -> Result<RunResult, Box<dyn std::error::Error>> {
+) -> Result<RunOutcome, Box<dyn std::error::Error>> {
     let catalog = common::create_table_fn_catalog();
 
     let lower_start = Instant::now();
@@ -159,8 +236,11 @@ fn dispatch(
     };
 
     match statement {
-        LogicalStatement::Query(plan) => stream_query(plan, &mut ctx, format, out, err),
-        other => dispatch_write(other, &mut ctx).map(RunResult::NonQuery),
+        LogicalStatement::Query(plan) => {
+            let handle = compile_query(plan, &mut ctx)?;
+            Ok(RunOutcome::Query(handle))
+        }
+        other => dispatch_write(other, &mut ctx).map(RunOutcome::Statement),
     }
 }
 
@@ -177,83 +257,31 @@ fn dispatch_write(
     }
 }
 
-fn stream_query(
+/// Compile a query plan into a handle ready to execute. VM setup
+/// (build_exec_context + PartiQLVM::new) is folded into `compile_time` so the
+/// footer accounts for all pre-execution work.
+fn compile_query(
     plan: LogicalPlan<BindingsOp>,
     ctx: &mut StatementCtx<'_>,
-    format: OutputFormat,
-    out: &mut dyn Write,
-    err: &mut dyn Write,
-) -> Result<RunResult, Box<dyn std::error::Error>> {
+) -> Result<QueryHandle, Box<dyn std::error::Error>> {
     let compile_start = Instant::now();
     let (compiled, catalog_id) =
         planner::build_compiled(&plan, ctx.debug, ctx.db.cloned(), ctx.capture)?;
+    let exec_context = planner::build_exec_context(ctx.db.cloned(), catalog_id, &compiled);
+    let vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+        .map_err(|e| format!("Execution setup error: {:?}", e))?;
     let compile_time = compile_start.elapsed();
 
-    let exec_start = Instant::now();
-    let exec_context = planner::build_exec_context(ctx.db.cloned(), catalog_id, &compiled);
-    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
-        .map_err(|e| format!("Execution setup error: {:?}", e))?;
     let shape = vm.shape().clone();
 
-    // Flush AST/plan/program NOW so debug on stderr precedes results on stdout.
-    crate::session::flush_debug(ctx.capture, err)?;
-    *ctx.capture = DebugCapture::default();
-
-    let row_count = match vm.execute() {
-        Ok(partiql_eval::ExecutionResult::Query(iter)) => match format {
-            OutputFormat::Text => stream_query_text(iter, &shape, out)?,
-            OutputFormat::Ion => stream_query_ion(iter, &shape, out)?,
-        },
-        Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
-    };
-    let exec_time = exec_start.elapsed();
-
-    Ok(RunResult::Query {
-        row_count,
-        timing: StatementTiming {
-            parse: ctx.parse_time,
-            lower: ctx.lower_time,
-            compile: compile_time,
-            exec: exec_time,
-        },
+    Ok(QueryHandle {
+        vm: Box::new(vm),
+        shape,
+        debug: std::mem::take(ctx.capture),
+        parse_time: ctx.parse_time,
+        lower_time: ctx.lower_time,
+        compile_time,
     })
-}
-
-/// Human-readable text: `<<\n  <row>,\n  ...\n>>\n` for Bag, `[`/`]` for List,
-/// bare `{value:?}` for Single.
-fn stream_query_text(
-    iter: partiql_eval::QueryIterator<'_>,
-    shape: &Shape,
-    out: &mut dyn Write,
-) -> Result<u64, Box<dyn std::error::Error>> {
-    let (prefix, tab, suffix) = match shape {
-        Shape::Bag(_) => (Some("<<"), "  ", Some(">>")),
-        Shape::List(_) => (Some("["), "  ", Some("]")),
-        Shape::Single(_) => (None, "", None),
-    };
-    if let Some(p) = prefix {
-        writeln!(out, "{}", p)?;
-    }
-
-    let mut count: u64 = 0;
-    let mut is_first = true;
-    for row_result in iter {
-        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
-        let v = value::row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
-        if is_first {
-            is_first = false;
-        } else {
-            writeln!(out, ",")?;
-        }
-        write!(out, "{tab}{v:?}")?;
-        count += 1;
-    }
-    writeln!(out)?;
-    if let Some(s) = suffix {
-        writeln!(out, "{}", s)?;
-    }
-    out.flush()?;
-    Ok(count)
 }
 
 fn exec_ctas(

--- a/partiql-tools/src/session/ion_output.rs
+++ b/partiql-tools/src/session/ion_output.rs
@@ -1,76 +1,15 @@
-//! PartiQL-encoded-Ion rendering. `stream_query_ion` streams row-by-row (peak
-//! memory O(1) in rows); `write_outcome_ion` renders a single small envelope.
+//! PartiQL-encoded-Ion envelope for non-query statement outcomes plus the
+//! control-char escape used by every Ion emit path. Streaming Query row
+//! rendering lives in `session::render::render_query_ion`.
 
 use std::io::{self, Write};
 
 use ion_rs::element::writer::TextKind;
 use ion_rs::element::{Element, Sequence, Struct};
-use partiql_eval::value::Shape;
 
 use crate::session::outcome::StatementOutcome;
-use crate::session::value::{row_to_value, value_to_element, RowConvertError};
-
-/// Emit `{rows: $bag::[...]}` (Bag), `{rows: [...]}` (List), or `{rows: v}`
-/// (Single). Each row is serialised and written before the next VM row is
-/// pulled.
-pub(super) fn stream_query_ion(
-    iter: partiql_eval::QueryIterator<'_>,
-    shape: &Shape,
-    out: &mut dyn Write,
-) -> Result<u64, Box<dyn std::error::Error>> {
-    // Spacing matches ion_rs' Struct/Sequence Compact writer.
-    let (open, close) = match shape {
-        Shape::Bag(_) => ("{rows: $bag::[", "]}"),
-        Shape::List(_) => ("{rows: [", "]}"),
-        Shape::Single(_) => ("{rows: ", "}"),
-    };
-
-    let mut count: u64 = 0;
-    let mut opened = false;
-    for row_result in iter {
-        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
-        let value = row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
-        let element = value_to_element(&value).map_err(|e: RowConvertError| {
-            io::Error::new(io::ErrorKind::InvalidData, e.to_string())
-        })?;
-        let text = element
-            .to_text(TextKind::Compact)
-            .map_err(|e| io::Error::other(e.to_string()))?;
-        // ion_rs 0.18.1's writer doesn't escape C0 controls in quoted regions.
-        let escaped = escape_control_chars_in_strings(&text);
-
-        // Reject before the second row is serialised. Note: partial stdout
-        // (opener + first row, no closer) can already be on `out`; per design,
-        // non-zero exit signals consumers to discard.
-        if matches!(shape, Shape::Single(_)) && count >= 1 {
-            return Err(
-                "single-row query produced more than one row (invalid Ion envelope)".into(),
-            );
-        }
-
-        if !opened {
-            out.write_all(open.as_bytes())?;
-        } else {
-            out.write_all(b", ")?;
-        }
-        out.write_all(escaped.as_bytes())?;
-        opened = true;
-        count += 1;
-    }
-
-    if matches!(shape, Shape::Single(_)) && count == 0 {
-        return Err("single-row query produced no row".into());
-    }
-
-    // Empty Bag/List still owes the opener.
-    if !opened {
-        out.write_all(open.as_bytes())?;
-    }
-    out.write_all(close.as_bytes())?;
-    out.write_all(b"\n")?;
-    out.flush()?;
-    Ok(count)
-}
+#[cfg(test)]
+use crate::session::value::value_to_element;
 
 /// Checked cast: LMDB stores row counts as `u64`; `Element::integer` takes
 /// `i64`. A count that exceeds `i64::MAX` is reported as an I/O error rather

--- a/partiql-tools/src/session/ion_output.rs
+++ b/partiql-tools/src/session/ion_output.rs
@@ -1,0 +1,247 @@
+//! PartiQL-encoded-Ion rendering. `stream_query_ion` streams row-by-row (peak
+//! memory O(1) in rows); `write_outcome_ion` renders a single small envelope.
+
+use std::io::{self, Write};
+
+use ion_rs::element::writer::TextKind;
+use ion_rs::element::{Element, Sequence, Struct};
+use partiql_eval::value::Shape;
+
+use crate::session::outcome::StatementOutcome;
+use crate::session::value::{row_to_value, value_to_element, RowConvertError};
+
+/// Emit `{rows: $bag::[...]}` (Bag), `{rows: [...]}` (List), or `{rows: v}`
+/// (Single). Each row is serialised and written before the next VM row is
+/// pulled.
+pub(super) fn stream_query_ion(
+    iter: partiql_eval::QueryIterator<'_>,
+    shape: &Shape,
+    out: &mut dyn Write,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    // Spacing matches ion_rs' Struct/Sequence Compact writer.
+    let (open, close) = match shape {
+        Shape::Bag(_) => ("{rows: $bag::[", "]}"),
+        Shape::List(_) => ("{rows: [", "]}"),
+        Shape::Single(_) => ("{rows: ", "}"),
+    };
+
+    let mut count: u64 = 0;
+    let mut opened = false;
+    for row_result in iter {
+        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
+        let value = row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
+        let element = value_to_element(&value).map_err(|e: RowConvertError| {
+            io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+        })?;
+        let text = element
+            .to_text(TextKind::Compact)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        // ion_rs 0.18.1's writer doesn't escape C0 controls in quoted regions.
+        let escaped = escape_control_chars_in_strings(&text);
+
+        // Reject before the second row is serialised. Note: partial stdout
+        // (opener + first row, no closer) can already be on `out`; per design,
+        // non-zero exit signals consumers to discard.
+        if matches!(shape, Shape::Single(_)) && count >= 1 {
+            return Err(
+                "single-row query produced more than one row (invalid Ion envelope)".into(),
+            );
+        }
+
+        if !opened {
+            out.write_all(open.as_bytes())?;
+        } else {
+            out.write_all(b", ")?;
+        }
+        out.write_all(escaped.as_bytes())?;
+        opened = true;
+        count += 1;
+    }
+
+    if matches!(shape, Shape::Single(_)) && count == 0 {
+        return Err("single-row query produced no row".into());
+    }
+
+    // Empty Bag/List still owes the opener.
+    if !opened {
+        out.write_all(open.as_bytes())?;
+    }
+    out.write_all(close.as_bytes())?;
+    out.write_all(b"\n")?;
+    out.flush()?;
+    Ok(count)
+}
+
+/// Checked cast: LMDB stores row counts as `u64`; `Element::integer` takes
+/// `i64`. A count that exceeds `i64::MAX` is reported as an I/O error rather
+/// than silently wrapping into a negative value or being clamped.
+fn checked_u64_to_i64(v: u64) -> io::Result<i64> {
+    i64::try_from(v).map_err(|_| io::Error::other("row count exceeds i64::MAX"))
+}
+
+/// Envelope for a non-query outcome (CTAS / INSERT / CREATE TABLE).
+pub(super) fn write_outcome_ion(outcome: &StatementOutcome, out: &mut dyn Write) -> io::Result<()> {
+    let element = outcome_to_element(outcome)?;
+    let text = element
+        .to_text(TextKind::Compact)
+        .map_err(|e| io::Error::other(e.to_string()))?;
+    let escaped = escape_control_chars_in_strings(&text);
+    writeln!(out, "{escaped}")?;
+    out.flush()
+}
+
+fn outcome_to_element(outcome: &StatementOutcome) -> io::Result<Element> {
+    match outcome {
+        StatementOutcome::InsertInto { rows, .. } => Ok(Element::from(
+            Struct::builder()
+                .with_field(
+                    "affected_rows",
+                    Element::integer(checked_u64_to_i64(*rows)?),
+                )
+                .build(),
+        )),
+        StatementOutcome::CreateTable { canonical_key, .. } => {
+            created_table_element(canonical_key, 0)
+        }
+        StatementOutcome::CreateTableAs {
+            canonical_key,
+            rows,
+            ..
+        } => created_table_element(canonical_key, *rows),
+    }
+}
+
+/// Inside `"..."` string literals and `'...'` symbol literals (both can carry
+/// raw control chars past ion_rs 0.18.1's writer), replace C0 controls, DEL,
+/// and C1 bytes with `\xNN` escapes. Tracks whichever delimiter opened the
+/// current region so a `'` inside a `"..."` is data.
+pub(crate) fn escape_control_chars_in_strings(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut delim: Option<char> = None;
+    let mut prev_backslash = false;
+    for ch in text.chars() {
+        match delim {
+            None => {
+                out.push(ch);
+                if ch == '"' || ch == '\'' {
+                    delim = Some(ch);
+                    prev_backslash = false;
+                }
+            }
+            Some(d) => {
+                if prev_backslash {
+                    out.push(ch);
+                    prev_backslash = false;
+                    continue;
+                }
+                if ch == '\\' {
+                    out.push(ch);
+                    prev_backslash = true;
+                    continue;
+                }
+                if ch == d {
+                    out.push(ch);
+                    delim = None;
+                    continue;
+                }
+                let code = ch as u32;
+                // Tab/LF/CR are already escaped by the writer; other C0, DEL,
+                // and C1 (0x80..=0x9F) must be escaped here.
+                let is_c0 = code < 0x20 && code != 0x09 && code != 0x0a && code != 0x0d;
+                let is_del_or_c1 = code == 0x7f || (0x80..=0x9f).contains(&code);
+                if is_c0 || is_del_or_c1 {
+                    use std::fmt::Write as _;
+                    let _ = write!(&mut out, "\\x{:02x}", code);
+                } else {
+                    out.push(ch);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// `{ name: [<canonical_key>], rows: N }` — `name` is a single-element list
+/// mirroring `_tables`.
+fn created_table_element(canonical_key: &str, rows: u64) -> io::Result<Element> {
+    let name = Element::from(
+        Sequence::builder()
+            .push(Element::string(canonical_key))
+            .build_list(),
+    );
+    let inner = Struct::builder()
+        .with_field("name", name)
+        .with_field("rows", Element::integer(checked_u64_to_i64(rows)?))
+        .build();
+    Ok(Element::from(
+        Struct::builder().with_field("created_table", inner).build(),
+    ))
+}
+
+/// Test helper: renders one Value through the same escape pass as streaming.
+#[cfg(test)]
+pub(crate) fn render_element_escaped(v: &partiql_value::Value) -> String {
+    let element = value_to_element(v).expect("test value must convert");
+    let text = element
+        .to_text(TextKind::Compact)
+        .expect("test element must render");
+    escape_control_chars_in_strings(&text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ion_rs::element::Element;
+    use partiql_value::Value;
+
+    /// Emit a `{rows: $bag::[<element>]}` envelope by hand for a single value,
+    /// exercising the same escape pass the streaming write path uses.
+    fn envelope_bag_one(v: &Value) -> Vec<u8> {
+        let inner = render_element_escaped(v);
+        format!("{{rows: $bag::[{inner}]}}\n").into_bytes()
+    }
+
+    #[test]
+    fn control_chars_escaped_and_reparseable() {
+        // ESC (0x1B) and NUL (0x00) inside a string body.
+        let bytes = envelope_bag_one(&Value::String(Box::new("x\u{1b}y\u{00}z".to_string())));
+        // Round-trip: the emitted bytes must reparse.
+        Element::read_all(&bytes).expect("output must reparse");
+    }
+
+    #[test]
+    fn control_char_in_field_name_escapes_via_single_quotes() {
+        // A field name containing a C0 control forces ion_rs' text writer to
+        // single-quote it; the escape scanner must escape symbol bodies the
+        // same way as string bodies.
+        let mut tuple = partiql_value::Tuple::new();
+        tuple.insert("x\u{1b}y", Value::Integer(1));
+        let bytes = envelope_bag_one(&Value::Tuple(Box::new(tuple)));
+        Element::read_all(&bytes).expect("output with escaped symbol must reparse");
+        assert!(!bytes.contains(&0x1b), "raw ESC byte leaked into output");
+    }
+
+    #[test]
+    fn blob_value_reparses_as_blob() {
+        // Query row of type Bytes decodes to Value::Blob; render must emit
+        // valid Ion blob syntax, not error.
+        let bytes = envelope_bag_one(&Value::Blob(Box::new(vec![0x00, 0x1b, 0xff])));
+        let parsed = Element::read_all(&bytes).expect("blob output must reparse");
+        assert_eq!(parsed.len(), 1);
+        // Envelope is `{ rows: $bag::[ <blob> ] }` — dig in and confirm.
+        let rows = parsed[0]
+            .as_struct()
+            .and_then(|s| s.get("rows"))
+            .expect("envelope has rows field");
+        let list = rows.as_sequence().expect("rows is a sequence");
+        let blob = list.elements().next().expect("one row");
+        assert_eq!(blob.ion_type(), ion_rs::IonType::Blob);
+    }
+
+    #[test]
+    fn ordinary_strings_unchanged_by_escape_pass() {
+        let bytes = envelope_bag_one(&Value::String(Box::new("hello world".to_string())));
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert!(text.contains("\"hello world\""), "got: {text}");
+    }
+}

--- a/partiql-tools/src/session/naming.rs
+++ b/partiql-tools/src/session/naming.rs
@@ -1,0 +1,29 @@
+//! Query-and-name normalization helpers. Pure functions; no I/O.
+
+use partiql_value::BindingsName;
+
+/// Trim outer whitespace and strip a single trailing `;` so the REPL can use
+/// `;` as a completion signal without it leaking into the PartiQL grammar.
+/// TODO: drop this once the parser accepts `;` natively.
+pub fn normalize_query(input: &str) -> &str {
+    let trimmed = input.trim();
+    trimmed.strip_suffix(';').unwrap_or(trimmed).trim_end()
+}
+
+/// SQL-idiomatic rendering: quoted identifiers re-quoted, bare ones bare.
+pub fn format_table_name(name: &BindingsName<'_>) -> String {
+    match name {
+        BindingsName::CaseSensitive(s) => format!("\"{}\"", s),
+        BindingsName::CaseInsensitive(s) => s.as_ref().to_string(),
+    }
+}
+
+/// Bare identifiers fold to ASCII lowercase; quoted identifiers are verbatim.
+/// Non-ASCII bare identifiers would diverge from the engine's UniCase fold,
+/// but the catalog does not accept them today.
+pub(super) fn canonical_table_key(name: &BindingsName<'_>) -> String {
+    match name {
+        BindingsName::CaseInsensitive(s) => s.to_lowercase(),
+        BindingsName::CaseSensitive(s) => s.to_string(),
+    }
+}

--- a/partiql-tools/src/session/outcome.rs
+++ b/partiql-tools/src/session/outcome.rs
@@ -1,0 +1,74 @@
+//! Non-query outcomes (CTAS / INSERT / CREATE TABLE). Query results stream
+//! directly to `out`; they do not flow through this type.
+
+use std::time::Duration;
+
+use clap::ValueEnum;
+use partiql_value::BindingsName;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Ion,
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            OutputFormat::Text => "text",
+            OutputFormat::Ion => "ion",
+        };
+        f.write_str(s)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct StatementTiming {
+    pub parse: Duration,
+    pub lower: Duration,
+    /// `Duration::ZERO` for pure-DDL CREATE TABLE (no compile step).
+    pub compile: Duration,
+    pub exec: Duration,
+}
+
+/// AST/plan/program captured under `--debug`, flushed to stderr.
+#[derive(Debug, Default)]
+pub struct DebugCapture {
+    pub ast: Option<String>,
+    pub plan: Option<String>,
+    pub program: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum StatementOutcome {
+    CreateTableAs {
+        table_name: BindingsName<'static>,
+        canonical_key: String,
+        rows: u64,
+        timing: StatementTiming,
+        debug: DebugCapture,
+    },
+    InsertInto {
+        table_name: BindingsName<'static>,
+        rows: u64,
+        timing: StatementTiming,
+        debug: DebugCapture,
+    },
+    CreateTable {
+        table_name: BindingsName<'static>,
+        canonical_key: String,
+        /// `compile` is `Duration::ZERO`; CREATE TABLE has no compile step.
+        timing: StatementTiming,
+        debug: DebugCapture,
+    },
+}
+
+impl StatementOutcome {
+    pub fn debug(&self) -> &DebugCapture {
+        match self {
+            StatementOutcome::CreateTableAs { debug, .. } => debug,
+            StatementOutcome::InsertInto { debug, .. } => debug,
+            StatementOutcome::CreateTable { debug, .. } => debug,
+        }
+    }
+}

--- a/partiql-tools/src/session/outcome.rs
+++ b/partiql-tools/src/session/outcome.rs
@@ -1,5 +1,7 @@
-//! Non-query outcomes (CTAS / INSERT / CREATE TABLE). Query results stream
-//! directly to `out`; they do not flow through this type.
+//! Non-query outcomes (CTAS / INSERT / CREATE TABLE). Query results are
+//! delivered as a live handle in `RunOutcome::Query` and do not flow through
+//! this type — the caller renders rows and their footer directly from the
+//! handle's timing/row-count fields.
 
 use std::time::Duration;
 
@@ -66,9 +68,17 @@ pub enum StatementOutcome {
 impl StatementOutcome {
     pub fn debug(&self) -> &DebugCapture {
         match self {
-            StatementOutcome::CreateTableAs { debug, .. } => debug,
-            StatementOutcome::InsertInto { debug, .. } => debug,
-            StatementOutcome::CreateTable { debug, .. } => debug,
+            StatementOutcome::CreateTableAs { debug, .. }
+            | StatementOutcome::InsertInto { debug, .. }
+            | StatementOutcome::CreateTable { debug, .. } => debug,
+        }
+    }
+
+    pub fn timing(&self) -> &StatementTiming {
+        match self {
+            StatementOutcome::CreateTableAs { timing, .. }
+            | StatementOutcome::InsertInto { timing, .. }
+            | StatementOutcome::CreateTable { timing, .. } => timing,
         }
     }
 }

--- a/partiql-tools/src/session/planner.rs
+++ b/partiql-tools/src/session/planner.rs
@@ -1,0 +1,172 @@
+//! Compilation-catalog assembly, plan compilation, execution-context setup,
+//! and source draining for the write paths.
+
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use partiql_common::catalog::CatalogId;
+use partiql_eval::plan::EvaluationMode;
+use partiql_eval::{CompilationContext, ExecutionCatalog, ExecutionContext, PlanCompiler};
+
+use crate::catalog::{HeedCompilationCatalog, HeedExecutionCatalog};
+use crate::common;
+use crate::session::debug::DebugFlags;
+use crate::session::outcome::DebugCapture;
+use crate::storage::{HeedDB, StorageError};
+
+/// Bundles `HeedCompilationCatalog` with the existing `TableFnCompilationCatalog`
+/// under `PlanCompiler`'s single `"default"` catalog name. Also records the
+/// first unresolved bare table name so `build_compiled` can fail fast with
+/// "Table not found" instead of letting Permissive mode yield a MISSING row.
+struct CombinedCatalog {
+    table_fns: common::TableFnCompilationCatalog,
+    heed: Option<HeedCompilationCatalog>,
+    unresolved_table_name: Arc<Mutex<Option<String>>>,
+}
+
+impl partiql_eval::CompilationCatalog for CombinedCatalog {
+    fn get_table(
+        &self,
+        path: &[partiql_value::BindingsName<'_>],
+    ) -> Option<partiql_eval::source::DataSourceHandle> {
+        if let Some(handle) = self.heed.as_ref().and_then(|h| h.get_table(path)) {
+            return Some(handle);
+        }
+        // Only record bare single-element bindings — schema-qualified paths
+        // never match anything here and aren't useful to surface as table names.
+        // The compiler may probe a name multiple times; keep the first.
+        if path.len() == 1 {
+            if let Ok(mut guard) = self.unresolved_table_name.lock() {
+                if guard.is_none() {
+                    let name = match &path[0] {
+                        partiql_value::BindingsName::CaseSensitive(s) => s.to_string(),
+                        partiql_value::BindingsName::CaseInsensitive(s) => s.to_string(),
+                    };
+                    *guard = Some(name);
+                }
+            }
+        }
+        None
+    }
+
+    fn get_table_function(&self, name: &str) -> Option<partiql_eval::source::TableFunctionHandle> {
+        self.table_fns.get_table_function(name)
+    }
+}
+
+/// CatalogId is reused by the matching ExecutionCatalog.
+pub(super) fn build_compiled(
+    logical: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+    debug: &DebugFlags,
+    db: Option<Arc<HeedDB>>,
+    capture: &mut DebugCapture,
+) -> Result<(partiql_eval::CompiledPlan, CatalogId), Box<dyn std::error::Error>> {
+    if debug.plan {
+        capture.plan = Some(format!("[Plan] {:?}", logical));
+    }
+
+    let mut context = CompilationContext::new();
+
+    let column_names = vec!["a".to_string(), "b".to_string()];
+    let unresolved_table_name: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let combined = CombinedCatalog {
+        table_fns: common::TableFnCompilationCatalog::new(column_names),
+        heed: db.map(HeedCompilationCatalog::new),
+        unresolved_table_name: Arc::clone(&unresolved_table_name),
+    };
+    let catalog: Arc<dyn partiql_eval::CompilationCatalog> = Arc::new(combined);
+    let catalog_id = context.add_catalog("default", catalog);
+
+    let mut compiler = PlanCompiler::new(&context, EvaluationMode::Permissive);
+    let compiled = compiler
+        .compile(logical)
+        .map_err(|e| format!("Compile error: {:?}", e))?;
+
+    // Recover from a poisoned lock so a panic in one probe doesn't downgrade a
+    // hard "Table not found" error into a Permissive-mode MISSING row.
+    let first_unresolved = unresolved_table_name
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .take();
+    if let Some(name) = first_unresolved {
+        return Err(format!("Error: Table '{}' not found", name).into());
+    }
+
+    if debug.program {
+        capture.program = Some(format!("[Program]\n{}", compiled));
+    }
+
+    Ok((compiled, catalog_id))
+}
+
+/// The Heed catalog is `prepare()`-d from `compiled` before being boxed so
+/// `ScanId → table-name` mappings are populated before the VM calls `create()`.
+pub(super) fn build_exec_context(
+    db: Option<Arc<HeedDB>>,
+    catalog_id: CatalogId,
+    compiled: &partiql_eval::CompiledPlan,
+) -> ExecutionContext {
+    let mut exec_context = ExecutionContext::new();
+    exec_context.register_table_function("rand", Arc::new(common::RandTableFunction));
+    exec_context.register_table_function("mem", Arc::new(common::MemTableFunction));
+    exec_context.register_table_function("scan_ion", Arc::new(common::ScanIonTableFunction));
+
+    if let Some(db) = db {
+        let mut heed_exec = HeedExecutionCatalog::new(db);
+        let scans = compiled.scans_for_catalog(catalog_id);
+        heed_exec.prepare(&scans);
+        exec_context.add_catalog(catalog_id, Box::new(heed_exec));
+    }
+
+    exec_context
+}
+
+/// Buffered source rows plus the timing a write-path caller needs to finish its
+/// own exec timer: `(encoded rows, compile time, exec start instant)`.
+pub(super) type DrainedSource = (Vec<Vec<u8>>, std::time::Duration, Instant);
+
+/// Compile the source plan, run it, and buffer every result row into owned
+/// bytes. The source is fully drained here — before any caller opens a write
+/// txn — because a streaming source holds a read txn open across iteration, and
+/// LMDB rejects opening a table handle in a write txn while one is live
+/// (MDB_BAD_DBI). Returns the buffered rows, the compile time, and the exec
+/// start instant so the caller can finish timing after its own write + commit.
+pub(super) fn drain_source_rows(
+    query: &partiql_logical::LogicalPlan<partiql_logical::BindingsOp>,
+    debug: &DebugFlags,
+    db: &Arc<HeedDB>,
+    capture: &mut DebugCapture,
+) -> Result<DrainedSource, Box<dyn std::error::Error>> {
+    let compile_start = Instant::now();
+    let (compiled, catalog_id) = build_compiled(query, debug, Some(Arc::clone(db)), capture)?;
+    let compile_time = compile_start.elapsed();
+
+    let exec_start = Instant::now();
+    let exec_context = build_exec_context(Some(Arc::clone(db)), catalog_id, &compiled);
+    let mut vm = partiql_eval::PartiQLVM::new(compiled, &exec_context)
+        .map_err(|e| format!("Execution setup error: {:?}", e))?;
+
+    // Snapshot RowShape before vm.execute() borrows the VM mutably.
+    let row_shape = vm.shape().row_shape().clone();
+
+    let mut rows: Vec<Vec<u8>> = Vec::new();
+    // Reused warm across rows (serialize_row clears on entry); each retained row
+    // is a tight clone (cap == len), so no per-row 4 KiB is held.
+    let mut scratch: Vec<u8> = Vec::with_capacity(4096);
+    match vm.execute() {
+        Ok(partiql_eval::ExecutionResult::Query(iter)) => {
+            // SAFETY: QueryIterator::next lifetime-extends its RegisterReader;
+            // aliasing across next() is UB. Consume `row` before the next pull.
+            for r in iter {
+                let row = r.map_err(|e| {
+                    format!("Error: {}", StorageError::Execution(format!("{:?}", e)))
+                })?;
+                crate::row_codec::serialize_row(&row, &row_shape, &mut scratch)
+                    .map_err(|e| format!("Error: {}", StorageError::Codec(format!("{e}"))))?;
+                rows.push(scratch.clone());
+            }
+        }
+        Err(e) => return Err(format!("Execution setup error: {:?}", e).into()),
+    }
+    Ok((rows, compile_time, exec_start))
+}

--- a/partiql-tools/src/session/render.rs
+++ b/partiql-tools/src/session/render.rs
@@ -1,0 +1,231 @@
+//! Rendering primitives shared by the CLI and the test harness. Session core
+//! does not call any of these — it returns structured results and the caller
+//! picks a renderer.
+
+use std::io::{self, Write};
+use std::time::Duration;
+
+use partiql_eval::value::{RegisterReader, Shape};
+
+use crate::session::exec::QueryFooter;
+use crate::session::ion_output::{escape_control_chars_in_strings, write_outcome_ion};
+use crate::session::naming::format_table_name;
+use crate::session::outcome::{DebugCapture, StatementOutcome};
+use crate::session::value::{row_to_value, value_to_element, RowConvertError};
+
+/// Flush a captured AST/plan/program block to `err`. Callers invoke this in
+/// the right ordering (before query rows on stdout, or on error).
+pub fn flush_debug(debug: &DebugCapture, err: &mut dyn Write) -> io::Result<()> {
+    if let Some(ast) = &debug.ast {
+        writeln!(err, "{}", ast)?;
+    }
+    if let Some(plan) = &debug.plan {
+        writeln!(err, "{}", plan)?;
+    }
+    if let Some(program) = &debug.program {
+        writeln!(err, "{}", program)?;
+    }
+    err.flush()
+}
+
+/// Text-format streaming query renderer. Emits `<<\n  row,\n  ...\n>>\n` for
+/// Bag, `[...]` for List, bare `{value:?}` for Single. Row count is tracked
+/// by whatever `Iterator` the caller passes (typically session's
+/// `CountingRows` so the row count is authoritative).
+pub fn render_query_text<'vm, I>(
+    iter: I,
+    shape: &Shape,
+    out: &mut dyn Write,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    I: Iterator<Item = Result<RegisterReader<'vm>, partiql_eval::EngineError>>,
+{
+    let (prefix, tab, suffix) = match shape {
+        Shape::Bag(_) => (Some("<<"), "  ", Some(">>")),
+        Shape::List(_) => (Some("["), "  ", Some("]")),
+        Shape::Single(_) => (None, "", None),
+    };
+    if let Some(p) = prefix {
+        writeln!(out, "{}", p)?;
+    }
+
+    let mut is_first = true;
+    for row_result in iter {
+        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
+        let v = row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
+        if is_first {
+            is_first = false;
+        } else {
+            writeln!(out, ",")?;
+        }
+        write!(out, "{tab}{v:?}")?;
+    }
+    writeln!(out)?;
+    if let Some(s) = suffix {
+        writeln!(out, "{}", s)?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+/// PartiQL-encoded-Ion streaming query renderer. Emits `{rows: $bag::[...]}`
+/// (Bag), `{rows: [...]}` (List), or `{rows: v}` (Single). Streams one row at
+/// a time; peak memory is O(1) in row count.
+pub fn render_query_ion<'vm, I>(
+    iter: I,
+    shape: &Shape,
+    out: &mut dyn Write,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    I: Iterator<Item = Result<RegisterReader<'vm>, partiql_eval::EngineError>>,
+{
+    let (open, close) = match shape {
+        Shape::Bag(_) => ("{rows: $bag::[", "]}"),
+        Shape::List(_) => ("{rows: [", "]}"),
+        Shape::Single(_) => ("{rows: ", "}"),
+    };
+
+    let mut count: u64 = 0;
+    let mut opened = false;
+    for row_result in iter {
+        let row = row_result.map_err(|e| format!("Execution error: {:?}", e))?;
+        let value = row_to_value(&row, shape).map_err(|e| format!("Execution error: {e}"))?;
+        let element = value_to_element(&value).map_err(|e: RowConvertError| {
+            io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+        })?;
+        let text = element
+            .to_text(ion_rs::element::writer::TextKind::Compact)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        let escaped = escape_control_chars_in_strings(&text);
+
+        if matches!(shape, Shape::Single(_)) && count >= 1 {
+            return Err(
+                "single-row query produced more than one row (invalid Ion envelope)".into(),
+            );
+        }
+
+        if !opened {
+            out.write_all(open.as_bytes())?;
+        } else {
+            out.write_all(b", ")?;
+        }
+        out.write_all(escaped.as_bytes())?;
+        opened = true;
+        count += 1;
+    }
+
+    if matches!(shape, Shape::Single(_)) && count == 0 {
+        return Err("single-row query produced no row".into());
+    }
+
+    if !opened {
+        out.write_all(open.as_bytes())?;
+    }
+    out.write_all(close.as_bytes())?;
+    out.write_all(b"\n")?;
+    out.flush()?;
+    Ok(())
+}
+
+/// Ion envelope for a completed non-query outcome.
+pub fn render_outcome_ion(outcome: &StatementOutcome, out: &mut dyn Write) -> io::Result<()> {
+    write_outcome_ion(outcome, out)
+}
+
+/// Human-readable footer for a completed non-query outcome, written to `err`.
+pub fn render_outcome_text(outcome: &StatementOutcome, err: &mut dyn Write) -> io::Result<()> {
+    match outcome {
+        StatementOutcome::CreateTableAs {
+            table_name,
+            rows,
+            timing,
+            ..
+        } => {
+            writeln!(
+                err,
+                "Created table {} ({} rows)",
+                format_table_name(table_name),
+                rows
+            )?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+        StatementOutcome::InsertInto {
+            table_name,
+            rows,
+            timing,
+            ..
+        } => {
+            writeln!(
+                err,
+                "Inserted {} rows into {}",
+                rows,
+                format_table_name(table_name)
+            )?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+        StatementOutcome::CreateTable {
+            table_name, timing, ..
+        } => {
+            writeln!(err, "Created table {}", format_table_name(table_name))?;
+            write_timing_line(
+                err,
+                "took",
+                timing.parse,
+                timing.lower,
+                timing.compile,
+                timing.exec,
+            )?;
+        }
+    }
+    err.flush()
+}
+
+/// `(N rows in ...)` footer for a completed Query. Ion mode skips this line to
+/// keep stderr clean for downstream Ion consumers.
+pub fn render_query_footer_text(footer: &QueryFooter, err: &mut dyn Write) -> io::Result<()> {
+    write_timing_line(
+        err,
+        &format!("{} rows in", footer.row_count),
+        footer.timing.parse,
+        footer.timing.lower,
+        footer.timing.compile,
+        footer.timing.exec,
+    )?;
+    err.flush()
+}
+
+/// `(<prefix> Xms — parse: ..., lower: ..., compile: ..., exec: ...)` line.
+fn write_timing_line(
+    err: &mut dyn Write,
+    prefix: &str,
+    parse: Duration,
+    lower: Duration,
+    compile: Duration,
+    exec: Duration,
+) -> io::Result<()> {
+    let total = parse + lower + compile + exec;
+    writeln!(
+        err,
+        "({} {:.1}ms — parse: {:.1}ms, lower: {:.1}ms, compile: {:.1}ms, exec: {:.1}ms)",
+        prefix,
+        total.as_secs_f64() * 1000.0,
+        parse.as_secs_f64() * 1000.0,
+        lower.as_secs_f64() * 1000.0,
+        compile.as_secs_f64() * 1000.0,
+        exec.as_secs_f64() * 1000.0,
+    )
+}

--- a/partiql-tools/src/session/value.rs
+++ b/partiql-tools/src/session/value.rs
@@ -1,0 +1,201 @@
+//! Conversion of VM register rows into owned `partiql_value::Value`, and thin
+//! adapter over the canonical `partiql-extension-ion` encoder for the ion
+//! render path. `value_to_element` is a delegation — spec-complete
+//! PartiQL-encoded-Ion (bag / missing / date / time / timestamp annotations)
+//! lives in the extension, not here.
+
+use partiql_extension_ion::encode::{IonEncoderBuilder, IonEncoderConfig};
+use partiql_extension_ion::Encoding;
+use partiql_value::{Tuple, Value};
+
+/// A `partiql_value::Value` that has no PartiQL-encoded-Ion representation.
+#[derive(Debug)]
+pub(super) struct RowConvertError(pub(super) String);
+
+impl std::fmt::Display for RowConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "cannot encode value as Ion: {}", self.0)
+    }
+}
+
+impl std::error::Error for RowConvertError {}
+
+/// Convert an owned PartiQL value into a PartiQL-encoded-Ion `Element` by
+/// running it through the canonical extension encoder into an
+/// `ElementStreamWriter`, then popping the single top-level element out.
+pub(super) fn value_to_element(value: &Value) -> Result<ion_rs::element::Element, RowConvertError> {
+    let mut out: Vec<ion_rs::element::Element> = Vec::with_capacity(1);
+    {
+        let mut writer = ion_rs::element::element_stream_writer::ElementStreamWriter::new(&mut out);
+        let mut encoder = IonEncoderBuilder::new(
+            IonEncoderConfig::default().with_mode(Encoding::PartiqlEncodedAsIon),
+        )
+        .build(&mut writer)
+        .map_err(|e| RowConvertError(format!("build encoder: {e:?}")))?;
+        encoder
+            .write_value(value)
+            .map_err(|e| RowConvertError(format!("encode value: {e:?}")))?;
+    }
+    out.pop()
+        .ok_or_else(|| RowConvertError("encoder produced no element".to_string()))
+}
+
+/// Convert one VM register row into an owned `Value`. Errors are propagated
+/// rather than fabricated (no `"?"` field names, no silent `continue`, no
+/// `unwrap`s over reader state).
+pub(super) fn row_to_value(
+    row: &partiql_eval::value::RegisterReader<'_>,
+    shape: &partiql_eval::value::Shape,
+) -> Result<Value, RowConvertError> {
+    use partiql_eval::value::{FieldName, RowShape};
+
+    match shape.row_shape() {
+        RowShape::Struct(fields) => {
+            let mut tuple = Tuple::new();
+            for field in fields.iter() {
+                let name = match &field.name {
+                    FieldName::Static(s) => (*s).to_string(),
+                    FieldName::Register(reg) => row
+                        .get_str(*reg)
+                        .ok_or_else(|| {
+                            RowConvertError(format!("field-name register {reg} unreadable"))
+                        })?
+                        .to_string(),
+                };
+                let reg_idx = match &field.value {
+                    RowShape::Register(idx, _) => *idx,
+                    RowShape::Struct(_) => {
+                        return Err(RowConvertError(format!(
+                            "nested struct row-shape not supported for field {name:?}"
+                        )));
+                    }
+                };
+                let mut view = row
+                    .get_value_view(reg_idx)
+                    .ok_or_else(|| RowConvertError(format!("register {reg_idx} unreadable")))?;
+                tuple.insert(&name, value_view_to_value(&mut view)?);
+            }
+            Ok(Value::Tuple(Box::new(tuple)))
+        }
+        RowShape::Register(idx, _) => {
+            let mut view = row
+                .get_value_view(*idx)
+                .ok_or_else(|| RowConvertError(format!("register {idx} unreadable")))?;
+            value_view_to_value(&mut view)
+        }
+    }
+}
+
+fn value_view_to_value(
+    view: &mut partiql_eval::value::ValueView<'_>,
+) -> Result<Value, RowConvertError> {
+    use partiql_eval::value::ValueType;
+
+    Ok(match view.get_type() {
+        ValueType::Missing => Value::Missing,
+        ValueType::Null => Value::Null,
+        ValueType::Bool => Value::Boolean(view.get_bool().map_err(scalar_err)?),
+        ValueType::Integer => Value::Integer(view.get_i64().map_err(scalar_err)?),
+        ValueType::Decimal => Value::Decimal(Box::new(view.get_decimal().map_err(scalar_err)?)),
+        ValueType::Float => Value::Real(view.get_f64().map_err(scalar_err)?.into()),
+        ValueType::String => {
+            Value::String(Box::new(view.get_str().map_err(scalar_err)?.to_string()))
+        }
+        ValueType::Bytes => Value::Blob(Box::new(view.get_bytes().map_err(scalar_err)?.to_vec())),
+        ValueType::Tuple => Value::Tuple(Box::new(walk_struct(view)?)),
+        ValueType::List => Value::List(Box::new(walk_sequence(view)?.into())),
+        ValueType::Bag => Value::Bag(Box::new(walk_sequence(view)?.into())),
+    })
+}
+
+fn scalar_err<E: std::fmt::Debug>(e: E) -> RowConvertError {
+    RowConvertError(format!("scalar read: {e:?}"))
+}
+
+fn walk_err<E: std::fmt::Debug>(op: &'static str) -> impl FnOnce(E) -> RowConvertError {
+    move |e| RowConvertError(format!("{op}: {e:?}"))
+}
+
+/// `ValueView::step_in` returns `IllegalState("cannot step into empty X")` for
+/// an empty container rather than an Ok+empty walk. That is a legitimate case
+/// for us — an empty bag is a valid result. Distinguish it from real errors
+/// on the message so we can yield an empty sequence instead of propagating.
+fn is_empty_container_error(e: &partiql_eval::EngineError) -> bool {
+    matches!(e, partiql_eval::EngineError::IllegalState(msg)
+        if msg.starts_with("cannot step into empty"))
+}
+
+/// Drive a `step_in` / `loop { advance }` / `step_out` walk over a container,
+/// yielding each child's decoded `Value`. Shared by `List` and `Bag`. Struct
+/// walks differ (they also read a field name per iteration), so they have
+/// their own helper.
+fn walk_sequence(
+    view: &mut partiql_eval::value::ValueView<'_>,
+) -> Result<Vec<Value>, RowConvertError> {
+    if let Err(e) = view.step_in() {
+        if is_empty_container_error(&e) {
+            return Ok(Vec::new());
+        }
+        return Err(walk_err("step_in")(e));
+    }
+    let mut items = Vec::new();
+    loop {
+        items.push(value_view_to_value(view)?);
+        if !view.advance().map_err(walk_err("advance"))? {
+            break;
+        }
+    }
+    view.step_out().map_err(walk_err("step_out"))?;
+    Ok(items)
+}
+
+fn walk_struct(view: &mut partiql_eval::value::ValueView<'_>) -> Result<Tuple, RowConvertError> {
+    if let Err(e) = view.step_in() {
+        if is_empty_container_error(&e) {
+            return Ok(Tuple::new());
+        }
+        return Err(walk_err("step_in")(e));
+    }
+    let mut tuple = Tuple::new();
+    loop {
+        let name = view
+            .get_field_name()
+            .map_err(walk_err("get_field_name"))?
+            .to_string();
+        let value = value_view_to_value(view)?;
+        tuple.insert(&name, value);
+        if !view.advance().map_err(walk_err("advance"))? {
+            break;
+        }
+    }
+    view.step_out().map_err(walk_err("step_out"))?;
+    Ok(tuple)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use partiql_value::DateTime;
+    use std::num::NonZeroU8;
+
+    /// Locks in the encoder adapter's DateTime handling. This is NOT
+    /// end-to-end coverage — engine `ValueType` has no `DateTime` variant,
+    /// so VM rows currently cannot produce `Value::DateTime`. Test guards
+    /// regression the day the engine adds `DateTime` support.
+    #[test]
+    fn datetime_encodes_as_ion_timestamp() {
+        let dt = DateTime::from_ymdhms_nano_offset_minutes(
+            2020,
+            NonZeroU8::new(3).unwrap(),
+            14,
+            12,
+            30,
+            45,
+            0,
+            Some(0),
+        );
+        let value = Value::DateTime(Box::new(dt));
+        let element = value_to_element(&value).expect("DateTime must encode via canonical encoder");
+        assert_eq!(element.ion_type(), ion_rs::IonType::Timestamp);
+    }
+}

--- a/partiql-tools/tests/pqlite/cases/catalog/quoted_identifier_roundtrip.test.ion
+++ b/partiql-tools/tests/pqlite/cases/catalog/quoted_identifier_roundtrip.test.ion
@@ -1,0 +1,3 @@
+// Case-sensitive quoted identifier — write and read.
+{ sql: "CREATE TABLE \"MyTable\" AS (SELECT * FROM << {'a': 1} >>)", expect: { created_table: { name: ["MyTable"], rows: 1 } } }
+{ sql: "SELECT * FROM \"MyTable\"", expect: { rows: $bag::[ { a: 1 } ] } }

--- a/partiql-tools/tests/pqlite/cases/catalog/table_lifecycle.test.ion
+++ b/partiql-tools/tests/pqlite/cases/catalog/table_lifecycle.test.ion
@@ -1,0 +1,5 @@
+// Full table lifecycle: create, insert inline rows, catalog listing, read back.
+{ sql: "CREATE TABLE orders", expect: { created_table: { name: ["orders"], rows: 0 } } }
+{ sql: "INSERT INTO orders SELECT * FROM << {'a': 1}, {'a': 2} >>", expect: { affected_rows: 2 } }
+{ sql: "SELECT name FROM _tables", expect: { rows: $bag::[ { name: ["_tables"] }, { name: ["orders"] } ] } }
+{ sql: "SELECT * FROM orders", expect: { rows: $bag::[ { a: 1 }, { a: 2 } ] } }

--- a/partiql-tools/tests/pqlite/cases/errors/parse_error.test.ion
+++ b/partiql-tools/tests/pqlite/cases/errors/parse_error.test.ion
@@ -1,0 +1,2 @@
+// Truncated query surfaces a parse error.
+{ sql: "SELECT * FROM foo WHERE", expect: { error: "Parse error:" } }

--- a/partiql-tools/tests/pqlite/cases/errors/runtime_errors.test.ion
+++ b/partiql-tools/tests/pqlite/cases/errors/runtime_errors.test.ion
@@ -1,0 +1,15 @@
+// Runtime error surface. Each fixture asserts on a substring of the error
+// message so a downstream rewording that loses the anchor phrase fails loudly.
+// Whitespace-only input trips the pre-parse empty-query guard.
+{ sql: "   ", expect: { error: "empty query" } }
+// SELECT from a name that isn't in _tables.
+{ sql: "SELECT * FROM ghost", expect: { error: "Table 'ghost' not found" } }
+// Duplicate CREATE TABLE surfaces the storage-layer TableExists error.
+{ sql: "CREATE TABLE t" }
+{ sql: "CREATE TABLE t", expect: { error: "already exists" } }
+// INSERT INTO a table that was never created.
+{ sql: "INSERT INTO ghost SELECT * FROM << {'a':1} >>", expect: { error: "table not found: ghost" } }
+// The system catalog is read-only from user-space.
+{ sql: "INSERT INTO _tables SELECT * FROM << {'name': ['x']} >>", expect: { error: "system table" } }
+// An INSERT that produces zero source rows must still succeed with count 0.
+{ sql: "INSERT INTO t SELECT * FROM << {'a':99} >> WHERE FALSE", expect: { affected_rows: 0 } }

--- a/partiql-tools/tests/pqlite/cases/errors/skipped_step_demo.test.ion
+++ b/partiql-tools/tests/pqlite/cases/errors/skipped_step_demo.test.ion
@@ -1,0 +1,4 @@
+// A step known to fail today; skip it so the rest of the case still runs.
+skip::"SELECT does_not_exist_yet FROM ghost"
+// Real step that must still pass.
+{ sql: "SELECT * FROM << {'a': 1} >>", expect: { rows: $bag::[ { a: 1 } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/aggregates.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/aggregates.test.ion
@@ -1,0 +1,5 @@
+// Aggregate functions over an inline bag: COUNT/SUM and GROUP BY.
+{ sql: "SELECT COUNT(*) AS c, SUM(t.a) AS s FROM << {'a': 1}, {'a': 2}, {'a': 3} >> t", expect: { rows: $bag::[ { c: 3, s: 6 } ] } }
+// Single-group GROUP BY: one output row avoids hash-iteration-order flake
+// while still exercising the aggregate path.
+{ sql: "SELECT g.k AS k, COUNT(*) AS n FROM << {'k':'x'}, {'k':'x'}, {'k':'x'} >> g GROUP BY g.k", expect: { rows: $bag::[ { k: "x", n: 3 } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/ctas_persisted_values.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/ctas_persisted_values.test.ion
@@ -1,0 +1,6 @@
+// CTAS a single table with a mix of value types (int, string, null, decimal,
+// list) so wire-format encode/decode is exercised for each type in one shot.
+// Decimal (3.14) must round-trip exactly (no float drift); the list column
+// covers container encoding through disk.
+{ sql: "CREATE TABLE t AS (SELECT * FROM << {'i': 1, 's': 'hello', 'n': NULL, 'd': 3.14, 'xs': [10, 20, 30]}, {'i': 2, 's': 'world', 'n': NULL, 'd': 2.5, 'xs': [40, 50]} >>)", expect: { created_table: { name: ["t"], rows: 2 } } }
+{ sql: "SELECT * FROM t", expect: { rows: $bag::[ { i: 1, s: "hello", n: null, d: 3.14, xs: [10, 20, 30] }, { i: 2, s: "world", n: null, d: 2.5, xs: [40, 50] } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/ctas_roundtrip.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/ctas_roundtrip.test.ion
@@ -1,0 +1,7 @@
+// CTAS from an inline bag literal, then read the stored table back.
+{ sql: "CREATE TABLE nums AS (SELECT * FROM << {'a': 1}, {'a': 2}, {'a': 3} >>)", expect: { created_table: { name: ["nums"], rows: 3 } } }
+{ sql: "SELECT * FROM nums", expect: { rows: $bag::[ { a: 1 }, { a: 2 }, { a: 3 } ] } }
+// Bool round-trip through disk: a regression in the bool wire-format encode
+// or decode would slip past inline-only tests that never persist to storage.
+{ sql: "CREATE TABLE flags AS (SELECT * FROM << {'b': true}, {'b': false} >>)", expect: { created_table: { name: ["flags"], rows: 2 } } }
+{ sql: "SELECT * FROM flags", expect: { rows: $bag::[ { b: true }, { b: false } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/empty_containers.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/empty_containers.test.ion
@@ -1,0 +1,5 @@
+// Empty user table renders as $bag::[] — pins the empty-scan envelope shape.
+{ sql: "CREATE TABLE empt" }
+{ sql: "SELECT * FROM empt", expect: { rows: $bag::[] } }
+// Empty list, empty bag, and non-empty bag as projected column values.
+{ sql: "SELECT [] AS xs, << >> AS ys, << 100, 200 >> AS zs FROM << {'a': 1} >> m", expect: { rows: $bag::[ { xs: [], ys: $bag::[], zs: $bag::[100, 200] } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/missing_field_projection.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/missing_field_projection.test.ion
@@ -1,0 +1,5 @@
+// Field-not-present projection on a stored row: reading absent field `b` from
+// a stored `{a:1}` produces MISSING at read time (persistence of MISSING itself
+// isn't reachable via SQL literals today).
+{ sql: "CREATE TABLE t AS (SELECT * FROM << {'a': 1} >>)", expect: { created_table: { name: ["t"], rows: 1 } } }
+{ sql: "SELECT t.b AS x FROM t", expect: { rows: $bag::[ { x: $missing::null } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/missing_vs_null.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/missing_vs_null.test.ion
@@ -1,0 +1,6 @@
+// A referenced-but-absent field must render as $missing::null, not null.
+// Locks in the MISSING_ANNOT branch in value_to_element.
+{ sql: "SELECT m.nope AS x FROM << {'a': 1} >> m", expect: { rows: $bag::[ { x: $missing::null } ] } }
+// NULL and MISSING side-by-side inside a list — the annotation must survive
+// container recursion.
+{ sql: "SELECT [NULL, m.nope] AS xs FROM << {'a': 1} >> m", expect: { rows: $bag::[ { xs: [null, $missing::null] } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/nested_bag_literal.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/nested_bag_literal.test.ion
@@ -1,0 +1,4 @@
+// Nested struct values survive insert and read-back.
+{ sql: "CREATE TABLE issues" }
+{ sql: "INSERT INTO issues SELECT * FROM << {'number':1, 'author':{'login':'alice'}}, {'number':2, 'author':{'login':'bob'}} >>", expect: { affected_rows: 2 } }
+{ sql: "SELECT * FROM issues", expect: { rows: $bag::[ { number: 1, author: { login: "alice" } }, { number: 2, author: { login: "bob" } } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/scalar_types.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/scalar_types.test.ion
@@ -1,0 +1,2 @@
+// Decimal, Bool, and Null value types survive projection over an inline bag.
+{ sql: "SELECT * FROM << {'d': 3.14, 'b': true, 'n': NULL}, {'d': 2.5, 'b': false, 'n': NULL} >> q", expect: { rows: $bag::[ { d: 3.14, b: true, n: null }, { d: 2.5, b: false, n: null } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/select_projection.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/select_projection.test.ion
@@ -1,0 +1,4 @@
+// Aliased projection over inline-inserted rows.
+{ sql: "CREATE TABLE t" }
+{ sql: "INSERT INTO t SELECT * FROM << {'id':1,'name':'alice'}, {'id':2,'name':'bob'} >>", expect: { affected_rows: 2 } }
+{ sql: "SELECT t.id AS user_id, t.name AS nm FROM t", expect: { rows: $bag::[ { user_id: 1, nm: "alice" }, { user_id: 2, nm: "bob" } ] } }

--- a/partiql-tools/tests/pqlite/cases/query/select_value.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/select_value.test.ion
@@ -1,0 +1,5 @@
+// SELECT VALUE unwraps the row shape: rows are bare values inside $bag::[...],
+// not {'_1': v} structs. Exercises the Shape::Bag(Register) render path.
+{ sql: "SELECT VALUE t.a FROM << {'a':10},{'a':20},{'a':30} >> t", expect: { rows: $bag::[ 10, 20, 30 ] } }
+// SELECT VALUE with a container expression: each row is itself a list.
+{ sql: "SELECT VALUE [m.a, m.a + 10] FROM << {'a': 1}, {'a': 2} >> m", expect: { rows: $bag::[ [1, 11], [2, 12] ] } }

--- a/partiql-tools/tests/pqlite/cases/query/select_value_through_disk.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/select_value_through_disk.test.ion
@@ -1,0 +1,3 @@
+// SELECT VALUE with a persisted source — exercises RowShape::Register through disk.
+{ sql: "CREATE TABLE t AS (SELECT * FROM << {'n':10},{'n':20},{'n':30} >>)", expect: { created_table: { name: ["t"], rows: 3 } } }
+{ sql: "SELECT VALUE t.n FROM t", expect: { rows: $bag::[ 10, 20, 30 ] } }

--- a/partiql-tools/tests/pqlite/cases/query/where_filter.test.ion
+++ b/partiql-tools/tests/pqlite/cases/query/where_filter.test.ion
@@ -1,0 +1,2 @@
+// Truthy WHERE predicate — only WHERE FALSE is exercised elsewhere.
+{ sql: "SELECT * FROM << {'n':1},{'n':2},{'n':3} >> t WHERE t.n > 1", expect: { rows: $bag::[ { n: 2 }, { n: 3 } ] } }

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -22,10 +22,11 @@ const PQLITE: &str = env!("CARGO_BIN_EXE_pqlite");
 /// (exit_success, stdout, stderr).
 fn run_exec(query: &str, db: Option<&std::path::Path>) -> (bool, String, String) {
     let mut cmd = Command::new(PQLITE);
-    cmd.arg("exec").arg(query);
+    cmd.arg("exec");
     if let Some(path) = db {
         cmd.arg("--db").arg(path);
     }
+    cmd.arg(query);
     let out = cmd.output().expect("failed to spawn pqlite");
     (
         out.status.success(),
@@ -123,9 +124,9 @@ fn empty_query_with_db_does_not_create_file() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("empty.pqlite");
     let out = Command::new(PQLITE)
+        .arg("exec")
         .arg("--db")
         .arg(&dbp)
-        .arg("exec")
         .arg("   ")
         .output()
         .expect("failed to spawn pqlite");
@@ -269,16 +270,16 @@ fn ctas_with_db_creates_table_and_persists_file() {
 
 #[test]
 fn ctas_with_bare_db_filename_creates_file_in_cwd() {
-    // Regression: `pqlite --db foo.pqlite` with a BARE filename (no directory
-    // component) must create the file in the current directory, like any UNIX
-    // tool — not fail with ENOENT. The child runs with its cwd set to a temp
-    // dir, so the bare name resolves there.
+    // Regression: `pqlite exec --db foo.pqlite ...` with a BARE filename (no
+    // directory component) must create the file in the current directory,
+    // like any UNIX tool — not fail with ENOENT. The child runs with its cwd
+    // set to a temp dir, so the bare name resolves there.
     let dir = tempfile::tempdir().unwrap();
 
     let out = Command::new(PQLITE)
+        .arg("exec")
         .arg("--db")
         .arg("bare.pqlite") // bare name: parent() is "" — the bug case
-        .arg("exec")
         .arg("CREATE TABLE t AS (SELECT t.a FROM mem(2,2) t)")
         .current_dir(dir.path())
         .output()

--- a/partiql-tools/tests/pqlite_cli.rs
+++ b/partiql-tools/tests/pqlite_cli.rs
@@ -35,6 +35,53 @@ fn run_exec(query: &str, db: Option<&std::path::Path>) -> (bool, String, String)
 }
 
 #[test]
+fn ion_format_bag_envelope() {
+    use ion_rs::element::Element;
+    use ion_rs::IonData;
+    let out = Command::new(PQLITE)
+        .arg("exec")
+        .arg("--format")
+        .arg("ion")
+        .arg("SELECT * FROM << {'a': 1}, {'a': 2} >>")
+        .output()
+        .expect("failed to spawn pqlite");
+    assert!(
+        out.status.success(),
+        "ion-format select should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Ion mode: silent on success — the summary footer that plain-text mode
+    // prints to stderr must not leak here.
+    assert!(
+        out.stderr.is_empty(),
+        "ion mode must be silent on stderr; got: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // Byte-for-byte-modulo-Ion-equivalence check: builds the exact expected
+    // envelope Element and compares via IonData (semantic Ion equality). Guards
+    // BOTH envelope shape (rows field, $bag annotation, count) AND row contents
+    // (a hollow shape+count check would pass on arbitrary two-row output).
+    let actual = Element::read_all(&out.stdout).expect("stdout must parse as Ion");
+    let expected =
+        Element::read_all(b"{rows: $bag::[{a: 1}, {a: 2}]}").expect("expected must parse");
+    assert_eq!(
+        actual.len(),
+        1,
+        "expected exactly one top-level value; got: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert_eq!(expected.len(), 1);
+    assert_eq!(
+        IonData::from(actual[0].clone()),
+        IonData::from(expected[0].clone()),
+        "actual: {} expected: {}",
+        actual[0],
+        expected[0]
+    );
+}
+
+#[test]
 fn plain_select_via_exec_needs_no_db_and_creates_no_file() {
     // Run from inside a temp dir so we can assert nothing was written there.
     // (The `exec` subcommand never builds the REPL history file, so there is
@@ -68,6 +115,40 @@ fn plain_select_via_exec_needs_no_db_and_creates_no_file() {
     assert!(
         stray.is_empty(),
         "a plain SELECT must create no files, but found: {stray:?}"
+    );
+}
+
+#[test]
+fn empty_query_with_db_does_not_create_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let dbp = dir.path().join("empty.pqlite");
+    let out = Command::new(PQLITE)
+        .arg("--db")
+        .arg(&dbp)
+        .arg("exec")
+        .arg("   ")
+        .output()
+        .expect("failed to spawn pqlite");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Error: empty query"),
+        "expected 'Error: empty query'; got: {stderr}"
+    );
+    assert!(
+        !dbp.exists(),
+        "empty-query rejection must not create the db file at {}",
+        dbp.display()
+    );
+    // Also assert no other stray files in tempdir.
+    let stray: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "no files should be created; found: {stray:?}"
     );
 }
 
@@ -264,65 +345,6 @@ fn duplicate_ctas_is_rejected_and_names_the_table() {
 //   * String values render single-quoted: `'x'`
 //   * NULL renders uppercase: `NULL`
 //   * Empty bag renders `<<\n\n>>`
-
-#[test]
-fn ctas_then_select_single_i64_column() {
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("e2e.pqlite");
-
-    let (ok, _, stderr) = run_exec("CREATE TABLE t AS (SELECT t.a FROM mem(3,2) t)", Some(&dbp));
-    assert!(ok, "CTAS should succeed; stderr: {stderr}");
-
-    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT should succeed; stderr: {stderr}");
-    // mem(3,2) yields a=0,1,2 in insertion order.
-    assert!(stdout.contains("'a': 0"), "got: {stdout}");
-    assert!(stdout.contains("'a': 1"), "got: {stdout}");
-    assert!(stdout.contains("'a': 2"), "got: {stdout}");
-}
-
-#[test]
-fn ctas_then_select_mixed_scalars() {
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("mixed.pqlite");
-
-    let (ok, _, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT 1 AS a, 2.5 AS b, 'x' AS c, NULL AS d FROM mem(1,2) m)",
-        Some(&dbp),
-    );
-    assert!(ok, "CTAS should succeed; stderr: {stderr}");
-
-    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT should succeed; stderr: {stderr}");
-    assert!(stdout.contains("'a': 1"), "got: {stdout}");
-    assert!(stdout.contains("'b': 2.5"), "got: {stdout}");
-    assert!(stdout.contains("'c': 'x'"), "got: {stdout}");
-    assert!(stdout.contains("'d': NULL"), "got: {stdout}");
-    // The Missing value would be a regression — distinct from explicit NULL.
-    assert!(!stdout.contains("MISSING"), "got: {stdout}");
-}
-
-#[test]
-fn ctas_then_select_preserves_multi_field_struct_shape() {
-    // Two-column row guards field-name preservation and column ordering
-    // through the encode → LMDB → decode → format pipeline. The nested-tuple
-    // case (a column whose VALUE is itself a tuple) is covered separately by
-    // ctas_then_select_runtime_tuple and ctas_then_select_nested_tuple_in_list.
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("tuple.pqlite");
-
-    let (ok, _, stderr) = run_exec(
-        "CREATE TABLE t AS (SELECT 99 AS outer_a, 'inner_a' AS outer_b FROM mem(1,2) m)",
-        Some(&dbp),
-    );
-    assert!(ok, "CTAS should succeed; stderr: {stderr}");
-
-    let (ok, stdout, stderr) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT should succeed; stderr: {stderr}");
-    // Both field names survive the round trip.
-    assert!(stdout.contains("'outer_a': 99"), "got: {stdout}");
-    assert!(stdout.contains("'outer_b': 'inner_a'"), "got: {stdout}");
-}
 
 #[test]
 fn ctas_zero_rows_then_select_prints_no_rows_no_error() {
@@ -598,29 +620,6 @@ fn wire_format_byte_shape_is_stable() {
 }
 
 #[test]
-fn ctas_then_select_bool_column() {
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("bool_rt.pqlite");
-    // mem's arg order is (rows, cols): mem(2,1) yields two rows a=0,a=1,
-    // so `m.a = 0` produces true then false. (Not mem(1,2), which is one row.)
-    let (ok, _out, err) = run_exec(
-        "CREATE TABLE t AS (SELECT (m.a = 0) AS b FROM mem(2,1) m)",
-        Some(&dbp),
-    );
-    assert!(ok, "CTAS failed: {err}");
-    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT failed: {err}");
-    assert!(
-        out.contains("true"),
-        "expected 'true' in output; got: {out}"
-    );
-    assert!(
-        out.contains("false"),
-        "expected 'false' in output; got: {out}"
-    );
-}
-
-#[test]
 fn ctas_then_select_missing_column() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("missing_rt.pqlite");
@@ -892,22 +891,6 @@ fn over_deep_nested_tuple_payload_is_rejected() {
 }
 
 #[test]
-fn ctas_then_select_list_of_ints() {
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("list_ints.pqlite");
-    let (ok, _out, err) = run_exec(
-        "CREATE TABLE t AS (SELECT [10, 20, 30] AS xs FROM mem(1,1) m)",
-        Some(&dbp),
-    );
-    assert!(ok, "list CTAS should succeed; stderr: {err}");
-    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT failed: {err}");
-    assert!(out.contains("10"), "expected 10; got: {out}");
-    assert!(out.contains("20"), "expected 20; got: {out}");
-    assert!(out.contains("30"), "expected 30; got: {out}");
-}
-
-#[test]
 fn ctas_then_select_bag_of_ints() {
     let dir = tempfile::tempdir().unwrap();
     let dbp = dir.path().join("bag_ints.pqlite");
@@ -937,29 +920,6 @@ fn ctas_then_select_empty_list() {
     assert!(ok, "SELECT over empty list failed: {err}");
     // Empty list renders as `[]` inside the row tuple.
     assert!(out.contains("'xs': []"), "expected empty list; got: {out}");
-}
-
-#[test]
-fn ctas_then_select_nested_tuple_in_list() {
-    let dir = tempfile::tempdir().unwrap();
-    let dbp = dir.path().join("nested.pqlite");
-    // A list of runtime tuples exercises the full recursion:
-    // list → tuple → scalar, on both encode and decode.
-    let (ok, _out, err) = run_exec(
-        "CREATE TABLE t AS (SELECT [{ 'a': 1 }, { 'a': 2 }] AS xs FROM mem(1,1) m)",
-        Some(&dbp),
-    );
-    assert!(
-        ok,
-        "nested-tuple-in-list CTAS should succeed; stderr: {err}"
-    );
-    let (ok, out, err) = run_exec("SELECT * FROM t", Some(&dbp));
-    assert!(ok, "SELECT failed: {err}");
-    assert!(out.contains("1"), "expected 1; got: {out}");
-    assert!(out.contains("2"), "expected 2; got: {out}");
-    // Both tuples preserve their field name through the round trip.
-    assert!(out.contains("'a': 1"), "expected 'a': 1; got: {out}");
-    assert!(out.contains("'a': 2"), "expected 'a': 2; got: {out}");
 }
 
 #[test]

--- a/partiql-tools/tests/pqlite_e2e.rs
+++ b/partiql-tools/tests/pqlite_e2e.rs
@@ -1,0 +1,14 @@
+//! Every `tests/pqlite/cases/**/*.test.ion` file runs as an independent case.
+
+mod pqlite_e2e {
+    pub mod loader;
+    pub mod runner;
+}
+
+use rstest::rstest;
+use std::path::PathBuf;
+
+#[rstest]
+fn case(#[files("tests/pqlite/cases/**/*.test.ion")] path: PathBuf) {
+    pqlite_e2e::runner::run_case(&path).unwrap_or_else(|e| panic!("{e}"));
+}

--- a/partiql-tools/tests/pqlite_e2e/loader.rs
+++ b/partiql-tools/tests/pqlite_e2e/loader.rs
@@ -1,0 +1,541 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ion_rs::element::Element;
+use ion_rs::IonType;
+
+const EXPECT_ERROR_FIELDS: &[&str] = &["error"];
+const EXPECT_SUCCESS_FIELDS: &[&str] = &["rows", "affected_rows", "created_table"];
+
+#[derive(Debug)]
+pub struct StepDef {
+    pub sql: String,
+    pub expect: Option<Element>,
+    /// `skip::` annotation on the top-level Ion value marks a step that the
+    /// runner must load but must NOT execute. Lets fixture authors keep
+    /// known-broken cases in-tree while the compiler is still catching up.
+    pub skip: bool,
+}
+
+#[derive(Debug)]
+pub enum LoadError {
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    Ion {
+        path: PathBuf,
+        source: ion_rs::IonError,
+    },
+    NotAStruct {
+        path: PathBuf,
+        index: usize,
+        actual: IonType,
+    },
+    MissingSql {
+        path: PathBuf,
+        index: usize,
+    },
+    /// `field` had the wrong Ion type; e.g. `sql` was an int, `expect` was a list.
+    TypeMismatch {
+        path: PathBuf,
+        index: usize,
+        field: &'static str,
+        expected: &'static str,
+        actual: IonType,
+    },
+    /// Catches typos like `expects:` or `row:` that would silently no-op the step.
+    UnknownField {
+        path: PathBuf,
+        index: usize,
+        location: &'static str,
+        name: String,
+    },
+    ConflictingExpect {
+        path: PathBuf,
+        index: usize,
+    },
+    /// A `.test.ion` file with zero top-level structs would pass with nothing checked.
+    EmptyFile {
+        path: PathBuf,
+    },
+    /// Ion allows repeat field names; `Struct::get` returns only one value.
+    DuplicateField {
+        path: PathBuf,
+        index: usize,
+        location: &'static str,
+        name: String,
+    },
+    /// `expect: { error: "" }` is a fixture-author bug — `msg.contains("")`
+    /// is trivially true, so any failure would satisfy the assertion.
+    EmptyErrorSubstring {
+        path: PathBuf,
+        index: usize,
+    },
+    /// Only bare `skip::` is recognized; chained annotations like
+    /// `skip::foo::"..."` or an unknown annotation would silently no-op.
+    UnknownAnnotation {
+        path: PathBuf,
+        index: usize,
+        annotations: Vec<String>,
+    },
+    /// `skip::` may only wrap a string or a struct.
+    SkipInvalidPayload {
+        path: PathBuf,
+        index: usize,
+        actual: IonType,
+    },
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use LoadError::*;
+        match self {
+            Io { path, source } => write!(f, "{}: {}", path.display(), source),
+            Ion { path, source } => write!(f, "{}: ion parse error: {}", path.display(), source),
+            NotAStruct {
+                path,
+                index,
+                actual,
+            } => write!(
+                f,
+                "{}: top-level value #{} must be a struct, was {}",
+                path.display(),
+                index,
+                actual
+            ),
+            MissingSql { path, index } => write!(
+                f,
+                "{}: step #{} missing required field `sql`",
+                path.display(),
+                index
+            ),
+            TypeMismatch {
+                path,
+                index,
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "{}: step #{} field `{}` must be {}, was {}",
+                path.display(),
+                index,
+                field,
+                expected,
+                actual
+            ),
+            UnknownField {
+                path,
+                index,
+                location,
+                name,
+            } => write!(
+                f,
+                "{}: step #{} unknown field `{}` on {}",
+                path.display(),
+                index,
+                name,
+                location
+            ),
+            ConflictingExpect { path, index } => write!(
+                f,
+                "{}: step #{} `expect` may contain either `error` or a success-shape key, not both",
+                path.display(),
+                index,
+            ),
+            EmptyFile { path } => {
+                write!(f, "{}: file contains no top-level structs", path.display())
+            }
+            DuplicateField {
+                path,
+                index,
+                location,
+                name,
+            } => write!(
+                f,
+                "{}: step #{} field `{}` appears more than once on {}",
+                path.display(),
+                index,
+                name,
+                location
+            ),
+            EmptyErrorSubstring { path, index } => write!(
+                f,
+                "{}: step #{} `expect.error` must be a non-empty substring",
+                path.display(),
+                index
+            ),
+            UnknownAnnotation {
+                path,
+                index,
+                annotations,
+            } => write!(
+                f,
+                "{}: top-level value #{} has unsupported annotations {:?}; \
+                 only bare `skip::` is recognized",
+                path.display(),
+                index,
+                annotations,
+            ),
+            SkipInvalidPayload {
+                path,
+                index,
+                actual,
+            } => write!(
+                f,
+                "{}: top-level value #{} `skip::` must wrap a string or a struct, was {}",
+                path.display(),
+                index,
+                actual
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+/// Load every top-level Ion value in `path`; each must be a struct with at
+/// least `sql: <string>` and optionally `expect: <struct>`. Unknown fields at
+/// either level are rejected so a typo can't silently disable a check.
+pub fn load_test_case(path: &Path) -> Result<Vec<StepDef>, LoadError> {
+    let bytes = fs::read(path).map_err(|e| LoadError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let elements = Element::read_all(&bytes).map_err(|e| LoadError::Ion {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    if elements.is_empty() {
+        return Err(LoadError::EmptyFile {
+            path: path.to_path_buf(),
+        });
+    }
+    let mut steps = Vec::with_capacity(elements.len());
+    for (index, el) in elements.into_iter().enumerate() {
+        steps.push(parse_step(path, index, &el)?);
+    }
+    Ok(steps)
+}
+
+fn parse_step(path: &Path, index: usize, el: &Element) -> Result<StepDef, LoadError> {
+    // Only `skip::` (alone) is recognized. Anything else — including chained
+    // annotations like `skip::foo::"..."` — must be a hard load error so
+    // typos can't silently disable a step. An annotation whose symbol has no
+    // resolvable text (e.g. `$0::`) must NOT be silently dropped — dropping
+    // it would let an unrecognized annotation slip past the check below.
+    let mut annotations: Vec<String> = Vec::new();
+    for sym in el.annotations().iter() {
+        match sym.text() {
+            Some(t) => annotations.push(t.to_string()),
+            None => {
+                return Err(LoadError::UnknownAnnotation {
+                    path: path.to_path_buf(),
+                    index,
+                    annotations: vec!["<unresolved symbol>".to_string()],
+                });
+            }
+        }
+    }
+    let skip = match annotations.as_slice() {
+        [] => false,
+        [only] if only == "skip" => true,
+        _ => {
+            return Err(LoadError::UnknownAnnotation {
+                path: path.to_path_buf(),
+                index,
+                annotations,
+            });
+        }
+    };
+
+    if skip && el.ion_type() == IonType::String {
+        // `skip::"INSERT INTO ..."` — a skipped bare SQL statement with no
+        // assertion. The runner will not execute it.
+        let sql = el
+            .as_string()
+            .expect("annotated string element must expose as_string")
+            .to_owned();
+        return Ok(StepDef {
+            sql,
+            expect: None,
+            skip: true,
+        });
+    }
+
+    if skip && el.ion_type() != IonType::Struct {
+        return Err(LoadError::SkipInvalidPayload {
+            path: path.to_path_buf(),
+            index,
+            actual: el.ion_type(),
+        });
+    }
+
+    let s = el.as_struct().ok_or_else(|| LoadError::NotAStruct {
+        path: path.to_path_buf(),
+        index,
+        actual: el.ion_type(),
+    })?;
+
+    let mut sql_count = 0;
+    let mut expect_count = 0;
+    for (name, _) in s.iter() {
+        let text = name.text().unwrap_or("");
+        match text {
+            "sql" => sql_count += 1,
+            "expect" => expect_count += 1,
+            _ => {
+                return Err(LoadError::UnknownField {
+                    path: path.to_path_buf(),
+                    index,
+                    location: "step",
+                    name: text.to_string(),
+                });
+            }
+        }
+    }
+    if sql_count > 1 {
+        return Err(LoadError::DuplicateField {
+            path: path.to_path_buf(),
+            index,
+            location: "step",
+            name: "sql".to_string(),
+        });
+    }
+    if expect_count > 1 {
+        return Err(LoadError::DuplicateField {
+            path: path.to_path_buf(),
+            index,
+            location: "step",
+            name: "expect".to_string(),
+        });
+    }
+
+    let sql_el = s.get("sql").ok_or(LoadError::MissingSql {
+        path: path.to_path_buf(),
+        index,
+    })?;
+    let sql = sql_el
+        .as_string()
+        .ok_or_else(|| LoadError::TypeMismatch {
+            path: path.to_path_buf(),
+            index,
+            field: "sql",
+            expected: "string",
+            actual: sql_el.ion_type(),
+        })?
+        .to_owned();
+
+    let expect = match s.get("expect") {
+        None => None,
+        Some(e) if e.ion_type() == IonType::Struct => {
+            validate_expect(path, index, e)?;
+            Some(e.clone())
+        }
+        Some(e) => {
+            return Err(LoadError::TypeMismatch {
+                path: path.to_path_buf(),
+                index,
+                field: "expect",
+                expected: "struct",
+                actual: e.ion_type(),
+            })
+        }
+    };
+
+    Ok(StepDef { sql, expect, skip })
+}
+
+fn validate_expect(path: &Path, index: usize, expect: &Element) -> Result<(), LoadError> {
+    let s = expect.as_struct().expect("caller guarantees struct");
+    let mut error_count = 0u32;
+    let mut success_count = 0u32;
+    let mut seen_names: Vec<String> = Vec::new();
+    for (name, value) in s.iter() {
+        let text = name.text().unwrap_or("");
+        if EXPECT_ERROR_FIELDS.contains(&text) {
+            error_count += 1;
+            if value.as_string() == Some("") {
+                return Err(LoadError::EmptyErrorSubstring {
+                    path: path.to_path_buf(),
+                    index,
+                });
+            }
+        } else if EXPECT_SUCCESS_FIELDS.contains(&text) {
+            success_count += 1;
+        } else {
+            return Err(LoadError::UnknownField {
+                path: path.to_path_buf(),
+                index,
+                location: "expect",
+                name: text.to_string(),
+            });
+        }
+        if seen_names.iter().any(|n| n == text) {
+            return Err(LoadError::DuplicateField {
+                path: path.to_path_buf(),
+                index,
+                location: "expect",
+                name: text.to_string(),
+            });
+        }
+        seen_names.push(text.to_string());
+    }
+    if error_count > 0 && success_count > 0 {
+        return Err(LoadError::ConflictingExpect {
+            path: path.to_path_buf(),
+            index,
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every malformed-fixture rejection lives in one table so a new variant
+    /// costs one row instead of a whole test. Each row: filename, fixture
+    /// body, predicate over the returned `LoadError`.
+    #[test]
+    fn rejects_malformed_fixtures() {
+        #[allow(clippy::type_complexity)]
+        const CASES: &[(&str, &str, fn(&LoadError) -> bool)] = &[
+            ("bad.test.ion", r#" 42 "#, |e| {
+                matches!(e, LoadError::NotAStruct { .. })
+            }),
+            ("bad2.test.ion", r#" { expect: { rows: [] } } "#, |e| {
+                matches!(e, LoadError::MissingSql { .. })
+            }),
+            (
+                "typo.test.ion",
+                r#" { sql: "SELECT * FROM t", expects: { rows: $bag::[] } } "#,
+                |e| {
+                    matches!(
+                        e,
+                        LoadError::UnknownField {
+                            location: "step",
+                            ..
+                        }
+                    )
+                },
+            ),
+            (
+                "typo2.test.ion",
+                r#" { sql: "SELECT * FROM t", expect: { row: $bag::[] } } "#,
+                |e| {
+                    matches!(
+                        e,
+                        LoadError::UnknownField {
+                            location: "expect",
+                            ..
+                        }
+                    )
+                },
+            ),
+            (
+                "mixed.test.ion",
+                r#" { sql: "SELECT * FROM t", expect: { error: "boom", rows: $bag::[] } } "#,
+                |e| matches!(e, LoadError::ConflictingExpect { .. }),
+            ),
+            (
+                "empty_file.test.ion",
+                "// just a comment, no cases\n",
+                |e| matches!(e, LoadError::EmptyFile { .. }),
+            ),
+            (
+                "dup_sql.test.ion",
+                r#" { sql: "SELECT 1", sql: "SELECT 2", expect: { rows: [1] } } "#,
+                |e| {
+                    matches!(
+                        e,
+                        LoadError::DuplicateField {
+                            location: "step",
+                            ..
+                        }
+                    )
+                },
+            ),
+            (
+                "empty_err.test.ion",
+                r#" { sql: "SELECT * FROM ghost", expect: { error: "" } } "#,
+                |e| matches!(e, LoadError::EmptyErrorSubstring { .. }),
+            ),
+            (
+                "dup_rows.test.ion",
+                r#" { sql: "SELECT * FROM t", expect: { rows: $bag::[], rows: $bag::[] } } "#,
+                |e| {
+                    matches!(
+                        e,
+                        LoadError::DuplicateField {
+                            location: "expect",
+                            ..
+                        }
+                    )
+                },
+            ),
+            (
+                "sql_int.test.ion",
+                r#" { sql: 42, expect: { rows: $bag::[] } } "#,
+                |e| matches!(e, LoadError::TypeMismatch { .. }),
+            ),
+            ("bad_annot.test.ion", "wrong::\"CREATE TABLE t\"\n", |e| {
+                matches!(e, LoadError::UnknownAnnotation { .. })
+            }),
+            ("skip_int.test.ion", "skip::42\n", |e| {
+                matches!(e, LoadError::SkipInvalidPayload { .. })
+            }),
+        ];
+
+        for (filename, body, predicate) in CASES {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join(filename);
+            std::fs::write(&path, body).unwrap();
+            let err = load_test_case(&path).unwrap_err();
+            assert!(
+                predicate(&err),
+                "case {filename}: predicate rejected LoadError: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_skip_annotated_string_as_skipped_bare_sql() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skip_str.test.ion");
+        std::fs::write(&path, r#" skip::"INSERT INTO t VALUES (1)" "#).unwrap();
+        let steps = load_test_case(&path).unwrap();
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].skip, "expected skip=true, got {:?}", steps[0]);
+        assert_eq!(steps[0].sql, "INSERT INTO t VALUES (1)");
+        assert!(steps[0].expect.is_none());
+    }
+
+    #[test]
+    fn parses_skip_annotated_struct_as_skipped_step() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skip_struct.test.ion");
+        std::fs::write(
+            &path,
+            r#" skip::{ sql: "SELECT * FROM t", expect: { rows: $bag::[] } } "#,
+        )
+        .unwrap();
+        let steps = load_test_case(&path).unwrap();
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].skip, "expected skip=true, got {:?}", steps[0]);
+        assert_eq!(steps[0].sql, "SELECT * FROM t");
+        assert!(steps[0].expect.is_some(), "expect should still be parsed");
+    }
+
+    #[test]
+    fn bare_sql_step_supported_when_skip_annotated() {
+        // An un-annotated top-level string must be REJECTED. Only skip::"..."
+        // may be a bare SQL step; regular steps must still be structs.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bare.test.ion");
+        std::fs::write(&path, r#" "CREATE TABLE t" "#).unwrap();
+        let err = load_test_case(&path).unwrap_err();
+        assert!(matches!(err, LoadError::NotAStruct { .. }), "got: {err:?}");
+    }
+}

--- a/partiql-tools/tests/pqlite_e2e/runner.rs
+++ b/partiql-tools/tests/pqlite_e2e/runner.rs
@@ -2,8 +2,12 @@ use std::path::Path;
 use std::sync::Mutex;
 
 use ion_rs::element::Element;
+use ion_rs::types::IntAccess;
 use ion_rs::{IonData, IonType};
-use partiql_tools::session::{Commands, DebugFlags, OutputFormat, PqliteSession};
+use partiql_tools::session::{
+    render_outcome_ion, render_query_ion, Commands, DebugFlags, PqliteSession, RunOutcome,
+    StatementOutcome,
+};
 
 use crate::pqlite_e2e::loader::{load_test_case, LoadError};
 
@@ -103,15 +107,12 @@ pub fn run_case(path: &Path) -> Result<(), CaseError> {
             .and_then(|s| s.get("error"))
             .and_then(|el| el.as_string());
 
-        let mut out = Vec::<u8>::new();
-        let mut err = Vec::<u8>::new();
         let cmd = Commands::Exec {
             query: step.sql.clone(),
-            format: OutputFormat::Ion,
         };
-        let result = session.run(&cmd, &mut out, &mut err);
+        let (result, _err_capture) = session.run(&cmd);
 
-        match (result, expected_err_substr) {
+        let outcome = match (result, expected_err_substr) {
             (Err(e), Some(substr)) => {
                 let msg = format!("{e}");
                 if !msg.contains(substr) {
@@ -121,13 +122,7 @@ pub fn run_case(path: &Path) -> Result<(), CaseError> {
                         source: format!("expected error containing {substr:?}, got: {msg}"),
                     });
                 }
-            }
-            (Ok(()), Some(substr)) => {
-                return Err(CaseError::ExpectedErrorButSucceeded {
-                    step_index: i,
-                    sql: step.sql.clone(),
-                    expected: substr.to_string(),
-                });
+                continue;
             }
             (Err(e), None) => {
                 return Err(CaseError::Exec {
@@ -136,46 +131,229 @@ pub fn run_case(path: &Path) -> Result<(), CaseError> {
                     source: format!("{e}"),
                 });
             }
-            (Ok(()), None) => {
-                let Some(expect) = &step.expect else { continue };
-                let elements = Element::read_all(&out).map_err(|e| CaseError::Exec {
-                    step_index: i,
-                    sql: step.sql.clone(),
-                    source: format!(
-                        "captured ion output did not reparse: {e}; bytes={:?}",
-                        String::from_utf8_lossy(&out)
-                    ),
-                })?;
-                if elements.len() != 1 {
-                    return Err(CaseError::Exec {
-                        step_index: i,
-                        sql: step.sql.clone(),
-                        source: format!(
-                            "expected exactly one top-level ion value, got {}",
-                            elements.len()
-                        ),
-                    });
-                }
-                let actual = &elements[0];
-                if actual.ion_type() != IonType::Struct {
-                    return Err(CaseError::Exec {
-                        step_index: i,
-                        sql: step.sql.clone(),
-                        source: format!(
-                            "expected top-level struct envelope, got {}",
-                            actual.ion_type()
-                        ),
-                    });
-                }
-                if IonData::from(actual.clone()) != IonData::from(expect.clone()) {
-                    return Err(CaseError::Mismatch {
-                        step_index: i,
-                        sql: step.sql.clone(),
-                        detail: format!("expected {expect}, got {actual}"),
-                    });
+            (Ok(o), Some(substr)) => {
+                // `run` succeeded, but Query rows can still error mid-iteration
+                // so drain before declaring the expected-error missed.
+                match drain_outcome(o) {
+                    Err(e) => {
+                        let msg = format!("{e}");
+                        if !msg.contains(substr) {
+                            return Err(CaseError::Exec {
+                                step_index: i,
+                                sql: step.sql.clone(),
+                                source: format!("expected error containing {substr:?}, got: {msg}"),
+                            });
+                        }
+                        continue;
+                    }
+                    Ok(_) => {
+                        return Err(CaseError::ExpectedErrorButSucceeded {
+                            step_index: i,
+                            sql: step.sql.clone(),
+                            expected: substr.to_string(),
+                        });
+                    }
                 }
             }
+            (Ok(o), None) => o,
+        };
+
+        let Some(expect) = &step.expect else {
+            // No expectation: just drain to detect a late error.
+            drain_outcome(outcome).map_err(|e| CaseError::Exec {
+                step_index: i,
+                sql: step.sql.clone(),
+                source: format!("{e}"),
+            })?;
+            continue;
+        };
+
+        match outcome {
+            RunOutcome::Query(handle) => {
+                let mut buf = Vec::<u8>::new();
+                handle
+                    .drain(|rows, shape| render_query_ion(rows, shape, &mut buf))
+                    .map_err(|e| CaseError::Exec {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        source: format!("{e}"),
+                    })?;
+                match_ion_envelope(&buf, expect).map_err(|detail| CaseError::Mismatch {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    detail,
+                })?;
+            }
+            RunOutcome::Statement(outcome) => {
+                // Structural check first: catches typos, unexpected fields,
+                // and the semantic (canonical_key + row count) mismatch.
+                match_statement_outcome(&outcome, expect).map_err(|detail| {
+                    CaseError::Mismatch {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        detail,
+                    }
+                })?;
+                // Render + reparse to keep the shared Ion envelope emitter
+                // under test coverage; the harness would otherwise never
+                // exercise render_outcome_ion for CTAS/INSERT/CREATE.
+                let mut buf = Vec::<u8>::new();
+                render_outcome_ion(&outcome, &mut buf).map_err(|e| CaseError::Exec {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    source: format!("render_outcome_ion: {e}"),
+                })?;
+                match_ion_envelope(&buf, expect).map_err(|detail| CaseError::Mismatch {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    detail,
+                })?;
+            }
         }
+    }
+    Ok(())
+}
+
+/// Parse `buf` as one top-level Ion struct and compare against `expect` under
+/// `IonData` equality — struct fields match as a multiset, but bag/list order
+/// is significant.
+fn match_ion_envelope(buf: &[u8], expect: &Element) -> Result<(), String> {
+    let elements = Element::read_all(buf).map_err(|e| {
+        format!(
+            "captured ion output did not reparse: {e}; bytes={:?}",
+            String::from_utf8_lossy(buf)
+        )
+    })?;
+    if elements.len() != 1 {
+        return Err(format!(
+            "expected exactly one top-level ion value, got {}",
+            elements.len()
+        ));
+    }
+    let actual = &elements[0];
+    if actual.ion_type() != IonType::Struct {
+        return Err(format!(
+            "expected top-level struct envelope, got {}",
+            actual.ion_type()
+        ));
+    }
+    if IonData::from(actual.clone()) != IonData::from(expect.clone()) {
+        return Err(format!("expected {expect}, got {actual}"));
+    }
+    Ok(())
+}
+
+/// Drain a `RunOutcome` for side-effect-only cases (no expectation): pull rows
+/// off a query iterator so late errors surface, and drop write outcomes on the
+/// floor.
+fn drain_outcome(outcome: RunOutcome) -> Result<(), Box<dyn std::error::Error>> {
+    match outcome {
+        RunOutcome::Query(handle) => handle
+            .drain(|rows, _shape| {
+                for row in rows {
+                    row.map_err(|e| format!("Execution error: {:?}", e))?;
+                }
+                Ok(())
+            })
+            .map(|((), _footer)| ()),
+        RunOutcome::Statement(_) => Ok(()),
+    }
+}
+
+/// Compare a `StatementOutcome::{CreateTableAs, InsertInto, CreateTable}`
+/// against the fixture's `expect` envelope. Compares structurally against the
+/// outcome fields — NO byte round-trip through Ion.
+///
+/// Strict on unknown fields: an expect struct with extra keys (e.g. both
+/// `affected_rows` and `created_table`) fails, matching the old `IonData`
+/// equality behavior.
+fn match_statement_outcome(outcome: &StatementOutcome, expect: &Element) -> Result<(), String> {
+    let expect_struct = expect.as_struct().ok_or_else(|| {
+        format!(
+            "expected top-level struct in expect, got {}",
+            expect.ion_type()
+        )
+    })?;
+    match outcome {
+        StatementOutcome::InsertInto { rows, .. } => {
+            expect_struct_has_only(expect_struct, &["affected_rows"])?;
+            let expected_rows = expect_struct
+                .get("affected_rows")
+                .and_then(|el| el.as_i64())
+                .ok_or_else(|| {
+                    format!("expected `affected_rows: <int>` in expect for INSERT; got {expect}")
+                })?;
+            if expected_rows as u64 != *rows {
+                return Err(format!(
+                    "affected_rows mismatch: expected {expected_rows}, got {rows}"
+                ));
+            }
+            Ok(())
+        }
+        StatementOutcome::CreateTableAs {
+            canonical_key,
+            rows,
+            ..
+        } => match_created_table(expect_struct, canonical_key, *rows),
+        StatementOutcome::CreateTable { canonical_key, .. } => {
+            match_created_table(expect_struct, canonical_key, 0)
+        }
+    }
+}
+
+fn expect_struct_has_only(s: &ion_rs::element::Struct, allowed: &[&str]) -> Result<(), String> {
+    for (name, _) in s.fields() {
+        let n = name.text().unwrap_or("");
+        if !allowed.contains(&n) {
+            return Err(format!(
+                "unexpected field `{n}` in expect (allowed: {allowed:?})"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn match_created_table(
+    expect_struct: &ion_rs::element::Struct,
+    canonical_key: &str,
+    rows: u64,
+) -> Result<(), String> {
+    expect_struct_has_only(expect_struct, &["created_table"])?;
+    let inner = expect_struct
+        .get("created_table")
+        .and_then(|el| el.as_struct())
+        .ok_or_else(|| "expected `created_table: {..}` in expect".to_string())?;
+    expect_struct_has_only(inner, &["name", "rows"])?;
+    let name_list = inner
+        .get("name")
+        .and_then(|el| el.as_sequence())
+        .ok_or_else(|| "created_table.name must be a list".to_string())?;
+    // Reject any non-string element (catches `name: ["orders", 123]`) and any
+    // wrong length.
+    let mut names: Vec<&str> = Vec::new();
+    for el in name_list.elements() {
+        let s = el.as_string().ok_or_else(|| {
+            format!(
+                "created_table.name elements must be strings; got {}",
+                el.ion_type()
+            )
+        })?;
+        names.push(s);
+    }
+    if names.len() != 1 || names[0] != canonical_key {
+        return Err(format!(
+            "created_table.name mismatch: expected [{:?}], got {:?}",
+            canonical_key, names
+        ));
+    }
+    let expected_rows = inner
+        .get("rows")
+        .and_then(|el| el.as_i64())
+        .ok_or_else(|| "created_table.rows must be an int".to_string())?;
+    if expected_rows as u64 != rows {
+        return Err(format!(
+            "created_table.rows mismatch: expected {expected_rows}, got {rows}"
+        ));
     }
     Ok(())
 }
@@ -227,5 +405,74 @@ mod tests {
             "#,
         );
         run_case(&path).unwrap();
+    }
+
+    /// The old runner compared the full Ion envelope under `IonData` equality,
+    /// so a fixture accidentally naming BOTH `affected_rows` AND `created_table`
+    /// would fail. The structured `match_statement_outcome` path must preserve
+    /// that: extra fields = mismatch, not silent pass.
+    #[test]
+    fn extra_field_in_insert_expect_fails() {
+        let (_dir, path) = write_case(
+            "extra.test.ion",
+            r#"
+            { sql: "CREATE TABLE t AS (SELECT m.a FROM mem(1,1) m)", expect: { created_table: { name: ["t"], rows: 1 } } }
+            { sql: "INSERT INTO t SELECT m.a FROM mem(2,1) m", expect: { affected_rows: 2, created_table: { name: ["t"], rows: 1 } } }
+            "#,
+        );
+        let err = run_case(&path).unwrap_err();
+        match err {
+            CaseError::Mismatch { detail, .. } => {
+                assert!(
+                    detail.contains("unexpected field"),
+                    "expected an unexpected-field mismatch, got: {detail}"
+                );
+            }
+            other => panic!("expected Mismatch, got: {other:?}"),
+        }
+    }
+
+    /// Non-string entries in `created_table.name` must fail (the fixture author
+    /// typo'd a bare int); a filter_map would silently ignore them.
+    #[test]
+    fn non_string_name_element_fails() {
+        let (_dir, path) = write_case(
+            "bad_name.test.ion",
+            r#"
+            { sql: "CREATE TABLE t AS (SELECT m.a FROM mem(1,1) m)", expect: { created_table: { name: ["t", 123], rows: 1 } } }
+            "#,
+        );
+        let err = run_case(&path).unwrap_err();
+        match err {
+            CaseError::Mismatch { detail, .. } => {
+                assert!(
+                    detail.contains("name elements must be strings"),
+                    "expected a string-element mismatch, got: {detail}"
+                );
+            }
+            other => panic!("expected Mismatch, got: {other:?}"),
+        }
+    }
+
+    /// A stray field inside `created_table` (e.g. `columns:`) must fail; keeps
+    /// fixture authors from silently drifting the schema.
+    #[test]
+    fn extra_field_inside_created_table_fails() {
+        let (_dir, path) = write_case(
+            "extra_inner.test.ion",
+            r#"
+            { sql: "CREATE TABLE t AS (SELECT m.a FROM mem(1,1) m)", expect: { created_table: { name: ["t"], rows: 1, columns: 1 } } }
+            "#,
+        );
+        let err = run_case(&path).unwrap_err();
+        match err {
+            CaseError::Mismatch { detail, .. } => {
+                assert!(
+                    detail.contains("unexpected field `columns`"),
+                    "expected an unexpected-field mismatch, got: {detail}"
+                );
+            }
+            other => panic!("expected Mismatch, got: {other:?}"),
+        }
     }
 }

--- a/partiql-tools/tests/pqlite_e2e/runner.rs
+++ b/partiql-tools/tests/pqlite_e2e/runner.rs
@@ -1,0 +1,231 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use ion_rs::element::Element;
+use ion_rs::{IonData, IonType};
+use partiql_tools::session::{Commands, DebugFlags, OutputFormat, PqliteSession};
+
+use crate::pqlite_e2e::loader::{load_test_case, LoadError};
+
+/// Bound live LMDB envs to one at a time. Each case opens a 1 GiB-map_size env
+/// in a tempdir; many-core hosts otherwise hit EINVAL on env-open when the
+/// OS-imposed mmap cap is exceeded (Linux: `vm.max_map_count`; macOS: OS-imposed
+/// cap).
+static CASE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug)]
+pub enum CaseError {
+    Load(LoadError),
+    OpenDb(String),
+    Exec {
+        step_index: usize,
+        sql: String,
+        source: String,
+    },
+    ExpectedErrorButSucceeded {
+        step_index: usize,
+        sql: String,
+        expected: String,
+    },
+    Mismatch {
+        step_index: usize,
+        sql: String,
+        detail: String,
+    },
+}
+
+impl std::fmt::Display for CaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use CaseError::*;
+        match self {
+            Load(e) => write!(f, "failed to load test case: {e}"),
+            OpenDb(e) => write!(f, "failed to open session db: {e}"),
+            Exec {
+                step_index,
+                sql,
+                source,
+            } => write!(
+                f,
+                "step {}: `{}` failed: {source}",
+                step_index + 1,
+                sql
+            ),
+            ExpectedErrorButSucceeded {
+                step_index,
+                sql,
+                expected,
+            } => write!(
+                f,
+                "step {}: `{}` was expected to fail with an error containing {:?}, but it succeeded",
+                step_index + 1,
+                sql,
+                expected
+            ),
+            Mismatch {
+                step_index,
+                sql,
+                detail,
+            } => write!(
+                f,
+                "step {}: `{}` produced an unexpected result: {detail}",
+                step_index + 1,
+                sql
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CaseError {}
+
+/// `IonData` equality is strict per `IonEq` but order-sensitive on
+/// `$bag::[...]` — a multiset matcher would treat bags as unordered.
+pub fn run_case(path: &Path) -> Result<(), CaseError> {
+    // Recover from poison so one panicked case doesn't cascade.
+    let _guard = CASE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let steps = load_test_case(path).map_err(CaseError::Load)?;
+    let dir = tempfile::tempdir().map_err(|e| CaseError::OpenDb(format!("{e}")))?;
+    let dbp = dir.path().join("t.pqlite");
+    let session = PqliteSession::open(&dbp, DebugFlags::default())
+        .map_err(|e| CaseError::OpenDb(format!("{e}")))?;
+
+    for (i, step) in steps.iter().enumerate() {
+        if step.skip {
+            // Preserves step numbering so a `skip::` before a real step does
+            // not shift the visible index. Never touches the session.
+            eprintln!("skipped step {}: {}", i + 1, step.sql);
+            continue;
+        }
+        let expected_err_substr: Option<&str> = step
+            .expect
+            .as_ref()
+            .and_then(|e| e.as_struct())
+            .and_then(|s| s.get("error"))
+            .and_then(|el| el.as_string());
+
+        let mut out = Vec::<u8>::new();
+        let mut err = Vec::<u8>::new();
+        let cmd = Commands::Exec {
+            query: step.sql.clone(),
+            format: OutputFormat::Ion,
+        };
+        let result = session.run(&cmd, &mut out, &mut err);
+
+        match (result, expected_err_substr) {
+            (Err(e), Some(substr)) => {
+                let msg = format!("{e}");
+                if !msg.contains(substr) {
+                    return Err(CaseError::Exec {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        source: format!("expected error containing {substr:?}, got: {msg}"),
+                    });
+                }
+            }
+            (Ok(()), Some(substr)) => {
+                return Err(CaseError::ExpectedErrorButSucceeded {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    expected: substr.to_string(),
+                });
+            }
+            (Err(e), None) => {
+                return Err(CaseError::Exec {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    source: format!("{e}"),
+                });
+            }
+            (Ok(()), None) => {
+                let Some(expect) = &step.expect else { continue };
+                let elements = Element::read_all(&out).map_err(|e| CaseError::Exec {
+                    step_index: i,
+                    sql: step.sql.clone(),
+                    source: format!(
+                        "captured ion output did not reparse: {e}; bytes={:?}",
+                        String::from_utf8_lossy(&out)
+                    ),
+                })?;
+                if elements.len() != 1 {
+                    return Err(CaseError::Exec {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        source: format!(
+                            "expected exactly one top-level ion value, got {}",
+                            elements.len()
+                        ),
+                    });
+                }
+                let actual = &elements[0];
+                if actual.ion_type() != IonType::Struct {
+                    return Err(CaseError::Exec {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        source: format!(
+                            "expected top-level struct envelope, got {}",
+                            actual.ion_type()
+                        ),
+                    });
+                }
+                if IonData::from(actual.clone()) != IonData::from(expect.clone()) {
+                    return Err(CaseError::Mismatch {
+                        step_index: i,
+                        sql: step.sql.clone(),
+                        detail: format!("expected {expect}, got {actual}"),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_case(name: &str, body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn expected_error_but_succeeded() {
+        let (_dir, path) = write_case(
+            "succeeded.test.ion",
+            r#"
+            { sql: "CREATE TABLE t", expect: { error: "Parse error:" } }
+            "#,
+        );
+        let err = run_case(&path).unwrap_err();
+        assert!(matches!(err, CaseError::ExpectedErrorButSucceeded { .. }));
+    }
+
+    #[test]
+    fn control_char_string_round_trips_through_ion_format() {
+        let (_dir, path) = write_case(
+            "ctl.test.ion",
+            "{ sql: \"SELECT * FROM << {'s': 'x\\x1by'} >>\", expect: { rows: $bag::[ { s: \"x\\x1by\" } ] } }\n",
+        );
+        run_case(&path).unwrap();
+    }
+
+    #[test]
+    fn skipped_step_is_not_executed_and_does_not_fail_case() {
+        // If the SELECT were executed it would error (ghost table); if the
+        // assertion were checked it would fail (never matches). Skipped =
+        // neither. The subsequent real step must still pass so the case
+        // exercises the ordering guarantee (skipped steps count for indexing
+        // but do not touch the session).
+        let (_dir, path) = write_case(
+            "skipped.test.ion",
+            r#"
+            skip::{ sql: "SELECT * FROM nonexistent_table", expect: { error: "must match" } }
+            { sql: "SELECT * FROM << {'a': 1} >>", expect: { rows: $bag::[ { a: 1 } ] } }
+            "#,
+        );
+        run_case(&path).unwrap();
+    }
+}


### PR DESCRIPTION
This PR introduces a file-driven `.test.ion` end-to-end test harness for `pqlite` along with the library extraction that makes it possible.

Each fixture is a stream of top-level `{sql, expect}` Ion structs. These are discovered by `rstest` and run against a single long-lived `PqliteSession`. This mirrors the CLI dispatch path so our tests exercise the real engine.
```ion
{ sql: "CREATE TABLE t AS (SELECT * FROM << {'a':1} >>)", expect: { created_table: { name: ["t"], rows: 1 } } }
{ sql: "SELECT * FROM t", expect: { rows: $bag::[ { a: 1 } ] } }

// Skip a known-broken case while keeping it in-tree.
skip::"SELECT * FROM not_yet_supported"
```

The CLI `exec` and REPL logic has been extracted from `bin/pqlite.rs` into a shared session module. The `exec` subcommand also gains a `--format ion` option to provide a stable, machine-parseable envelope. Text output remains byte-identical to the `dev` branch.

### Key Changes

* **Library extraction:** `bin/pqlite.rs` is now about 680 lines shorter. The exec and REPL logic moved into `PqliteSession::run(&Commands, out, err)`. The CLI and the test harness now dispatch through the exact same `clap`-typed entry point.
* **Streaming SELECT:** Rows now stream row-by-row through `stream_query_ion` and `stream_query_text` directly into the caller's writer. Peak memory usage is reduced to just one row rather than the entire result set. Additionally, `--format ion` output is silent on `stderr` for successful queries.
* **Loader:** We now use a top-level Ion stream that fails loudly at load time on unknown or duplicate fields, empty expects, empty files, and `expect: { error: "" }`. This ensures a fixture typo cannot silently disable a test case. Table-driven schema tests now cover every `LoadError` variant.
* **Matcher:** Strict `IonEq` via `IonData` is implemented (e.g., NULL is not equal to MISSING, type-strict, decimal precision is preserved).
* **`skip::` annotation:** Fixture authors can keep known-broken test cases in the tree while the compiler catches up. Using `skip::"bare SQL"` or `skip::{sql, expect}` will record the step without executing it.
* **LMDB isolation:** A per-case mutex bounds live environments to one. Otherwise, many-core hosts hit `EINVAL` on environment-open with a 1 GiB `map_size` multiplied by N parallel cases.
* **Canonical encoder reuse**: Value→Ion goes through PartiqlEncodedIonValueEncoder from partiql-extension-ion instead of a hand-rolled encoder.

### Testing Summary

Added 152 tests (60 lib, 68 CLI, 24 e2e) across 17 fixtures. These cover:
* CREATE, INSERT, SELECT, and CTAS round-trips (decimal, list, mixed-scalar, bool)
* Aggregates, nested structs, scalars, and empty containers
* SELECT VALUE
* MISSING vs NULL
* Quoted identifiers and WHERE clauses
* Runtime errors and one `skip::` demo

Removed 6 CLI tests whose only assertion was `stdout.contains("<literal>")` because they are now fully covered by fixtures with stricter `IonEq` semantics.