### PR TITLE
Lower scalar-position SELECT subqueries to SubQueryExpr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Added
+- partiql-logical-planner: Lower scalar-position `SELECT` subqueries — projection-list
+  items, `SELECT VALUE` struct values, function-call arguments, and subqueries nested in
+  other scalar operators (`CASE`, binary operators, ...) — to `ValueExpr::SubQueryExpr`.
+  Previously these produced `NotYetImplemented("Subquery within project")` or `IllegalState`
+  during lowering. Set-operation (`UNION`/`EXCEPT`/`INTERSECT`) subqueries in scalar position
+  remain unsupported. No scalar coercion is introduced: the subquery's result collection is
+  returned as-is (matching existing `SubQueryExpr` evaluation).
 
 ### Fixed
 - Fixed user-registered scalar functions silently returning `MISSING` (permissive) or

--- a/partiql-logical-planner/src/lower.rs
+++ b/partiql-logical-planner/src/lower.rs
@@ -171,6 +171,10 @@ pub struct AstToLogical<'a> {
 
     q_stack: Vec<QueryClauses>,
     ctx_stack: Vec<QueryContext>,
+    // whether the next entered query is a scalar-position subquery
+    pending_query_is_scalar: bool,
+    // scalar-position flag per enclosing query
+    scalar_query_stack: Vec<bool>,
     bexpr_stack: Vec<Vec<logical::OpId>>,
     vexpr_stack: Vec<Vec<(NodeId, ValueExpr)>>,
     arg_stack: Vec<Vec<CallArgument>>,
@@ -239,6 +243,8 @@ impl<'a> AstToLogical<'a> {
 
             q_stack: Default::default(),
             ctx_stack: Default::default(),
+            pending_query_is_scalar: false,
+            scalar_query_stack: Default::default(),
             bexpr_stack: Default::default(),
             vexpr_stack: Default::default(),
             arg_stack: Default::default(),
@@ -731,25 +737,58 @@ impl<'ast> Visitor<'ast> for AstToLogical<'_> {
         Traverse::Continue
     }
 
