### PR TITLE
Accept scalar arguments to user-registered scalar functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+- Fixed user-registered scalar functions silently returning `MISSING` (permissive) or
+  erroring (strict) when called with a non-struct argument. Scalar-function arguments are
+  now checked against `DYNAMIC` rather than a struct-of-dynamic type, so `String`,
+  `Integer`, and other scalar arguments reach the function body.
+- `tupleunion`/`tupleconcat` (in `partiql-extension-value-functions`) now reject a non-tuple
+  argument (`MISSING` in permissive mode, an error in strict mode) instead of silently
+  coercing it to a single-attribute tuple. Per the PartiQL specification these functions are
+  defined only over tuples; scalar coercion for `SELECT *` remains the planner's concern.
+
 ### Removed
 
 ## [0.14.0]

--- a/extension/partiql-extension-value-functions/src/lib.rs
+++ b/extension/partiql-extension-value-functions/src/lib.rs
@@ -9,8 +9,28 @@ use partiql_catalog::scalar_fn::{
     vararg_scalar_fn_overloads, ScalarFnExpr, ScalarFnExprResult, ScalarFunction,
     SimpleScalarFunctionInfo,
 };
+use partiql_value::datum::{DatumCategory, DatumCategoryRef};
 use partiql_value::{Tuple, Value};
 use std::borrow::Cow;
+
+/// Rejects a non-tuple argument to a tuple function.
+///
+/// `TUPLEUNION` is defined by the PartiQL specification only over tuple arguments; scalar/sequence
+/// coercion is a `SELECT *` concern handled by the planner, not by these functions. `NULL`/`MISSING`
+/// arguments never reach here — they are short-circuited by the dispatcher's argument checker.
+fn require_tuple(func: &str, arg: &Value) -> Result<(), ExtensionResultError> {
+    let found = match arg.category() {
+        DatumCategoryRef::Tuple(_) => return Ok(()),
+        DatumCategoryRef::Null => "null",
+        DatumCategoryRef::Missing => "missing",
+        DatumCategoryRef::Sequence(_) => "sequence",
+        DatumCategoryRef::Scalar(_) => "scalar",
+        DatumCategoryRef::Graph(_) => "graph",
+    };
+    Err(ExtensionResultError::DataError(
+        format!("`{func}` expects tuple arguments, found {found}").into(),
+    ))
+}
 
 #[derive(Debug, Default)]
 pub struct PartiqlValueFnExtension {}