+    fn enter_expr(&mut self, expr: &'ast Expr) -> Traverse {
+        // A `Query` node reached through an `Expr` is a subquery in *scalar*
+        // (value) position — and must be lowered to a `ValueExpr::SubQueryExpr`
+        // operand — UNLESS it is the immediate expression of a FROM source
+        // (`FromLet.expr`), which is a *query*-position derived table handled via
+        // `benv`. (Set-operation operands are bare `Query` nodes, not wrapped in
+        // `Expr`, so they never reach here and default to query position.)
+        self.pending_query_is_scalar = matches!(expr, Expr::Query(_))
+            && !matches!(self.current_ctx(), Some(QueryContext::FromLet));
+        Traverse::Continue
+    }
+
     fn enter_query(&mut self, query: &'ast Query) -> Traverse {
+        let is_scalar = std::mem::take(&mut self.pending_query_is_scalar);
+        let is_select = matches!(query.set.node, QuerySet::Select(_));
+        self.scalar_query_stack.push(is_scalar);
+        // Isolate a scalar SELECT subquery's operators in their own sub-plan so
+        // it can be wrapped as a self-contained `SubQueryExpr`.
+        if is_scalar && is_select {
+            self.enter_plan();
+        }
         self.enter_benv();
-        if let QuerySet::Select(_) = query.set.node {
+        if is_select {
             self.enter_q();
         }
         Traverse::Continue
     }
 
     fn exit_query(&mut self, query: &'ast Query) -> Traverse {
+        let is_scalar = self.scalar_query_stack.pop().expect("scalar query level");
         let benv = self.exit_benv();
         match query.set.node {
             QuerySet::Select(_) => {
                 let clauses = self.exit_q();
                 let mut clauses = clauses.evaluation_order().into_iter();
+                let mut last_id = None;
                 if let Some(mut src_id) = clauses.next() {
                     for dst_id in clauses {
                         self.curr_plan().add_flow(src_id, dst_id);
                         src_id = dst_id;
                     }
+                    last_id = Some(src_id);
+                }
+                if is_scalar {
+                    // Scalar-position subquery: pop the isolated sub-plan and hand
+                    // it to the enclosing scalar operator as an ordinary `env`
+                    // operand (interleaves in source order with sibling operands).
+                    let subplan = self.exit_plan();
+                    self.push_vexpr(ValueExpr::SubQueryExpr(logical::SubQueryExpr {
+                        plan: subplan,
+                    }));
+                } else if let Some(src_id) = last_id {
                     self.push_bexpr(src_id);
                 }
             }

--- a/partiql/tests/subquery_lowering.rs
+++ b/partiql/tests/subquery_lowering.rs
@@ -1,0 +1,78 @@
+use crate::common::{eval_query, TestError};
+use assert_matches::assert_matches;
+use partiql_eval::eval::Evaluated;
+use partiql_eval::plan::EvaluationMode;
+use partiql_value::{bag, tuple, Value};
+
+mod common;
+
+#[track_caller]
+#[inline]
+fn eval(statement: &str) -> Result<Evaluated, TestError<'_>> {
+    eval_query(statement, EvaluationMode::Permissive)
+}
+
+/// A subquery in a projection-list item lowers and evaluates as a `SubQueryExpr` value.
+#[test]
+fn subquery_in_projection_list() {
+    let res = eval("SELECT (SELECT VALUE 2 FROM [0] AS z) AS s FROM [0] AS t");
+    assert_matches!(res, Ok(_));
+    assert_eq!(
+        res.unwrap().result,
+        Value::from(bag![tuple![("s", bag![2i64])]])
+    );
+}
+
+/// A subquery as a struct value in `SELECT VALUE { ... }` lowers and evaluates.
+#[test]
+fn subquery_as_struct_value() {
+    let res = eval("SELECT VALUE {'s': (SELECT VALUE 2 FROM [0] AS z)} FROM [0] AS t");
+    assert_matches!(res, Ok(_));
+    assert_eq!(
+        res.unwrap().result,
+        Value::from(bag![tuple![("s", bag![2i64])]])
+    );
+}
+
+/// A subquery nested inside a scalar operator (here, a function-call argument) lowers and
+/// evaluates as an ordinary operand.
+#[test]
+fn subquery_in_call_arg() {
+    let res = eval("SELECT VALUE CARDINALITY((SELECT VALUE 1 FROM [0, 0] AS z)) FROM [0] AS t");
+    assert_matches!(res, Ok(_));
+    assert_eq!(res.unwrap().result, Value::from(bag![2i64]));
+}
+
+/// A subquery nested inside a `CASE` branch lowers and evaluates.
+#[test]
+fn subquery_in_case_branch() {
+    let res = eval(
+        "SELECT VALUE CASE WHEN true THEN (SELECT VALUE 1 FROM [0] AS z) ELSE 0 END FROM [0] AS t",
+    );
+    assert_matches!(res, Ok(_));
+    assert_eq!(res.unwrap().result, Value::from(bag![bag![1i64]]));
+}
+
+/// A scalar-position subquery returns the subquery's collection as-is; it is not coerced to a
+/// scalar. An empty subquery therefore yields an empty bag (matching the `SubQueryExpr`
+/// evaluator semantics; see the `subquery_in_project` evaluator test).
+#[test]
+fn subquery_empty_result() {
+    let res = eval("SELECT (SELECT VALUE 2 FROM [] AS z) AS s FROM [0] AS t");
+    assert_matches!(res, Ok(_));
+    assert_eq!(
+        res.unwrap().result,
+        Value::from(bag![tuple![("s", bag![])]])
+    );
+}
+
+/// A set-operation (`UNION`/`EXCEPT`/`INTERSECT`) subquery in scalar position is not handled by
+/// this change — only scalar-position `SELECT` subqueries are lowered. It still fails lowering,
+/// as it did before; documented here to bound the change.
+#[test]
+fn setop_subquery_in_scalar_position_unsupported() {
+    let res = eval(
+        "SELECT (SELECT VALUE 1 FROM [0] AS z UNION SELECT VALUE 2 FROM [0] AS z) AS s FROM [0] AS t",
+    );
+    assert_matches!(res, Err(TestError::Lower(_)));
+}


### PR DESCRIPTION
## Summary

Scalar-position `SELECT` subqueries fail AST-to-logical-plan lowering, even though the
evaluator already supports them — the existing `subquery_in_project` evaluator test builds
exactly such a plan and evaluates it correctly.

Today, lowering a subquery in one of these positions errors:

| Position | Error on `main` |
|---|---|
| projection-list item (`SELECT (subq) AS s ...`) | `NotYetImplemented("Subquery within project")` |
| `SELECT VALUE (subq)` / `CASE` branch | `NotYetImplemented("Subquery within project")` |
| function-call argument (`f((subq))`) | `IllegalState("env.len() != 1")` |
| struct value (`{'k': (subq)}`) | `IllegalState("env.len() is not even")` |

## Cause

A `Query` node always pushes its output onto the current `benv` (a *query*-position
operand). A subquery appearing where a *value* is expected therefore leaves the enclosing
scalar operator short an `env` operand and its `benv` non-empty, tripping the asserts above.

## Fix

Route a scalar-position `SELECT` subquery through `env` as an ordinary operand:

- `enter_expr` sets a one-shot `pending_query_is_scalar` flag when the next `Query` is
  reached through an `Expr` (i.e. it is a subquery) and the current context is not
  `FromLet`. FROM-source derived tables stay query-position; set-operation operands are
  bare `Query` nodes and never reach `enter_expr`, so they too stay query-position.
- `enter_query` consumes the flag onto a `scalar_query_stack` and, for a scalar `SELECT`
  subquery, isolates its operators in a fresh `plan_stack` entry.
- `exit_query` pops the stack and, for a scalar subquery, wraps the isolated sub-plan as
  `ValueExpr::SubQueryExpr` pushed onto `env`. Query-position subqueries are unchanged.

Because the subquery now arrives as an ordinary `env` operand, the existing projection /
struct / call-argument consumers require no changes.

## Semantics

This is a lowering change only; `SubQueryExpr` evaluation is unchanged. A scalar-position
subquery returns the subquery's result collection as-is — it is **not** coerced to a scalar
(SQL-style scalar-subquery coercion is a separate concern, not implemented here). Empty
result → empty bag; N rows → N-element bag. This matches the existing `subquery_in_project`
evaluator test.

## Tests

`partiql/tests/subquery_lowering.rs` covers a subquery in a projection-list item, as a
`SELECT VALUE` struct value, in a function-call argument, and in a `CASE` branch — all four
fail on `main` with the errors above and pass with this change. It also covers an
empty-result subquery (→ empty bag, documenting the no-coercion semantics) and asserts a
set-operation subquery in scalar position is still rejected (bounding the change). Existing
subquery-in-FROM and correlated-subquery tests continue to pass.

## Scope / limitations

- Only scalar-position `SELECT` subqueries are lowered. Set-operation
  (`UNION`/`EXCEPT`/`INTERSECT`) subqueries in scalar position remain
  `NotYetImplemented("Subquery within project")` (possible follow-up).
- No scalar coercion of subquery results (see Semantics).

## Compatibility

No API change. Query-position subqueries (FROM sources, set-operation operands) are lowered
exactly as before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