@@ -54,6 +74,7 @@ impl ScalarFnExpr for TupleUnionFnExpr {
     ) -> ScalarFnExprResult<'c> {
         let mut t = Tuple::default();
         for arg in args {
+            require_tuple("tupleunion", arg.as_ref())?;
             t.extend(
                 arg.as_tuple_ref()
                     .pairs()
@@ -85,6 +106,9 @@ impl ScalarFnExpr for TupleConcatFnExpr {
         args: &[Cow<'_, Value>],
         _ctx: &'c dyn SessionContext,
     ) -> ScalarFnExprResult<'c> {
+        for arg in args {
+            require_tuple("tupleconcat", arg.as_ref())?;
+        }
         let result = args
             .iter()
             .map(|val| val.as_tuple_ref())

--- a/partiql-eval/src/eval/expr/functions.rs
+++ b/partiql-eval/src/eval/expr/functions.rs
@@ -5,7 +5,7 @@ use crate::eval::eval_expr_wrapper::{
 use crate::eval::expr::{BindError, BindEvalExpr, EvalExpr};
 use crate::eval::EvalContext;
 
-use partiql_types::PartiqlNoIdShapeBuilder;
+use partiql_types::TYPE_DYNAMIC;
 use partiql_value::Value;
 
 use std::borrow::Cow;
@@ -44,9 +44,10 @@ impl<const STRICT: bool> EvalExpr for EvalExprFnScalar<STRICT> {
         'a: 'o,
     {
         type Check<const STRICT: bool> = DefaultArgChecker<STRICT, PropagateMissing<true>>;
-        // use DummyShapeBuilder, as we don't care about shape Ids for evaluation dispatch
-        let mut bld = PartiqlNoIdShapeBuilder::default();
-        let typ = bld.new_struct_of_dyn();
+        // Scalar function arguments carry no declared type in `ScalarFnCallSpec` (its
+        // `CallSpecArg`s are only `Positional`/`Named`), so accept any value here and let
+        // the function body validate.
+        let typ = TYPE_DYNAMIC;
         match evaluate_and_validate_args::<{ STRICT }, Check<STRICT>, _>(
             &self.args,
             |_| &typ,

--- a/partiql/tests/scalar_fns.rs
+++ b/partiql/tests/scalar_fns.rs
@@ -1,0 +1,73 @@
+use crate::common::{eval_query_with_catalog, TestError};
+use assert_matches::assert_matches;
+use partiql_catalog::call_defs::{CallSpecArg, ScalarFnCallDef, ScalarFnCallSpec};
+use partiql_catalog::catalog::{MutableCatalog, PartiqlCatalog};
+use partiql_catalog::context::SessionContext;
+use partiql_catalog::scalar_fn::{
+    ScalarFnExpr, ScalarFnExprResult, ScalarFunction, SimpleScalarFunctionInfo,
+};
+use partiql_eval::eval::Evaluated;
+use partiql_eval::plan::EvaluationMode;
+use partiql_value::Value;
+use std::borrow::Cow;
+
+mod common;
+
+/// A test-only scalar UDF taking a single `String` argument, registered directly into the
+/// catalog (not shipped by any extension). It exercises the dispatcher's handling of scalar
+/// arguments to user-registered scalar functions: with the struct-of-dynamic guard this call
+/// short-circuited to `MISSING`/error before the body ran.
+#[derive(Debug, Clone, Default)]
+struct StrLengthFnExpr {}
+impl ScalarFnExpr for StrLengthFnExpr {
+    fn evaluate<'c>(
+        &self,
+        args: &[Cow<'_, Value>],
+        _ctx: &'c dyn SessionContext,
+    ) -> ScalarFnExprResult<'c> {
+        let result = match args.first().map(|arg| arg.as_ref()) {
+            Some(Value::String(s)) => Value::from(s.chars().count() as i64),
+            _ => Value::Missing,
+        };
+        Ok(Cow::Owned(result))
+    }
+}
+
+fn str_length_fn() -> ScalarFunction {
+    let call_def = ScalarFnCallDef {
+        names: vec!["str_length"],
+        overloads: vec![ScalarFnCallSpec {
+            input: vec![CallSpecArg::Positional],
+            output: Box::new(StrLengthFnExpr::default()),
+        }],
+    };
+    ScalarFunction::new(Box::new(SimpleScalarFunctionInfo::new(call_def)))
+}
+
+#[track_caller]
+#[inline]
+pub fn eval(statement: &str, mode: EvaluationMode) -> Result<Evaluated, TestError<'_>> {
+    let mut catalog = PartiqlCatalog::default();
+    catalog
+        .add_scalar_function(str_length_fn())
+        .expect("register str_length");
+    let catalog = catalog.to_shared_catalog();
+
+    eval_query_with_catalog(statement, &catalog, mode)
+}
+
+/// A user-registered scalar function invoked with a scalar (non-struct) argument runs and
+/// returns its result, in both permissive and strict modes.
+#[test]
+fn scalar_fn_string_arg_permissive() {
+    let res = eval("str_length('hello')", EvaluationMode::Permissive);
+    assert_matches!(res, Ok(_));
+    assert_matches!(res.unwrap().result, Value::Integer(5));
+}
+
+#[test]
+fn scalar_fn_string_arg_strict() {
+    let res = eval("str_length('hello')", EvaluationMode::Strict);
+    assert_matches!(res, Ok(_));
+    assert_matches!(res.unwrap().result, Value::Integer(5));
+}

--- a/partiql/tests/tuple_ops.rs
+++ b/partiql/tests/tuple_ops.rs
@@ -49,3 +49,30 @@ fn tupleconcat() {
 
     insta::assert_debug_snapshot!(tuple);
 }
+
+/// `tupleunion`/`tupleconcat` are defined only over tuples (PartiQL spec, SELECT * semantics).
+/// A non-tuple argument is rejected rather than silently coerced: `MISSING` in permissive mode,
+/// an error in strict mode.
+#[test]
+fn tupleunion_non_tuple_arg_permissive() {
+    let res = eval("tupleunion('x')", EvaluationMode::Permissive);
+    assert_matches!(res.unwrap().result, Value::Missing);
+}
+
+#[test]
+fn tupleunion_non_tuple_arg_strict() {
+    let res = eval("tupleunion('x')", EvaluationMode::Strict);
+    assert_matches!(res, Err(TestError::Eval(_)));
+}
+
+#[test]
+fn tupleconcat_non_tuple_arg_permissive() {
+    let res = eval("tupleconcat({ 'a': 1 }, 2)", EvaluationMode::Permissive);
+    assert_matches!(res.unwrap().result, Value::Missing);
+}
+
+#[test]
+fn tupleconcat_non_tuple_arg_strict() {
+    let res = eval("tupleconcat({ 'a': 1 }, 2)", EvaluationMode::Strict);
+    assert_matches!(res, Err(TestError::Eval(_)));
+}


### PR DESCRIPTION
## Summary

A user-registered scalar function (`Catalog::add_scalar_function`) called with a
non-struct argument silently returns `MISSING` in permissive mode (and errors in strict
mode) — the function body is never invoked.

`EvalExprFnScalar::evaluate` builds the expected argument type as
`PartiqlNoIdShapeBuilder::default().new_struct_of_dyn()` and validates every argument
against it via `DefaultArgChecker<STRICT, PropagateMissing<true>>`. Only a struct/tuple
satisfies that type, so a `String`, `Integer`, etc. fails `typ.satisfies(val)` and
short-circuits before the function runs.

`ScalarFnCallSpec` carries no declared per-argument type (`CallSpecArg` is only
`Positional`/`Named`), so the struct-of-dynamic expectation is arbitrary. The correct
universal expectation is `DYNAMIC`, which is satisfied by any value; the function body is
then responsible for validating its own arguments.

## Fix

- `partiql-eval/src/eval/expr/functions.rs`: use `TYPE_DYNAMIC` as the argument-check type
  instead of `new_struct_of_dyn()`.
- `partiql-extension-value-functions`: because scalar arguments now reach the function
  body, `tupleunion`/`tupleconcat` — which previously relied on the struct-of-dynamic guard
  to reject non-tuple arguments — would otherwise silently coerce a scalar into a
  single-attribute tuple (e.g. `tupleunion('x')` → `{'_1': 'x'}`). Per the [PartiQL
  specification](https://partiql.org/assets/PartiQL-Specification.pdf#page=28) these
  functions are defined only over tuples; scalar coercion for `SELECT *` is the planner's
  concern and uses positional synthetic names. Both functions now reject a non-tuple
  argument (`MISSING` in permissive mode, an error in strict mode), preserving their prior
  behavior.

## Tests

- `partiql/tests/scalar_fns.rs` registers a test-only `str_length(<string>) -> int` scalar
  UDF (the shipped `tupleunion`/`tupleconcat` take tuples, so they could not surface this
  bug) and asserts `str_length('hello') == 5` in both permissive and strict modes. These
  tests fail on `main` (permissive → `MISSING`; strict →
  `IllegalState("expected ({...}), found (MISSING)")`) and pass with this change.
- `partiql/tests/tuple_ops.rs` asserts `tupleunion`/`tupleconcat` reject a non-tuple
  argument (`MISSING` in permissive, error in strict), and that the existing tuple-argument
  cases still pass.

## Compatibility

No public API change. Scalar functions taking struct/tuple arguments are unaffected —
`DYNAMIC` still accepts structs, and `tupleunion`/`tupleconcat` keep their tuple behavior.
The dispatcher simply stops rejecting non-struct arguments before dispatch, and the two
tuple functions now reject non-tuple arguments explicitly rather than coercing them.